### PR TITLE
Fix background tasks from disappearing 

### DIFF
--- a/.envs/.local/.django
+++ b/.envs/.local/.django
@@ -16,7 +16,7 @@ CELERY_FLOWER_USER=QSocnxapfMvzLqJXSsXtnEZqRkBtsmKT
 CELERY_FLOWER_PASSWORD=BEQgmCtgyrFieKNoGTsux9YIye0I7P5Q7vEgfJD2C4jxmtHDetFaE2jhS7K7rxaf
 
 # Attempting to keep Flower from showing workers as offline
-# FLOWER_BROKER_API=http://redis:6379/0 
+# FLOWER_BROKER_API=REDIS_URL
 FLOWER_PERSISTENT=True
 FLOWER_UPDATE_INTERVAL=10000  # 10 seconds in milliseconds
 FLOWER_HEARTBEAT_INTERVAL=5000  # Default

--- a/.envs/.local/.django
+++ b/.envs/.local/.django
@@ -15,6 +15,12 @@ REDIS_URL=redis://redis:6379/0
 CELERY_FLOWER_USER=QSocnxapfMvzLqJXSsXtnEZqRkBtsmKT
 CELERY_FLOWER_PASSWORD=BEQgmCtgyrFieKNoGTsux9YIye0I7P5Q7vEgfJD2C4jxmtHDetFaE2jhS7K7rxaf
 
