### PR TITLE
Remove actual numbers from `Related Issues` section in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,9 @@ Brief description of what this PR does. (tl;dr).
 
 ### Related Issues
 If the PR closes or is related to an issue, reference it here.
-For example, "Closes #123", "Fixes #456" or "Relates to #741" .
+For example, "Closes #<ISSUE_NUMBER>", "Fixes #<ISSUE_NUMBER>" or "Relates to #<ISSUE_NUMBER>" .
+
+See [Github Keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) for more information on this
 
 ## Detailed Description
 A clear and detailed description of the changes, how they solve/fix the related issues.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,30 +1,39 @@
 ## Summary
+
 Brief description of what this PR does. (tl;dr).
 
 ### List of Changes
+
 * Modified class X
 * Added model Y
 * Fixed problem Z
 * etc.
 
 ### Related Issues
+
 If the PR closes or is related to an issue, reference it here.
 For example, "Closes #<ISSUE_NUMBER>", "Fixes #<ISSUE_NUMBER>" or "Relates to #<ISSUE_NUMBER>" .
 
-See [Github Keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) for more information on this
+See [Github Keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)
+for more information on this
 
 ## Detailed Description
+
 A clear and detailed description of the changes, how they solve/fix the related issues.
 
 Mention potential side effects or risks associated with the changes, if applicable.
 
 ### How to Test the Changes
-Instructions on how to test the changes Include references to automated and/or manual tests that were created/used to test the changes.
+
+Instructions on how to test the changes Include references to automated and/or manual tests that were created/used to
+test the changes.
 
 ### Screenshots
+
 If applicable, add screenshots to help explain this PR (ex. Before and after for UI changes).
 
 ## Deployment Notes
+
 Include instructions if this PR requires specific steps for its deployment (database migrations, config changes, etc.)
 
 ## Checklist


### PR DESCRIPTION
## Summary

The use of actual numbers in the Pull Request template creates links to those issues if not removed or modified manually.

### List of Changes

* Change numbers to placeholder strings in "Related Issues" section

### Related Issues

Closes #710 

## Detailed Description

See #710 

## Deployment Notes

## Checklist

- [x] I have tested these changes appropriately.
- [x] I have added and/or modified relevant tests.
- [x] I updated relevant documentation or comments.
- [x] I have verified that this PR follows the project's coding standards.
- [x] Any dependent changes have already been merged to main.
