### PR TITLE
Add meta images

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -3,11 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta
-      name="description"
-      content="An interdisciplinary platform to upload, classify, and analyse in-the-wild images of invertebrates for research and conservation efforts."
-    />
-    <title>Antenna Data Platform</title>
 
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,6 +32,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.11",
+    "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.43.9",
     "react-leaflet": "^4.2.1",
     "react-markdown": "^9.0.1",

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -171,7 +171,6 @@ const ProjectContainer = () => {
           name="description"
           content={projectDetails.project?.description}
         />
-        <meta property="og:image" content={projectDetails.project?.image} />
       </Helmet>
       <Portal.Root container={document.getElementById(INTRO_CONTAINER_ID)}>
         <Menu />

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -166,17 +166,13 @@ const ProjectContainer = () => {
 
   return (
     <>
-      {projectDetails.project && (
-        <Helmet>
-          <meta
-            name="description"
-            content={projectDetails.project.description}
-          />
-          {projectDetails.project.image && (
-            <meta property="og:image" content={projectDetails.project.image} />
-          )}
-        </Helmet>
-      )}
+      <Helmet>
+        <meta
+          name="description"
+          content={projectDetails.project?.description}
+        />
+        <meta property="og:image" content={projectDetails.project?.image} />
+      </Helmet>
       <Portal.Root container={document.getElementById(INTRO_CONTAINER_ID)}>
         <Menu />
       </Portal.Root>

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -25,6 +25,7 @@ import { Sessions } from 'pages/sessions/sessions'
 import { Species } from 'pages/species/species'
 import { UnderConstruction } from 'pages/under-construction/under-construction'
 import { ReactNode, useContext, useEffect } from 'react'
+import { Helmet, HelmetProvider } from 'react-helmet-async'
 import { Navigate, Outlet, Route, Routes, useParams } from 'react-router-dom'
 import {
   BreadcrumbContext,
@@ -45,6 +46,13 @@ const INTRO_CONTAINER_ID = 'intro'
 
 export const App = () => (
   <AppProviders>
+    <Helmet>
+      <title>Antenna Data Platform</title>
+      <meta
+        name="description"
+        content="An interdisciplinary platform to upload, classify, and analyse in-the-wild images of invertebrates for research and conservation efforts."
+      />
+    </Helmet>
     <div id={APP_CONTAINER_ID} className={styles.wrapper}>
       <div id={INTRO_CONTAINER_ID}>
         <Header />
@@ -92,17 +100,19 @@ export const App = () => (
 )
 
 const AppProviders = ({ children }: { children: ReactNode }) => (
-  <QueryClientProvider client={queryClient}>
-    <CookieConsentContextProvider>
-      <UserPreferencesContextProvider>
-        <UserContextProvider>
-          <UserInfoContextProvider>
-            <BreadcrumbContextProvider>{children}</BreadcrumbContextProvider>
-          </UserInfoContextProvider>
-        </UserContextProvider>
-      </UserPreferencesContextProvider>
-    </CookieConsentContextProvider>
-  </QueryClientProvider>
+  <HelmetProvider>
+    <QueryClientProvider client={queryClient}>
+      <CookieConsentContextProvider>
+        <UserPreferencesContextProvider>
+          <UserContextProvider>
+            <UserInfoContextProvider>
+              <BreadcrumbContextProvider>{children}</BreadcrumbContextProvider>
+            </UserInfoContextProvider>
+          </UserContextProvider>
+        </UserPreferencesContextProvider>
+      </CookieConsentContextProvider>
+    </QueryClientProvider>
+  </HelmetProvider>
 )
 
 const AuthContainer = () => (
@@ -154,24 +164,19 @@ const ProjectContainer = () => {
     }
   }, [projectDetails.project])
 
-  useEffect(() => {
-    const meta = document.getElementsByTagName('meta').namedItem('description')
-    const newDescription = projectDetails.project?.description
-    const prevDescription = meta?.content
-
-    if (meta && newDescription) {
-      meta.content = newDescription
-    }
-
-    return () => {
-      if (meta && prevDescription) {
-        meta.content = prevDescription
-      }
-    }
-  }, [projectDetails.project])
-
   return (
     <>
+      {projectDetails.project && (
+        <Helmet>
+          <meta
+            name="description"
+            content={projectDetails.project.description}
+          />
+          {projectDetails.project.image && (
+            <meta property="og:image" content={projectDetails.project.image} />
+          )}
+        </Helmet>
+      )}
       <Portal.Root container={document.getElementById(INTRO_CONTAINER_ID)}>
         <Menu />
       </Portal.Root>

--- a/ui/src/components/header/header.tsx
+++ b/ui/src/components/header/header.tsx
@@ -3,6 +3,7 @@ import { useLogout } from 'data-services/hooks/auth/useLogout'
 import { Button, ButtonTheme } from 'design-system/components/button/button'
 import buttonStyles from 'design-system/components/button/button.module.scss'
 import { Icon, IconTheme, IconType } from 'design-system/components/icon/icon'
+import { Helmet } from 'react-helmet-async'
 import { Link, useLocation } from 'react-router-dom'
 import { APP_ROUTES, LANDING_PAGE_URL } from 'utils/constants'
 import { STRING, translate } from 'utils/language'
@@ -17,11 +18,13 @@ export const Header = () => {
   const location = useLocation()
   const { user } = useUser()
   const { logout, isLoading: isLogoutLoading } = useLogout()
-
-  usePageTitle()
+  const pageTitle = usePageTitle()
 
   return (
     <header className={styles.header}>
+      <Helmet>
+        <title>{pageTitle}</title>
+      </Helmet>
       <Link to="/" className={styles.logoContainer}>
         <img
           alt="Antenna"

--- a/ui/src/design-system/components/plot/plot.tsx
+++ b/ui/src/design-system/components/plot/plot.tsx
@@ -17,7 +17,6 @@ const Plot = ({
   orientation,
   type = 'bar',
   showRangeSlider,
-  hovertemplate,
 }: PlotProps) => (
   <div
     className={classNames(styles.plot, { [styles.round]: data.x.length >= 3 })}

--- a/ui/src/design-system/components/plot/types.ts
+++ b/ui/src/design-system/components/plot/types.ts
@@ -10,5 +10,4 @@ export interface PlotProps {
   type?: 'bar' | 'scatter'
   showRangeSlider?: boolean
   categorical?: boolean
-  hovertemplate?: string
 }

--- a/ui/src/pages/deployment-details/deployment-details-dialog.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-dialog.tsx
@@ -69,11 +69,9 @@ const DeploymentDetailsDialogContent = ({
 
   return (
     <>
-      {deployment.image && (
-        <Helmet>
-          <meta name="og:image" content={deployment.image} />
-        </Helmet>
-      )}
+      <Helmet>
+        <meta name="og:image" content={deployment.image} />
+      </Helmet>
       {!isEditing ? (
         <DeploymentDetailsInfo
           deployment={deployment}

--- a/ui/src/pages/deployment-details/deployment-details-dialog.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-dialog.tsx
@@ -4,6 +4,7 @@ import { DeploymentDetails } from 'data-services/models/deployment-details'
 import * as Dialog from 'design-system/components/dialog/dialog'
 import _ from 'lodash'
 import { useContext, useEffect, useState } from 'react'
+import { Helmet } from 'react-helmet-async'
 import { useNavigate, useParams } from 'react-router-dom'
 import { BreadcrumbContext } from 'utils/breadcrumbContext'
 import { APP_ROUTES } from 'utils/constants'
@@ -68,6 +69,11 @@ const DeploymentDetailsDialogContent = ({
 
   return (
     <>
+      {deployment.image && (
+        <Helmet>
+          <meta name="og:image" content={deployment.image} />
+        </Helmet>
+      )}
       {!isEditing ? (
         <DeploymentDetailsInfo
           deployment={deployment}

--- a/ui/src/pages/occurrence-details/occurrence-details.tsx
+++ b/ui/src/pages/occurrence-details/occurrence-details.tsx
@@ -119,11 +119,9 @@ export const OccurrenceDetails = ({
 
   return (
     <div className={styles.wrapper} ref={containerRef}>
-      {occurrence.images[0] && (
-        <Helmet>
-          <meta name="og:image" content={occurrence.images[0].src} />
-        </Helmet>
-      )}
+      <Helmet>
+        <meta name="og:image" content={occurrence.images[0]?.src} />
+      </Helmet>
       <div className={styles.header}>
         <TaxonInfo
           taxon={occurrence.determinationTaxon}

--- a/ui/src/pages/occurrence-details/occurrence-details.tsx
+++ b/ui/src/pages/occurrence-details/occurrence-details.tsx
@@ -14,6 +14,7 @@ import { InfoBlock } from 'design-system/components/info-block/info-block'
 import * as Tabs from 'design-system/components/tabs/tabs'
 import { Tooltip } from 'design-system/components/tooltip/tooltip'
 import { useMemo, useRef, useState } from 'react'
+import { Helmet } from 'react-helmet-async'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
@@ -118,6 +119,11 @@ export const OccurrenceDetails = ({
 
   return (
     <div className={styles.wrapper} ref={containerRef}>
+      {occurrence.images[0] && (
+        <Helmet>
+          <meta name="og:image" content={occurrence.images[0].src} />
+        </Helmet>
+      )}
       <div className={styles.header}>
         <TaxonInfo
           taxon={occurrence.determinationTaxon}

--- a/ui/src/pages/overview/overview.tsx
+++ b/ui/src/pages/overview/overview.tsx
@@ -14,6 +14,7 @@ import styles from './overview.module.scss'
 import { Pipelines } from './pipelines/pipelines'
 import { StorageSources } from './storage/storage'
 import { Summary } from './summary/summary'
+import { Helmet } from 'react-helmet-async'
 
 export const Overview = () => {
   const { selectedView, setSelectedView } = useSelectedView('summary')
@@ -38,6 +39,9 @@ export const Overview = () => {
 
   return (
     <>
+      <Helmet>
+        <meta property="og:image" content={project?.image} />
+      </Helmet>
       <div className={styles.about}>
         <div className={styles.aboutImage}>
           {project.image ? (

--- a/ui/src/pages/session-details/session-details.tsx
+++ b/ui/src/pages/session-details/session-details.tsx
@@ -6,6 +6,7 @@ import { PlotGrid } from 'design-system/components/plot-grid/plot-grid'
 import { Plot } from 'design-system/components/plot/lazy-plot'
 import { Error } from 'pages/error/error'
 import { useContext, useEffect } from 'react'
+import { Helmet } from 'react-helmet-async'
 import { useParams } from 'react-router-dom'
 import { BreadcrumbContext } from 'utils/breadcrumbContext'
 import { Playback } from './playback/playback'
@@ -46,6 +47,11 @@ export const SessionDetails = () => {
 
   return (
     <div className={styles.main}>
+      {session.exampleCaptures[0] && (
+        <Helmet>
+          <meta name="og:image" content={session.exampleCaptures[0].src} />
+        </Helmet>
+      )}
       {isFetching && (
         <div className={styles.fetchInfoWrapper}>
           <FetchInfo isLoading={isLoading} />

--- a/ui/src/pages/session-details/session-details.tsx
+++ b/ui/src/pages/session-details/session-details.tsx
@@ -47,11 +47,9 @@ export const SessionDetails = () => {
 
   return (
     <div className={styles.main}>
-      {session.exampleCaptures[0] && (
-        <Helmet>
-          <meta name="og:image" content={session.exampleCaptures[0].src} />
-        </Helmet>
-      )}
+      <Helmet>
+        <meta name="og:image" content={session.exampleCaptures[0]?.src} />
+      </Helmet>
       {isFetching && (
         <div className={styles.fetchInfoWrapper}>
           <FetchInfo isLoading={isLoading} />

--- a/ui/src/pages/species-details/species-details.tsx
+++ b/ui/src/pages/species-details/species-details.tsx
@@ -9,6 +9,7 @@ import {
 import { SpeciesDetails as Species } from 'data-services/models/species-details'
 import { InfoBlock } from 'design-system/components/info-block/info-block'
 import { useMemo } from 'react'
+import { Helmet } from 'react-helmet-async'
 import { useParams } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
@@ -17,6 +18,13 @@ import styles from './species-details.module.scss'
 
 export const SpeciesDetails = ({ species }: { species: Species }) => {
   const { projectId } = useParams()
+
+  const image = useMemo(() => {
+    if (species.occurrences.length) {
+      const occurrenceInfo = species.getOccurrenceInfo(species.occurrences[0])
+      return occurrenceInfo?.image.src
+    }
+  }, [species])
 
   const blueprintItems = useMemo(
     () =>
@@ -57,6 +65,11 @@ export const SpeciesDetails = ({ species }: { species: Species }) => {
 
   return (
     <div className={styles.wrapper}>
+      {image && (
+        <Helmet>
+          <meta name="og:image" content={image} />
+        </Helmet>
+      )}
       <div className={styles.header}>
         <TaxonInfo
           taxon={species}

--- a/ui/src/pages/species-details/species-details.tsx
+++ b/ui/src/pages/species-details/species-details.tsx
@@ -65,11 +65,9 @@ export const SpeciesDetails = ({ species }: { species: Species }) => {
 
   return (
     <div className={styles.wrapper}>
-      {image && (
-        <Helmet>
-          <meta name="og:image" content={image} />
-        </Helmet>
-      )}
+      <Helmet>
+        <meta name="og:image" content={image} />
+      </Helmet>
       <div className={styles.header}>
         <TaxonInfo
           taxon={species}

--- a/ui/src/utils/usePageTitle.ts
+++ b/ui/src/utils/usePageTitle.ts
@@ -30,9 +30,5 @@ export const usePageTitle = () => {
     setPageTitle(pageTitle)
   }, [pageBreadcrumb, projectBreadcrumb, mainBreadcrumb, detailBreadcrumb])
 
-  useEffect(() => {
-    document.title = pageTitle
-  }, [pageTitle])
-
   return pageTitle
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6906,6 +6906,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-error-boundary: "npm:^4.0.11"
+    react-helmet-async: "npm:^2.0.5"
     react-hook-form: "npm:^7.43.9"
     react-leaflet: "npm:^4.2.1"
     react-markdown: "npm:^9.0.1"
@@ -14383,6 +14384,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-fast-compare@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "react-fast-compare@npm:3.2.2"
+  checksum: 0bbd2f3eb41ab2ff7380daaa55105db698d965c396df73e6874831dbafec8c4b5b08ba36ff09df01526caa3c61595247e3269558c284e37646241cba2b90a367
+  languageName: node
+  linkType: hard
+
+"react-helmet-async@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "react-helmet-async@npm:2.0.5"
+  dependencies:
+    invariant: "npm:^2.2.4"
+    react-fast-compare: "npm:^3.2.2"
+    shallowequal: "npm:^1.1.0"
+  peerDependencies:
+    react: ^16.6.0 || ^17.0.0 || ^18.0.0
+  checksum: f390ea8bf13c2681850e5f8eb5b73d8613f407c245a5fd23e9db9b2cc14a3700dd1ce992d3966632886d1d613083294c2aeee009193f49dfa7d145d9f13ea2b0
+  languageName: node
+  linkType: hard
+
 "react-hook-form@npm:^7.43.9":
   version: 7.43.9
   resolution: "react-hook-form@npm:7.43.9"
@@ -15328,6 +15349,13 @@ __metadata:
   version: 0.0.1
   resolution: "shallow-copy@npm:0.0.1"
   checksum: ab1c762e36fa3a02cec228e111f227be0b46457a82f123c5ef13f3bc970be16b74dbfd0f1b6ffb450a66db856832800c86713ffc1ec5733d61f59f23fe114769
+  languageName: node
+  linkType: hard
+
+"shallowequal@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "shallowequal@npm:1.1.0"
+  checksum: b926efb51cd0f47aa9bc061add788a4a650550bbe50647962113a4579b60af2abe7b62f9b02314acc6f97151d4cf87033a2b15fc20852fae306d1a095215396c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Specify meta images using following logic:
- For project overview page, use project image
- For station details, use station cover image
- For session details, use first example capture
- For occurrence details, use first crop
- For species details, use first occurrence crop
- For other pages, use no image

Also, we introduce the library [react-helmet-async](https://github.com/staylor/react-helmet-async#readme) as part of this PR, to make meta tags in general easier to handle.