### PR TITLE
fix: missing collections filter

### DIFF
--- a/ui/src/utils/useFilters.ts
+++ b/ui/src/utils/useFilters.ts
@@ -11,7 +11,11 @@ export const AVAILABLE_FILTERS = [
   },
   {
     label: 'Collection',
-    field: 'source_image_collection', // TODO: Can we update this key to "collection" to streamline?
+    field: 'collection', // This is for viewing Occurrences by collection
+  },
+  {
+    label: 'Source image collection',
+    field: 'source_image_collection', // This is for viewing Jobs by collection. @TODO can we update this key to "collection" to streamline?
   },
   {
     label: 'Station',
@@ -48,10 +52,6 @@ export const AVAILABLE_FILTERS = [
   {
     label: 'Source image',
     field: 'source_image_single', // TODO: Can we update this key to "source_image" to streamline?
-  },
-  {
-    label: 'Source image collection',
-    field: 'source_image_collection',
   },
   {
     label: 'Status',

--- a/ui/src/utils/useFilters.ts
+++ b/ui/src/utils/useFilters.ts
@@ -14,7 +14,7 @@ export const AVAILABLE_FILTERS = [
     field: 'collection', // This is for viewing Occurrences by collection
   },
   {
-    label: 'Source image collection',
+    label: 'Collection',
     field: 'source_image_collection', // This is for viewing Jobs by collection. @TODO can we update this key to "collection" to streamline?
   },
   {


### PR DESCRIPTION
We have two different URL params for filtering by source image collections throughout the site. This covers both. Perhaps we can make them both "collection" in #633 