### PR TITLE
Ensure minio and proxy containers are ready before permissions are set

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,8 @@ services:
       - "9000:9000"
     volumes:
       - ./compose/local/minio/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - minio
 
   minio-init:
     image: minio/mc
@@ -133,6 +135,7 @@ services:
       - ./.envs/.local/.django
     depends_on:
       - minio
+      - minio-proxy
     volumes:
       - ./compose/local/minio/init.sh:/etc/minio/init.sh
     entrypoint: /etc/minio/init.sh


### PR DESCRIPTION
Sometimes when the project starts up, images were broken because the set-permissions init script had failed to run. 