+# Attempting to keep Flower from showing workers as offline
+# FLOWER_BROKER_API=http://redis:6379/0 
+FLOWER_PERSISTENT=True
+FLOWER_UPDATE_INTERVAL=10000  # 10 seconds in milliseconds
+FLOWER_HEARTBEAT_INTERVAL=5000  # Default
+
 # This is the hostname for the frontend server
 EXTERNAL_HOSTNAME=localhost:4000
 DJANGO_CSRF_TRUSTED_ORIGINS=http://localhost:3000,http://localhost:4000

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -276,17 +276,50 @@ LOGGING = {
 
 # Celery
 # ------------------------------------------------------------------------------
-
 if USE_TZ:
     # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-timezone
     CELERY_TIMEZONE = TIME_ZONE
-
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-broker_url
 CELERY_BROKER_URL = env("CELERY_BROKER_URL")
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-result_backend
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-extended
 CELERY_RESULT_EXTENDED = True
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-backend-always-retry
+# https://github.com/celery/celery/pull/6122
+CELERY_RESULT_BACKEND_ALWAYS_RETRY = True
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-backend-max-retries
+CELERY_RESULT_BACKEND_MAX_RETRIES = 10
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-accept_content
+CELERY_ACCEPT_CONTENT = ["json"]
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-task_serializer
+CELERY_TASK_SERIALIZER = "json"
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-result_serializer
+CELERY_RESULT_SERIALIZER = "json"
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-time-limit
+# TODO: set to whatever value is adequate in your circumstances
+CELERY_TASK_TIME_LIMIT = 7 * 60 * 24
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-soft-time-limit
+# TODO: set to whatever value is adequate in your circumstances
+CELERY_TASK_SOFT_TIME_LIMIT = 6 * 60 * 24
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#beat-scheduler
+CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-send-task-events
+CELERY_WORKER_SEND_TASK_EVENTS = True
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_send_sent_event
+CELERY_TASK_SEND_SENT_EVENT = True
+
+# Health checking and retries, specific to Redis
+CELERY_REDIS_MAX_CONNECTIONS = 50  # Total connection pool limit for results backend
+CELERY_REDIS_SOCKET_TIMEOUT = 120  # Match Redis timeout
+CELERY_REDIS_SOCKET_KEEPALIVE = True
+CELERY_REDIS_BACKEND_HEALTH_CHECK_INTERVAL = 30  # Check health every 30s
+
+# Help distribute long-running tasks
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-prefetch-multiplier
+# @TODO Review and test this setting
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1
+CELERY_WORKER_ENABLE_PREFETCH_COUNT_REDUCTION = True
 
 # Connection settings to match Redis timeout and keepalive
 CELERY_BROKER_TRANSPORT_OPTIONS = {
@@ -298,23 +331,9 @@ CELERY_BROKER_TRANSPORT_OPTIONS = {
     "max_connections": 20,  # Per process connection pool limit
 }
 
-# Health checking and retries
-CELERY_REDIS_MAX_CONNECTIONS = 50  # Total connection pool limit for results backend
-CELERY_REDIS_SOCKET_TIMEOUT = 120  # Match Redis timeout
-CELERY_REDIS_SOCKET_KEEPALIVE = True
-CELERY_REDIS_BACKEND_HEALTH_CHECK_INTERVAL = 30  # Check health every 30s
-
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-backend-always-retry
-# https://github.com/celery/celery/pull/6122
-CELERY_RESULT_BACKEND_ALWAYS_RETRY = True
-CELERY_RESULT_BACKEND_MAX_RETRIES = 10
 CELERY_BROKER_CONNECTION_RETRY = True
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 CELERY_BROKER_CONNECTION_MAX_RETRIES = None  # Retry forever
-
-# Task settings to help with reliability
-CELERY_WORKER_PREFETCH_MULTIPLIER = 1  # Don't prefetch tasks
-CELERY_WORKER_ENABLE_PREFETCH_COUNT_REDUCTION = True
 
 
 # django-rest-framework

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -276,17 +276,24 @@ LOGGING = {
 
 # Celery
 # ------------------------------------------------------------------------------
+
+if USE_TZ:
+    # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-timezone
+    CELERY_TIMEZONE = TIME_ZONE
+
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-broker_url
+CELERY_BROKER_URL = env("CELERY_BROKER_URL")
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-result_backend
+CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-extended
+CELERY_RESULT_EXTENDED = True
+
 # Connection settings to match Redis timeout and keepalive
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     "visibility_timeout": 43200,  # 12 hours - default celery value
     "socket_timeout": 120,  # Matches Redis timeout setting
     "socket_connect_timeout": 30,  # Max time to establish connection
     "socket_keepalive": True,  # Enable TCP keepalive
-    # 'socket_keepalive_options': {
-    #     'TCP_KEEPIDLE': 60,           # Match Redis tcp-keepalive value
-    #     'TCP_KEEPINTVL': 10,          # Interval between keepalive probes
-    #     'TCP_KEEPCNT': 3              # Number of keepalive probes
-    # },
     "retry_on_timeout": True,  # Retry operations if Redis times out
     "max_connections": 20,  # Per process connection pool limit
 }
@@ -297,7 +304,8 @@ CELERY_REDIS_SOCKET_TIMEOUT = 120  # Match Redis timeout
 CELERY_REDIS_SOCKET_KEEPALIVE = True
 CELERY_REDIS_BACKEND_HEALTH_CHECK_INTERVAL = 30  # Check health every 30s
 
-# Already in your settings but important to keep with these values
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-backend-always-retry
+# https://github.com/celery/celery/pull/6122
 CELERY_RESULT_BACKEND_ALWAYS_RETRY = True
 CELERY_RESULT_BACKEND_MAX_RETRIES = 10
 CELERY_BROKER_CONNECTION_RETRY = True

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -276,38 +276,37 @@ LOGGING = {
 
 # Celery
 # ------------------------------------------------------------------------------
-if USE_TZ:
-    # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-timezone
-    CELERY_TIMEZONE = TIME_ZONE
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-broker_url
-CELERY_BROKER_URL = env("CELERY_BROKER_URL")
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-result_backend
-CELERY_RESULT_BACKEND = CELERY_BROKER_URL
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-extended
-CELERY_RESULT_EXTENDED = True
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-backend-always-retry
-# https://github.com/celery/celery/pull/6122
+# Connection settings to match Redis timeout and keepalive
+CELERY_BROKER_TRANSPORT_OPTIONS = {
+    'visibility_timeout': 43200,      # 12 hours - default celery value
+    'socket_timeout': 120,            # Matches Redis timeout setting
+    'socket_connect_timeout': 30,     # Max time to establish connection
+    'socket_keepalive': True,         # Enable TCP keepalive
+    # 'socket_keepalive_options': {
+    #     'TCP_KEEPIDLE': 60,           # Match Redis tcp-keepalive value
+    #     'TCP_KEEPINTVL': 10,          # Interval between keepalive probes
+    #     'TCP_KEEPCNT': 3              # Number of keepalive probes
+    # },
+    'retry_on_timeout': True,         # Retry operations if Redis times out
+    'max_connections': 20             # Per process connection pool limit
+}
+
+# Health checking and retries
+CELERY_REDIS_MAX_CONNECTIONS = 50     # Total connection pool limit for results backend
+CELERY_REDIS_SOCKET_TIMEOUT = 120     # Match Redis timeout
+CELERY_REDIS_SOCKET_KEEPALIVE = True
+CELERY_REDIS_BACKEND_HEALTH_CHECK_INTERVAL = 30  # Check health every 30s
+
+# Already in your settings but important to keep with these values
 CELERY_RESULT_BACKEND_ALWAYS_RETRY = True
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-backend-max-retries
 CELERY_RESULT_BACKEND_MAX_RETRIES = 10
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-accept_content
-CELERY_ACCEPT_CONTENT = ["json"]
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-task_serializer
-CELERY_TASK_SERIALIZER = "json"
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-result_serializer
-CELERY_RESULT_SERIALIZER = "json"
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-time-limit
-# TODO: set to whatever value is adequate in your circumstances
-CELERY_TASK_TIME_LIMIT = 5 * 60
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-soft-time-limit
-# TODO: set to whatever value is adequate in your circumstances
-CELERY_TASK_SOFT_TIME_LIMIT = 60
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#beat-scheduler
-CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-send-task-events
-CELERY_WORKER_SEND_TASK_EVENTS = True
-# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_send_sent_event
-CELERY_TASK_SEND_SENT_EVENT = True
+CELERY_BROKER_CONNECTION_RETRY = True
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+CELERY_BROKER_CONNECTION_MAX_RETRIES = None  # Retry forever
+
+# Task settings to help with reliability
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1        # Don't prefetch tasks
+CELERY_WORKER_ENABLE_PREFETCH_COUNT_REDUCTION = True
 
 
 # django-rest-framework

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -278,22 +278,22 @@ LOGGING = {
 # ------------------------------------------------------------------------------
 # Connection settings to match Redis timeout and keepalive
 CELERY_BROKER_TRANSPORT_OPTIONS = {
-    'visibility_timeout': 43200,      # 12 hours - default celery value
-    'socket_timeout': 120,            # Matches Redis timeout setting
-    'socket_connect_timeout': 30,     # Max time to establish connection
-    'socket_keepalive': True,         # Enable TCP keepalive
+    "visibility_timeout": 43200,  # 12 hours - default celery value
+    "socket_timeout": 120,  # Matches Redis timeout setting
+    "socket_connect_timeout": 30,  # Max time to establish connection
+    "socket_keepalive": True,  # Enable TCP keepalive
     # 'socket_keepalive_options': {
     #     'TCP_KEEPIDLE': 60,           # Match Redis tcp-keepalive value
     #     'TCP_KEEPINTVL': 10,          # Interval between keepalive probes
     #     'TCP_KEEPCNT': 3              # Number of keepalive probes
     # },
-    'retry_on_timeout': True,         # Retry operations if Redis times out
-    'max_connections': 20             # Per process connection pool limit
+    "retry_on_timeout": True,  # Retry operations if Redis times out
+    "max_connections": 20,  # Per process connection pool limit
 }
 
 # Health checking and retries
-CELERY_REDIS_MAX_CONNECTIONS = 50     # Total connection pool limit for results backend
-CELERY_REDIS_SOCKET_TIMEOUT = 120     # Match Redis timeout
+CELERY_REDIS_MAX_CONNECTIONS = 50  # Total connection pool limit for results backend
+CELERY_REDIS_SOCKET_TIMEOUT = 120  # Match Redis timeout
 CELERY_REDIS_SOCKET_KEEPALIVE = True
 CELERY_REDIS_BACKEND_HEALTH_CHECK_INTERVAL = 30  # Check health every 30s
 
@@ -305,7 +305,7 @@ CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 CELERY_BROKER_CONNECTION_MAX_RETRIES = None  # Retry forever
 
 # Task settings to help with reliability
-CELERY_WORKER_PREFETCH_MULTIPLIER = 1        # Don't prefetch tasks
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1  # Don't prefetch tasks
 CELERY_WORKER_ENABLE_PREFETCH_COUNT_REDUCTION = True
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,11 +2,12 @@ python-slugify==8.0.1  # https://github.com/un33k/python-slugify
 Pillow==10.2.0  # https://github.com/python-pillow/Pillow
 argon2-cffi==21.3.0  # https://github.com/hynek/argon2_cffi
 whitenoise==6.5.0  # https://github.com/evansd/whitenoise
-redis==4.6.0  # https://github.com/redis/redis-py
+redis==5.2.1  # https://github.com/redis/redis-py
 hiredis==2.2.3  # https://github.com/redis/hiredis-py
-celery==5.3.1  # pyup: < 6.0  # https://github.com/celery/celery
+celery==5.4.0  # pyup: < 6.0  # https://github.com/celery/celery
 django-celery-beat==2.5.0  # https://github.com/celery/django-celery-beat
-flower==2.0.0  # https://github.com/mher/flower
+flower==2.0.1  # https://github.com/mher/flower
+kombu==5.4.2
 uvicorn[standard]==0.22.0  # https://github.com/encode/uvicorn
 rich==13.5.0
 markdown==3.4.4


### PR DESCRIPTION
## Summary
Celery workers seem to be disconnecting after 1/2 a day or so. This PR makes a number of changes to address the issue.

### List of Changes
* Update recommended settings for Django Celery 
* Update recommended settings for Flower
* Update settings to the Redis server (https://github.com/RolnickLab/ami-devops/commit/e0d3a71e2b67a5b8d5b538063bf321abd4ead719)
* Upgrade packages Celery, Flower, redis and kombu (kombu may have been the culprit)

### Related Issues
Another attempt to fix this issue #673 

### How to Test the Changes
So far so good. I have already tested this branch in the live environment since tasks were not working. Jobs can be triggered again now, but we will see if it sticks tomorrow.

### Screenshots
![image](https://github.com/user-attachments/assets/be9cc1e4-5c70-4d17-bb68-b8e464054321)
