### PR TITLE
Reset pagination on project tab change

### DIFF
--- a/ui/src/pages/projects/projects.tsx
+++ b/ui/src/pages/projects/projects.tsx
@@ -40,7 +40,13 @@ export const Projects = () => {
         isFetching={isFetching}
       >
         {user.loggedIn ? (
-          <Tabs.Root onValueChange={setSelectedTab} value={selectedTab}>
+          <Tabs.Root
+            onValueChange={(value) => {
+              setSelectedTab(value)
+              setPage(0)
+            }}
+            value={selectedTab}
+          >
             <Tabs.List>
               <Tabs.Trigger
                 label={translate(STRING.TAB_ITEM_MY_PROJECTS)}


### PR DESCRIPTION
Since number of pages will likely vary for "My projects" and "All projects", it makes sense to reset the pagination on tab change to avoid confusions.