### PR TITLE
Lazy load activity plot

### DIFF
--- a/ui/src/design-system/components/loading-spinner/loading-spinner.module.scss
+++ b/ui/src/design-system/components/loading-spinner/loading-spinner.module.scss
@@ -4,7 +4,7 @@
   display: inline-block;
   border-style: solid;
   border-color: $color-primary-2-500;
-  border-top-color: $color-primary-2-50;
+  border-top-color: transparent;
   border-radius: 50%;
   animation: spin 0.7s ease-in-out infinite;
 }

--- a/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
+++ b/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
@@ -1,9 +1,8 @@
-import { SessionDetails } from 'data-services/models/session-details'
-import { TimelineTick } from 'data-services/models/timeline-tick'
 import { useRef } from 'react'
 import Plot from 'react-plotly.js'
 import { getCompactTimespanString } from 'utils/date/getCompactTimespanString/getCompactTimespanString'
 import { findClosestCaptureId } from '../utils'
+import { ActivityPlotProps } from './types'
 import { useDynamicPlotWidth } from './useDynamicPlotWidth'
 
 const fontFamily = 'Mazzard, sans-serif'
@@ -14,17 +13,12 @@ const textColor = '#303137'
 const tooltipBgColor = '#FFFFFF'
 const tooltipBorderColor = '#303137'
 
-export const ActivityPlot = ({
+const ActivityPlot = ({
   session,
   snapToDetections,
   timeline,
   setActiveCaptureId,
-}: {
-  session: SessionDetails
-  snapToDetections?: boolean
-  timeline: TimelineTick[]
-  setActiveCaptureId: (captureId: string) => void
-}) => {
+}: ActivityPlotProps) => {
   const containerRef = useRef(null)
   const width = useDynamicPlotWidth(containerRef)
 
@@ -170,3 +164,5 @@ export const ActivityPlot = ({
     </div>
   )
 }
+
+export default ActivityPlot

--- a/ui/src/pages/session-details/playback/activity-plot/lazy-activity-plot.module.scss
+++ b/ui/src/pages/session-details/playback/activity-plot/lazy-activity-plot.module.scss
@@ -1,0 +1,6 @@
+.loadingWrapper {
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/ui/src/pages/session-details/playback/activity-plot/lazy-activity-plot.tsx
+++ b/ui/src/pages/session-details/playback/activity-plot/lazy-activity-plot.tsx
@@ -1,0 +1,14 @@
+import { ErrorBoundary } from 'components/error-boundary/error-boundary'
+import { LoadingSpinner } from 'design-system/components/loading-spinner/loading-spinner'
+import React, { Suspense } from 'react'
+import { ActivityPlotProps } from './types'
+
+const _ActivityPlot = React.lazy(() => import('./activity-plot'))
+
+export const ActivityPlot = (props: ActivityPlotProps) => (
+  <Suspense fallback={<LoadingSpinner />}>
+    <ErrorBoundary>
+      <_ActivityPlot {...props} />
+    </ErrorBoundary>
+  </Suspense>
+)

--- a/ui/src/pages/session-details/playback/activity-plot/lazy-activity-plot.tsx
+++ b/ui/src/pages/session-details/playback/activity-plot/lazy-activity-plot.tsx
@@ -1,12 +1,19 @@
 import { ErrorBoundary } from 'components/error-boundary/error-boundary'
 import { LoadingSpinner } from 'design-system/components/loading-spinner/loading-spinner'
 import React, { Suspense } from 'react'
+import styles from './lazy-activity-plot.module.scss'
 import { ActivityPlotProps } from './types'
 
 const _ActivityPlot = React.lazy(() => import('./activity-plot'))
 
 export const ActivityPlot = (props: ActivityPlotProps) => (
-  <Suspense fallback={<LoadingSpinner />}>
+  <Suspense
+    fallback={
+      <div className={styles.loadingWrapper}>
+        <LoadingSpinner size={32} />
+      </div>
+    }
+  >
     <ErrorBoundary>
       <_ActivityPlot {...props} />
     </ErrorBoundary>

--- a/ui/src/pages/session-details/playback/activity-plot/types.ts
+++ b/ui/src/pages/session-details/playback/activity-plot/types.ts
@@ -1,0 +1,9 @@
+import { SessionDetails } from 'data-services/models/session-details'
+import { TimelineTick } from 'data-services/models/timeline-tick'
+
+export interface ActivityPlotProps {
+  session: SessionDetails
+  snapToDetections?: boolean
+  timeline: TimelineTick[]
+  setActiveCaptureId: (captureId: string) => void
+}

--- a/ui/src/pages/session-details/playback/playback.tsx
+++ b/ui/src/pages/session-details/playback/playback.tsx
@@ -8,7 +8,7 @@ import {
 } from 'design-system/components/checkbox/checkbox'
 import { useMemo, useState } from 'react'
 import { useUserPreferences } from 'utils/userPreferences/userPreferencesContext'
-import { ActivityPlot } from './activity-plot/activity-plot'
+import { ActivityPlot } from './activity-plot/lazy-activity-plot'
 import { CaptureDetails } from './capture-details/capture-details'
 import { CaptureNavigation } from './capture-navigation/capture-navigation'
 import { Frame } from './frame/frame'


### PR DESCRIPTION
Plotly lib is huge and it was included in our main bundle (loaded even if the user is not visiting a page where this lib is used). By lazy loading components that is using this lib, we could reduce the main bundle size.

Before:
<img width="877" alt="Skärmavbild 2024-10-31 kl  18 35 48" src="https://github.com/user-attachments/assets/75aef9e7-0a2f-4a03-81a5-998a819e936d">

After:
<img width="875" alt="Skärmavbild 2024-10-31 kl  18 32 37" src="https://github.com/user-attachments/assets/bd741c70-17dd-4d99-80c1-f9e680f8f673">
