### PR TITLE
Remove default classification threshold

### DIFF
--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -563,7 +563,8 @@ class SourceImageCollectionViewSet(DefaultViewSet):
     def get_queryset(self) -> QuerySet:
         classification_threshold = get_active_classification_threshold(self.request)
         queryset = (
-            super().get_queryset()
+            super()
+            .get_queryset()
             .with_occurrences_count(classification_threshold=classification_threshold)  # type: ignore
             .with_taxa_count(classification_threshold=classification_threshold)
         )

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -375,12 +375,7 @@ class SourceImageViewSet(DefaultViewSet):
     GET /captures/1/
     """
 
-    queryset = (
-        SourceImage.objects.all()
-        .with_occurrences_count()  # type: ignore
-        .with_taxa_count()
-        # .with_detections_count()
-    )
+    queryset = SourceImage.objects.all()
 
     serializer_class = SourceImageSerializer
     filterset_fields = ["event", "deployment", "deployment__project", "collections"]
@@ -411,6 +406,13 @@ class SourceImageViewSet(DefaultViewSet):
     def get_queryset(self) -> QuerySet:
         queryset = super().get_queryset()
         with_detections_default = False
+
+        classification_threshold = get_active_classification_threshold(self.request)
+        queryset = queryset.with_occurrences_count(  # type: ignore
+            classification_threshold=classification_threshold
+        ).with_taxa_count(  # type: ignore
+            classification_threshold=classification_threshold
+        )
 
         queryset.select_related(
             "event",
@@ -543,8 +545,6 @@ class SourceImageCollectionViewSet(DefaultViewSet):
         SourceImageCollection.objects.all()
         .with_source_images_count()  # type: ignore
         .with_source_images_with_detections_count()
-        .with_occurrences_count()
-        .with_taxa_count()
         .prefetch_related("jobs")
     )
     serializer_class = SourceImageCollectionSerializer
@@ -559,6 +559,15 @@ class SourceImageCollectionViewSet(DefaultViewSet):
         "source_images_with_detections_count",
         "occurrences_count",
     ]
+
+    def get_queryset(self) -> QuerySet:
+        classification_threshold = get_active_classification_threshold(self.request)
+        queryset = (
+            super().get_queryset()
+            .with_occurrences_count(classification_threshold=classification_threshold)  # type: ignore
+            .with_taxa_count(classification_threshold=classification_threshold)
+        )
+        return queryset
 
     @action(detail=True, methods=["post"], name="populate")
     def populate(self, request, pk=None):

--- a/ami/utils/requests.py
+++ b/ami/utils/requests.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.forms import FloatField
 from rest_framework.request import Request
 
@@ -10,5 +9,5 @@ def get_active_classification_threshold(request: Request) -> float:
     if classification_threshold is not None:
         classification_threshold = FloatField(required=False).clean(classification_threshold)
     else:
-        classification_threshold = settings.DEFAULT_CONFIDENCE_THRESHOLD
+        classification_threshold = 0
     return classification_threshold

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -369,8 +369,6 @@ SPECTACULAR_SETTINGS = {
 # Your stuff...
 # ------------------------------------------------------------------------------
 
-DEFAULT_CONFIDENCE_THRESHOLD = env.float("DEFAULT_CONFIDENCE_THRESHOLD", default=0.6)  # type: ignore[no-untyped-call]
-
 S3_TEST_ENDPOINT = env("MINIO_ENDPOINT", default="http://minio:9000")  # type: ignore[no-untyped-call]
 S3_TEST_KEY = env("MINIO_ROOT_USER", default=None)  # type: ignore[no-untyped-call]
 S3_TEST_SECRET = env("MINIO_ROOT_PASSWORD", default=None)  # type: ignore[no-untyped-call]


### PR DESCRIPTION
Previously several counts and lists of occurrences and taxa were filtered by a default threshold of their best classification score. This cause confusion because some counts in the UI were filtered, and others were not, and the threshold is only adjustable by the user in some views. 

The decision was made to remove the threshold and show all occurrences & taxa unfiltered. Any filtering should be user configurable and passed to the backend via a query param.  