### PR TITLE
Improve the lookup & usage of Taxon names

### DIFF
--- a/ami/main/admin.py
+++ b/ami/main/admin.py
@@ -348,6 +348,10 @@ class TaxonAdmin(admin.ModelAdmin[Taxon]):
     )
     list_filter = ("lists", "rank", TaxonParentFilter)
     search_fields = ("name",)
+    autocomplete_fields = (
+        "parent",
+        "synonym_of",
+    )
 
     # annotate queryset with occurrence counts and allow sorting
     # https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1080,6 +1080,7 @@ class TaxonViewSet(DefaultViewSet):
                 taxa = (
                     Taxon.objects.select_related("parent", "parent__parent")
                     .annotate(similarity=TrigramSimilarity("name", query))
+                    .filter(active=True)
                     .order_by("-similarity")[:limit]
                 )
                 return Response(TaxonNestedSerializer(taxa, many=True, context={"request": request}).data)
@@ -1088,6 +1089,7 @@ class TaxonViewSet(DefaultViewSet):
                     Taxon.objects.filter(name__icontains=query)
                     .annotate(similarity=TrigramSimilarity("name", query))
                     .order_by("-similarity")[:default_results_limit]
+                    .filter(active=True)
                     .values("id", "name", "rank")[:limit]
                 )
                 return Response(TaxonSearchResultSerializer(taxa, many=True, context={"request": request}).data)

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -2573,6 +2573,7 @@ class Taxon(BaseModel):
     gbif_taxon_key = models.BigIntegerField("GBIF taxon key", blank=True, null=True)
     bold_taxon_bin = models.CharField("BOLD taxon BIN", max_length=255, blank=True, null=True)
     inat_taxon_id = models.BigIntegerField("iNaturalist taxon ID", blank=True, null=True)
+    # lepsai_id = models.BigIntegerField("LepsAI / Fieldguide ID", blank=True, null=True)
 
     notes = models.TextField(blank=True)
 

--- a/ami/ml/models/algorithm.py
+++ b/ami/ml/models/algorithm.py
@@ -78,7 +78,12 @@ class AlgorithmCategoryMap(BaseModel):
             labels_data = self.data
             labels_label = self.labels
 
-        taxa = Taxon.objects.filter(models.Q(name__in=labels_label) | models.Q(search_names__overlap=labels_label))
+        # @TODO standardize species search / lookup.
+        # See similar query in ml.models.pipeline.get_or_create_taxon_for_classification()
+        taxa = Taxon.objects.filter(
+            models.Q(name__in=labels_label) | models.Q(search_names__overlap=labels_label),
+            active=True,
+        )
         taxon_map = {taxon.name: taxon for taxon in taxa}
 
         for category in labels_data:


### PR DESCRIPTION
## Summary

Some improvements to support #621 to return the same "Moth" and "Not a Moth" species records rather than creating new ones. 

First use of our species search field!
Requires adding moth and nonmoth to search_names in the live DB, unless we add a data migration. A data migration may be worth it to merge existing records as well. 

Goes with https://github.com/RolnickLab/ami-data-companion/pull/70

### Changes

- Search the "search_names" field in addition to the name field so that we can name taxa differently than the backend returns them (nonmoth & non-moth should both map to "Not-a-moth"
- Search only taxa that are set to "Active"
- Update the searches happening in two places:
- 1) the main determination of a prediction when processing results are being processed (a single Taxon gets looked up & associated with the Occurrence)
- 2) when the top-N or more prediction results are mapped to taxa objects 

### Follow-ups
- Search names & search_names of synonym children as well