### PR TITLE
Handle occurrence detail view tab state as a search param

### DIFF
--- a/ui/src/pages/occurrence-details/occurrence-details.tsx
+++ b/ui/src/pages/occurrence-details/occurrence-details.tsx
@@ -35,8 +35,12 @@ export const TABS = {
 
 export const OccurrenceDetails = ({
   occurrence,
+  selectedTab,
+  setSelectedTab,
 }: {
   occurrence: Occurrence
+  selectedTab?: string
+  setSelectedTab: (selectedTab?: string) => void
 }) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const suggestIdInputRef = useRef<HTMLInputElement>(null)
@@ -48,9 +52,6 @@ export const OccurrenceDetails = ({
   const { projectId } = useParams()
   const navigate = useNavigate()
   const location = useLocation()
-  const [selectedTab, setSelectedTab] = useState<string | undefined>(
-    state?.defaultTab ?? TABS.FIELDS
-  )
   const [suggestIdOpen, setSuggestIdOpen] = useState<boolean>(
     state?.suggestIdOpen ?? false
   )

--- a/ui/src/pages/occurrences/occurrences.tsx
+++ b/ui/src/pages/occurrences/occurrences.tsx
@@ -13,9 +13,12 @@ import { PaginationBar } from 'design-system/components/pagination-bar/paginatio
 import { ColumnSettings } from 'design-system/components/table/column-settings/column-settings'
 import { Table } from 'design-system/components/table/table/table'
 import { ToggleGroup } from 'design-system/components/toggle-group/toggle-group'
-import { OccurrenceDetails } from 'pages/occurrence-details/occurrence-details'
+import {
+  OccurrenceDetails,
+  TABS,
+} from 'pages/occurrence-details/occurrence-details'
 import { useContext, useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { BreadcrumbContext } from 'utils/breadcrumbContext'
 import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
@@ -210,6 +213,11 @@ const OccurrenceDetailsDialog = ({
   occurrences?: Occurrence[]
 }) => {
   const navigate = useNavigate()
+  const { state } = useLocation()
+  const { selectedView, setSelectedView } = useSelectedView(
+    state?.defaultTab ?? TABS.FIELDS,
+    'tab'
+  )
   const { projectId } = useParams()
   const { setDetailBreadcrumb } = useContext(BreadcrumbContext)
   const { occurrence, isLoading, error } = useOccurrenceDetails(id)
@@ -227,21 +235,31 @@ const OccurrenceDetailsDialog = ({
   return (
     <Dialog.Root
       open={!!id}
-      onOpenChange={() =>
+      onOpenChange={(open) => {
+        if (!open) {
+          setSelectedView(undefined)
+        }
+
         navigate(
           getAppRoute({
             to: APP_ROUTES.OCCURRENCES({ projectId: projectId as string }),
             keepSearchParams: true,
           })
         )
-      }
+      }}
     >
       <Dialog.Content
         ariaCloselabel={translate(STRING.CLOSE)}
         isLoading={isLoading}
         error={error}
       >
-        {occurrence ? <OccurrenceDetails occurrence={occurrence} /> : null}
+        {occurrence ? (
+          <OccurrenceDetails
+            occurrence={occurrence}
+            selectedTab={selectedView}
+            setSelectedTab={setSelectedView}
+          />
+        ) : null}
         <OccurrenceNavigation occurrences={occurrences} />
       </Dialog.Content>
     </Dialog.Root>

--- a/ui/src/pages/occurrences/occurrences.tsx
+++ b/ui/src/pages/occurrences/occurrences.tsx
@@ -214,13 +214,17 @@ const OccurrenceDetailsDialog = ({
 }) => {
   const navigate = useNavigate()
   const { state } = useLocation()
-  const { selectedView, setSelectedView } = useSelectedView(
-    state?.defaultTab ?? TABS.FIELDS,
-    'tab'
-  )
+  const { selectedView, setSelectedView } = useSelectedView(TABS.FIELDS, 'tab')
   const { projectId } = useParams()
   const { setDetailBreadcrumb } = useContext(BreadcrumbContext)
   const { occurrence, isLoading, error } = useOccurrenceDetails(id)
+
+  useEffect(() => {
+    // If a default tab is set from router state, set this as active
+    if (state?.defaultTab) {
+      setSelectedView(state.defaultTab)
+    }
+  }, [state?.defaultTab])
 
   useEffect(() => {
     setDetailBreadcrumb(

--- a/ui/src/pages/overview/overview.tsx
+++ b/ui/src/pages/overview/overview.tsx
@@ -17,7 +17,7 @@ import { StorageSources } from './storage/storage'
 import { Summary } from './summary/summary'
 
 export const Overview = () => {
-  const { selectedView, setSelectedView } = useSelectedView('summary')
+  const { selectedView, setSelectedView } = useSelectedView('summary', 'tab')
   const { project, isLoading, error } = useOutletContext<{
     project?: Project
     isLoading: boolean

--- a/ui/src/utils/useSelectedView.ts
+++ b/ui/src/utils/useSelectedView.ts
@@ -2,15 +2,18 @@ import { useSearchParams } from 'react-router-dom'
 
 const SEARCH_PARAM_KEY_VIEW = 'view'
 
-export const useSelectedView = (defaultValue: string) => {
+export const useSelectedView = (
+  defaultValue: string,
+  key: string = SEARCH_PARAM_KEY_VIEW
+) => {
   const [searchParams, setSearchParams] = useSearchParams()
-  const selectedView = searchParams.get(SEARCH_PARAM_KEY_VIEW) ?? undefined
+  const selectedView = searchParams.get(key) ?? undefined
 
-  const setSelectedView = (selectedView: string | null) => {
-    searchParams.delete(SEARCH_PARAM_KEY_VIEW)
+  const setSelectedView = (selectedView?: string) => {
+    searchParams.delete(key)
 
     if (selectedView && selectedView !== defaultValue) {
-      searchParams.set(SEARCH_PARAM_KEY_VIEW, selectedView)
+      searchParams.set(key, selectedView ?? defaultValue)
     }
 
     setSearchParams(searchParams)


### PR DESCRIPTION
Fixes #662 

To fix this, we use our already existing hook `useSelectedView`. We use this hook for the project summary tabs and also for the table/gallery state in main views. We update this took to handle a custom search param key (so we can use "tab" instead of "view" to avoid conflicts with the occurrence main view).