### PR TITLE
fix: standardize line-length settings for auto-formatting & checks (python)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,8 +15,16 @@
     "typescript.format.enable": true,
     "prettier.requireConfig": true,
     "[python]": {
-      "editor.defaultFormatter": "ms-python.black-formatter"
+      "editor.defaultFormatter": "ms-python.black-formatter",
+      "editor.tabSize": 4,
+      "editor.rulers": [
+        119
+      ]
     },
+    "black-formatter.args": ["--line-length", "119"],
+    "flake8.args": [
+        "--max-line-length", "119"
+    ],
     "[javascript]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },


### PR DESCRIPTION
The pre-commit hook runs the Black formatter with a line-length setting of 117 (set in pyproject.toml), however VScode was not using this value. This sets the same line length for Black and Flake8 for checks during dev, format-on-save, and the visual editor "ruler". 

I would consider changing this to 88 to match the Black & Django default, but that's another PR! 