### PR TITLE
Fix updates to deployments and session grouping

### DIFF
--- a/ami/main/admin.py
+++ b/ami/main/admin.py
@@ -115,13 +115,11 @@ class DeploymentAdmin(admin.ModelAdmin[Deployment]):
         self.message_user(request, msg)
 
     # Action that regroups all captures in the deployment into events
-    @admin.action(description="Regroup captures into events")
+    @admin.action(description="Regroup captures into events (async)")
     def regroup_events(self, request: HttpRequest, queryset: QuerySet[Deployment]) -> None:
-        from ami.main.models import group_images_into_events
-
-        for deployment in queryset:
-            group_images_into_events(deployment)
-        self.message_user(request, f"Regrouped {queryset.count()} deployments.")
+        queued_tasks = [tasks.regroup_events.delay(deployment.pk) for deployment in queryset]
+        msg = f"Regrouping captures into events for {len(queued_tasks)} deployments in background: {queued_tasks}"
+        self.message_user(request, msg)
 
     list_filter = ("project",)
     actions = [sync_captures, regroup_events]

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -896,13 +896,19 @@ def group_images_into_events(
             f"Duration: {event.duration_label()}"
         )
 
+    logger.info(
+        f"Done grouping {len(image_timestamps)} captures into {len(events)} events " f"for deployment {deployment}"
+    )
+
     if delete_empty:
         delete_empty_events()
 
     for event in events:
         # Set the width and height of all images in each event based on the first image
+        logger.info(f"Setting image dimensions for event {event}")
         set_dimensions_for_collection(event)
 
+    logger.info("Checking for unusual statistics of events")
     events_over_24_hours = Event.objects.filter(
         deployment=deployment, start__lt=models.F("end") - datetime.timedelta(days=1)
     )

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -916,6 +916,10 @@ def group_images_into_events(
             f"Found {events_starting_before_noon.count()} events starting before noon in deployment {deployment}. "
         )
 
+    logger.info("Updating relevant cached fields on deployment")
+    deployment.events_count = len(events)
+    deployment.save(update_calculated_fields=False, update_fields=["events_count"])
+
     return events
 
 

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -602,13 +602,16 @@ class Deployment(BaseModel):
             self.save(update_calculated_fields=False)
 
     def save(self, update_calculated_fields=True, *args, **kwargs):
-        events_last_updated = min(
-            [
-                self.events.aggregate(latest_updated_at=models.Max("updated_at")).get("latest_update_at")
-                or datetime.datetime.min,
-                self.updated_at,
-            ]
-        )
+        if self.pk:
+            events_last_updated = min(
+                [
+                    self.events.aggregate(latest_updated_at=models.Max("updated_at")).get("latest_update_at")
+                    or datetime.datetime.max,
+                    self.updated_at,
+                ]
+            )
+        else:
+            events_last_updated = datetime.datetime.min
 
         super().save(*args, **kwargs)
         if self.pk and update_calculated_fields:

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -62,7 +62,7 @@ class TestImageGrouping(TestCase):
         for event in events:
             event.captures.all().delete()
 
-        delete_empty_events()
+        delete_empty_events(deployment=self.deployment)
 
         remaining_events = Event.objects.filter(pk__in=[event.pk for event in events])
 

--- a/ami/tasks.py
+++ b/ami/tasks.py
@@ -97,7 +97,6 @@ def regroup_events(deployment_id: int) -> None:
         logger.info(f"{deployment } now has {len(events)} events")
     else:
         logger.error(f"Deployment with id {deployment_id} not found")
-    deployment.update_calculated_fields(save=True)
 
 
 @celery_app.task(soft_time_limit=one_hour, time_limit=one_hour + 60)


### PR DESCRIPTION
## Summary
After images are added to a deployment (via syncing the data source or adding an image manually in the web UI) then the sessions/events for that deployment should be created or updated.

This step was getting hung up on a sub-step that was searching all events in all projects to clean up empty ones (no images or occurrences). This has been updated to only clean the current deployment.

Additionally, events are regrouped if an image was updated after the events were last modified. We likely could use a field for "events_last_regrouped" on the Deployment model, but let's try this first.

Also adding more logging to the event regrouping to debug. And the ability to regroup events manually from the Django admin.

## Checklist

- [x] I have tested these changes appropriately.
- [x] I have added and/or modified relevant tests.
- [x] I updated relevant documentation or comments.
- [x] I have verified that this PR follows the project's coding standards.
- [x] Any dependent changes have already been merged to main.
