### PR TITLE
Allow collections to be filtered by station

### DIFF
--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -1037,6 +1037,13 @@ class SourceImageCollectionCommonKwargsSerializer(serializers.Serializer):
     hour_start = serializers.IntegerField(required=False, allow_null=True)
     hour_end = serializers.IntegerField(required=False, allow_null=True)
 
+    deployment_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        required=False,
+        allow_null=True,
+        allow_empty=True,
+    )
+
     # Kwargs for other sampling methods, this is not complete
     # see the SourceImageCollection model for all available kwargs.
     size = serializers.IntegerField(required=False, allow_null=True)

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -3003,9 +3003,12 @@ class SourceImageCollection(BaseModel):
         month_end: int | None = None,
         date_start: str | None = None,
         date_end: str | None = None,
+        deployment_ids: list[int] | None = None,
     ) -> models.QuerySet | typing.Generator[SourceImage, None, None]:
         qs = self.get_queryset()
 
+        if deployment_ids is not None:
+            qs = qs.filter(deployment__in=deployment_ids)
         if date_start is not None:
             qs = qs.filter(timestamp__date__gte=DateStringField.to_date(date_start))
         if date_end is not None:

--- a/ami/ml/tasks.py
+++ b/ami/ml/tasks.py
@@ -102,7 +102,7 @@ def check_processing_services_online():
         logger.info(f"Checking service {service}")
         try:
             status_response = service.get_status()
-            logger.info(status_response)
+            logger.debug(status_response)
         except Exception as e:
             logger.error(f"Error checking service {service}: {e}")
             continue


### PR DESCRIPTION
## Summary

Collections can currently be filtered by time ranges, but not to images from a specific monitoring Station (aka Deployment). This small PR adds that capability to the backend so that we can better run tests for the UK / AMBER annotation project and help debug why some large processing jobs are stopping early.

### List of Changes

* Added new named parameter to the `common_combined" sampling method
* Add parameter to the API serializer and expose in the UI
* Does not add form field controls for selecting a deployment, these collections can only be created from the Django admin or API for the time being.

## Deployment Notes

- Deploy to all main servers and background workers
- Copy the August 1st collection in the UK Test project and create individual collections for each deployment

## Checklist

- [x] I have tested these changes appropriately.
- [x] I have added and/or modified relevant tests.
- [ ] I updated relevant documentation or comments.
- [x] I have verified that this PR follows the project's coding standards.
- [x] Any dependent changes have already been merged to main.
- [x] I have tested against a recent snapshot of the live DB 
