### PR TITLE
Add deprecated styling to environment label

### DIFF
--- a/ui/src/components/header/version-info/version-info.module.scss
+++ b/ui/src/components/header/version-info/version-info.module.scss
@@ -23,3 +23,10 @@
   color: $color-neutral-700;
   white-space: nowrap;
 }
+
+.deprecated {
+  .badge {
+    background-color: $color-destructive-100;
+    color: $color-destructive-600;
+  }
+}

--- a/ui/src/components/header/version-info/version-info.tsx
+++ b/ui/src/components/header/version-info/version-info.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { Tooltip } from 'design-system/components/tooltip/tooltip'
 import styles from './version-info.module.scss'
 
@@ -10,7 +11,13 @@ const COPY = {
 }
 
 export const VersionInfo = () => (
-  <div className={styles.wrapper}>
+  <div
+    className={classNames(styles.wrapper, {
+      [styles.deprecated]: (COPY.LABEL as string)
+        .toLocaleLowerCase()
+        .includes('deprecated'),
+    })}
+  >
     <Tooltip content={COPY.INFO}>
       <div className={styles.badge}>{COPY.LABEL}</div>
     </Tooltip>

--- a/ui/src/components/header/version-info/version-info.tsx
+++ b/ui/src/components/header/version-info/version-info.tsx
@@ -14,7 +14,7 @@ export const VersionInfo = () => (
   <div
     className={classNames(styles.wrapper, {
       [styles.deprecated]: (COPY.LABEL as string)
-        .toLocaleLowerCase()
+        .toLowerCase()
         .includes('deprecated'),
     })}
   >


### PR DESCRIPTION
If the environment variable `VITE_ENV_LABEL` includes the word "deprecated", we update its style:

![Skärmavbild 2024-11-06 kl  20 15 39](https://github.com/user-attachments/assets/f9536e64-09b4-4e75-9264-3e25c68b9e97)
