### PR TITLE
Update filter logic to fix capture collection filtering

### DIFF
--- a/ui/src/components/filtering/filter-control.tsx
+++ b/ui/src/components/filtering/filter-control.tsx
@@ -68,7 +68,7 @@ export const FilterControl = ({
       </label>
       <div className="flex items-center justify-between gap-2">
         <FilterComponent
-          isValid={!filter.error}
+          error={filter.error}
           onAdd={(value) => addFilter(field, value)}
           onClear={() => clearFilter(field)}
           value={filter.value}

--- a/ui/src/components/filtering/filters/date-filter.tsx
+++ b/ui/src/components/filtering/filters/date-filter.tsx
@@ -12,7 +12,7 @@ const dateToLabel = (date: Date) => {
   }
 }
 
-export const DateFilter = ({ isValid, onAdd, onClear, value }: FilterProps) => {
+export const DateFilter = ({ error, onAdd, onClear, value }: FilterProps) => {
   const [open, setOpen] = useState(false)
   const selected = value ? new Date(value) : undefined
 
@@ -35,7 +35,7 @@ export const DateFilter = ({ isValid, onAdd, onClear, value }: FilterProps) => {
         >
           <>
             <span>{triggerLabel}</span>
-            {selected && !isValid ? (
+            {selected && error ? (
               <AlertCircleIcon className="w-4 w-4 text-destructive" />
             ) : (
               <CalendarIcon className="w-4 w-4" />

--- a/ui/src/components/filtering/filters/types.ts
+++ b/ui/src/components/filtering/filters/types.ts
@@ -1,5 +1,5 @@
 export interface FilterProps {
-  isValid?: boolean
+  error?: string
   onAdd: (value: string) => void
   onClear: () => void
   value: string | undefined

--- a/ui/src/data-services/types.ts
+++ b/ui/src/data-services/types.ts
@@ -2,7 +2,7 @@ export interface FetchParams {
   projectId?: string
   pagination?: { page: number; perPage: number }
   sort?: { field: string; order: 'asc' | 'desc' }
-  filters?: { field: string; value?: string; isValid?: boolean }[]
+  filters?: { field: string; value?: string; error?: string }[]
 }
 
 export interface APIValidationError {

--- a/ui/src/data-services/utils.ts
+++ b/ui/src/data-services/utils.ts
@@ -27,7 +27,7 @@ export const getFetchUrl = ({
   }
   if (params?.filters?.length) {
     params.filters.forEach((filter) => {
-      if (filter.value?.length && filter.isValid) {
+      if (filter.value?.length && !filter.error) {
         queryParams[filter.field] = filter.value
       }
     })

--- a/ui/src/utils/useFilters.ts
+++ b/ui/src/utils/useFilters.ts
@@ -124,12 +124,10 @@ export const useFilters = (defaultFilters?: { [field: string]: string }) => {
 
   const filters = _filters.map(({ validate, value, ...rest }) => {
     const error = validate ? validate(value, _filters) : undefined
-    const isValid = !error
 
     return {
       ...rest,
       value,
-      isValid,
       error,
     }
   })


### PR DESCRIPTION
Comment from @mihow :
> I just noticed that when viewing the captures in a collection, they are no longer being filtered by the collection, it's showing all captures in the whole project, no matter which collection you click on.

We recently introduced logic to only pass valid filters with backend calls. However, in this particular view the collections filter is hard coded (not possible to modify from URL or UI). Since hard coded filters are excluded from the validation logic, it wasn't marked as valid and therefore excluded from the backend request. By tweaking the logic to check for errors, rather than "marked as valid", we could fix the problem.

How the hard coded filter is defined in code (FIY I think this is the only hard coded filter situation):

<img width="564" alt="Screenshot 2024-12-20 at 10 11 23" src="https://github.com/user-attachments/assets/cee9b2f7-9fd0-4a42-aa1a-a53d479cae71" />

