### PR TITLE
Disable snap behavior for sessions with no detections

### DIFF
--- a/ui/src/design-system/components/checkbox/checkbox.module.scss
+++ b/ui/src/design-system/components/checkbox/checkbox.module.scss
@@ -64,4 +64,8 @@
   &.neutral {
     color: $color-generic-white;
   }
+
+  &.disabled {
+    opacity: 0.5;
+  }
 }

--- a/ui/src/design-system/components/checkbox/checkbox.tsx
+++ b/ui/src/design-system/components/checkbox/checkbox.tsx
@@ -53,6 +53,7 @@ export const Checkbox = ({
           [styles.success]: theme === CheckboxTheme.Success,
           [styles.alert]: theme === CheckboxTheme.Alert,
           [styles.neutral]: theme === CheckboxTheme.Neutral,
+          [styles.disabled]: disabled,
         })}
       >
         {label}

--- a/ui/src/pages/session-details/playback/playback.tsx
+++ b/ui/src/pages/session-details/playback/playback.tsx
@@ -26,7 +26,9 @@ export const Playback = ({ session }: { session: SessionDetails }) => {
   const [showDetections, setShowDetections] = useState(true)
   const [showDetectionsBelowThreshold, setShowDetectionsBelowThreshold] =
     useState(false)
-  const [snapToDetections, setSnapToDetections] = useState(true)
+  const [snapToDetections, setSnapToDetections] = useState(
+    session.numDetections ? true : false
+  )
   const { activeCaptureId, setActiveCaptureId } = useActiveCaptureId(
     session.firstCapture?.id
   )
@@ -93,6 +95,7 @@ export const Playback = ({ session }: { session: SessionDetails }) => {
               checked={snapToDetections}
               onCheckedChange={setSnapToDetections}
               theme={CheckboxTheme.Neutral}
+              disabled={session.numDetections ? false : true}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
For sessions with no detections (for example if not processed yet), the control "Snap to images with detections" is annoying for users since it blocks navigation. Before, we always had it enabled by default. In this PR, we only enable by default if the session has detections. Also we disable this control if the session has no detections, to avoid users ending up in this state.

### Related Issues
Fixes #672 

### How to Test the Changes
1. Go to a session **with no** detections and make sure the images can be navigated **without** the snap behavior.
2. Go to a session **with** detections. Make sure the images can be navigated **with** the snap behavior.

### Screenshots
After changes:
<img width="1728" alt="Screenshot 2025-01-22 at 10 20 41" src="https://github.com/user-attachments/assets/f0ebe6c5-90c9-4301-855a-42cbddbe79cf" />
