### PR TITLE
fix: cannot use storage source for deployments

### DIFF
--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1453,7 +1453,8 @@ class StorageSourceViewSet(DefaultViewSet):
     def get_queryset(self) -> QuerySet:
         query_set: QuerySet = super().get_queryset()
         project = get_active_project(self.request)
-        query_set = query_set.filter(project=project)
+        if project:
+            query_set = query_set.filter(project=project)
         return query_set
 
     @extend_schema(parameters=[project_id_doc_param])


### PR DESCRIPTION
## Summary
We started allowing many endpoints to filter by project. However in this case, if no `project_id` filter is specified then the `StorageSourceViewSet` was returning a 404 for the detail views. 

### List of Changes
Added a check to skip filtering if project_id is not specified, rather than returning only storage sources that have no projects (projects=None)
