### PR TITLE
Fix taxa pages

### DIFF
--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -493,7 +493,6 @@ class TaxonSearchResultSerializer(TaxonNestedSerializer):
 class TaxonListSerializer(DefaultSerializer):
     # latest_detection = DetectionNestedSerializer(read_only=True)
     occurrences = serializers.SerializerMethodField()
-    # occurrence_images = serializers.SerializerMethodField()
     parents = TaxonNestedSerializer(read_only=True)
     parent_id = serializers.PrimaryKeyRelatedField(queryset=Taxon.objects.all(), source="parent")
 
@@ -503,7 +502,6 @@ class TaxonListSerializer(DefaultSerializer):
             "id",
             "name",
             "rank",
-            # "parent",
             "parent_id",
             "parents",
             "details",
@@ -703,7 +701,6 @@ class TaxonSerializer(DefaultSerializer):
             "parents",
             "details",
             "occurrences_count",
-            # "detections_count",
             "events_count",
             "occurrences",
             "gbif_taxon_key",

--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -495,6 +495,7 @@ class TaxonListSerializer(DefaultSerializer):
     occurrences = serializers.SerializerMethodField()
     # occurrence_images = serializers.SerializerMethodField()
     parents = TaxonNestedSerializer(read_only=True)
+    parent_id = serializers.PrimaryKeyRelatedField(queryset=Taxon.objects.all(), source="parent")
 
     class Meta:
         model = Taxon
@@ -503,6 +504,7 @@ class TaxonListSerializer(DefaultSerializer):
             "name",
             "rank",
             # "parent",
+            "parent_id",
             "parents",
             "details",
             "occurrences_count",

--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -684,8 +684,7 @@ class TaxonOccurrenceNestedSerializer(DefaultSerializer):
 
 class TaxonSerializer(DefaultSerializer):
     # latest_detection = DetectionNestedSerializer(read_only=True)
-    # occurrences = TaxonOccurrenceNestedSerializer(many=True, read_only=True)
-    occurrences = serializers.SerializerMethodField()
+    occurrences = TaxonOccurrenceNestedSerializer(many=True, read_only=True, source="example_occurrences")
     parent = TaxonNoParentNestedSerializer(read_only=True)
     parent_id = serializers.PrimaryKeyRelatedField(queryset=Taxon.objects.all(), source="parent", write_only=True)
     parents = TaxonParentSerializer(many=True, read_only=True, source="parents_json")
@@ -705,14 +704,6 @@ class TaxonSerializer(DefaultSerializer):
             "occurrences",
             "gbif_taxon_key",
         ]
-
-    def get_occurrences(self, obj):
-        """
-        Disable this nested list until it's optimized or the taxon page is redesigned.
-        @TODO remove this when the taxon page is redesigned.
-        """
-
-        return []
 
 
 class CaptureOccurrenceSerializer(DefaultSerializer):

--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -510,7 +510,7 @@ class TaxonListSerializer(DefaultSerializer):
             "occurrences_count",
             "occurrences",
             "last_detected",
-            # "best_determination_score",
+            "best_determination_score",
             "created_at",
             "updated_at",
         ]
@@ -687,6 +687,7 @@ class TaxonOccurrenceNestedSerializer(DefaultSerializer):
 class TaxonSerializer(DefaultSerializer):
     # latest_detection = DetectionNestedSerializer(read_only=True)
     # occurrences = TaxonOccurrenceNestedSerializer(many=True, read_only=True)
+    occurrences = serializers.SerializerMethodField()
     parent = TaxonNoParentNestedSerializer(read_only=True)
     parent_id = serializers.PrimaryKeyRelatedField(queryset=Taxon.objects.all(), source="parent", write_only=True)
     parents = TaxonParentSerializer(many=True, read_only=True, source="parents_json")
@@ -704,9 +705,17 @@ class TaxonSerializer(DefaultSerializer):
             "occurrences_count",
             # "detections_count",
             "events_count",
-            # "occurrences",
+            "occurrences",
             "gbif_taxon_key",
         ]
+
+    def get_occurrences(self, obj):
+        """
+        Disable this nested list until it's optimized or the taxon page is redesigned.
+        @TODO remove this when the taxon page is redesigned.
+        """
+
+        return []
 
 
 class CaptureOccurrenceSerializer(DefaultSerializer):

--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -11,7 +11,6 @@ from ami.ml.models import Algorithm
 from ami.ml.serializers import AlgorithmSerializer
 from ami.users.models import User
 from ami.utils.dates import get_image_timestamp_from_filename
-from ami.utils.requests import get_active_classification_threshold
 
 from ..models import (
     Classification,
@@ -494,8 +493,8 @@ class TaxonSearchResultSerializer(TaxonNestedSerializer):
 class TaxonListSerializer(DefaultSerializer):
     # latest_detection = DetectionNestedSerializer(read_only=True)
     occurrences = serializers.SerializerMethodField()
-    occurrence_images = serializers.SerializerMethodField()
-    parent = TaxonNestedSerializer(read_only=True)
+    # occurrence_images = serializers.SerializerMethodField()
+    parents = TaxonNestedSerializer(read_only=True)
 
     class Meta:
         model = Taxon
@@ -503,13 +502,13 @@ class TaxonListSerializer(DefaultSerializer):
             "id",
             "name",
             "rank",
-            "parent",
+            # "parent",
+            "parents",
             "details",
             "occurrences_count",
             "occurrences",
-            "occurrence_images",
             "last_detected",
-            "best_determination_score",
+            # "best_determination_score",
             "created_at",
             "updated_at",
         ]
@@ -527,23 +526,6 @@ class TaxonListSerializer(DefaultSerializer):
             "occurrence-list",
             request=self.context.get("request"),
             params=params,
-        )
-
-    def get_occurrence_images(self, obj):
-        """
-        Call the occurrence_images method on the Taxon model, with arguments.
-        """
-
-        # request = self.context.get("request")
-        # project_id = request.query_params.get("project") if request else None
-        project_id = self.context["request"].query_params["project_id"]
-        classification_threshold = get_active_classification_threshold(self.context["request"])
-
-        return obj.occurrence_images(
-            # @TODO pass the request to generate media url & filter by current user's access
-            # request=self.context.get("request"),
-            project_id=project_id,
-            classification_threshold=classification_threshold,
         )
 
 
@@ -702,10 +684,9 @@ class TaxonOccurrenceNestedSerializer(DefaultSerializer):
 
 class TaxonSerializer(DefaultSerializer):
     # latest_detection = DetectionNestedSerializer(read_only=True)
-    occurrences = TaxonOccurrenceNestedSerializer(many=True, read_only=True)
+    # occurrences = TaxonOccurrenceNestedSerializer(many=True, read_only=True)
     parent = TaxonNoParentNestedSerializer(read_only=True)
     parent_id = serializers.PrimaryKeyRelatedField(queryset=Taxon.objects.all(), source="parent", write_only=True)
-    # parents = TaxonParentNestedSerializer(many=True, read_only=True, source="parents_json")
     parents = TaxonParentSerializer(many=True, read_only=True, source="parents_json")
 
     class Meta:
@@ -719,9 +700,9 @@ class TaxonSerializer(DefaultSerializer):
             "parents",
             "details",
             "occurrences_count",
-            "detections_count",
+            # "detections_count",
             "events_count",
-            "occurrences",
+            # "occurrences",
             "gbif_taxon_key",
         ]
 

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -6,6 +6,7 @@ from django.contrib.postgres.search import TrigramSimilarity
 from django.core import exceptions
 from django.db import models
 from django.db.models import Prefetch
+from django.db.models.functions import Coalesce
 from django.db.models.query import QuerySet
 from django.forms import BooleanField, CharField, IntegerField
 from django.utils import timezone
@@ -1038,7 +1039,7 @@ class TaxonViewSet(DefaultViewSet):
     API endpoint that allows taxa to be viewed or edited.
     """
 
-    queryset = Taxon.objects.all()
+    queryset = Taxon.objects.all().defer("notes")
     serializer_class = TaxonSerializer
     filter_backends = DefaultViewSetMixin.filter_backends + [CustomTaxonFilter, TaxonCollectionFilter]
     filterset_fields = [
@@ -1109,109 +1110,63 @@ class TaxonViewSet(DefaultViewSet):
         else:
             return TaxonSerializer
 
-    def filter_taxa_by_observed(self, queryset: QuerySet) -> tuple[QuerySet, bool]:
+    def get_occurrence_filters(self) -> models.Q:
         """
         Filter taxa by when/where it has occurred.
 
         Supports querying by occurrence, project, deployment, or event.
 
         @TODO Consider using a custom filter class for this (see get_filter_name)
+        @TODO Move this to a custom QuerySet manager on the Taxon model
         """
 
-        occurrence_id = self.request.query_params.get("occurrence")
         project = get_active_project(self.request)
+        if not project:
+            # Raise a 400 if no project is specified
+            raise api_exceptions.ValidationError(detail="A project must be specified")
+
+        occurrence_id = self.request.query_params.get("occurrence")
         deployment_id = self.request.query_params.get("deployment") or self.request.query_params.get(
             "occurrences__deployment"
         )
         event_id = self.request.query_params.get("event") or self.request.query_params.get("occurrences__event")
         collection_id = self.request.query_params.get("collection")
 
-        filter_active = any([occurrence_id, project, deployment_id, event_id, collection_id])
+        # filter_active = any([occurrence_id, project, deployment_id, event_id, collection_id])
 
-        if not project:
-            # Raise a 400 if no project is specified
-            raise api_exceptions.ValidationError(detail="A project must be specified")
-
-        queryset = super().get_queryset()
+        filters = models.Q(
+            project=project,
+            event__isnull=False,
+        )
         try:
-            if project:
-                queryset = queryset.filter(occurrences__project=project)
+            """
+            Ensure that the related objects exist before filtering by them.
+            This may be overkill!
+            """
             if occurrence_id:
-                occurrence = Occurrence.objects.get(id=occurrence_id)
+                Occurrence.objects.get(id=occurrence_id)
                 # This query does not need the same filtering as the others
-                queryset = queryset.filter(occurrences=occurrence)
+                filters &= models.Q(id=occurrence_id)
             if deployment_id:
-                deployment = Deployment.objects.get(id=deployment_id)
-                queryset = queryset.filter(occurrences__deployment=deployment)
+                Deployment.objects.get(id=deployment_id)
+                filters &= models.Q(deployment=deployment_id)
             if event_id:
-                event = Event.objects.get(id=event_id)
-                queryset = queryset.filter(occurrences__event=event)
+                Event.objects.get(id=event_id)
+                filters &= models.Q(event=event_id)
             if collection_id:
-                queryset = queryset.filter(occurrences__detections__source_image__collections=collection_id)
+                SourceImageCollection.objects.get(id=collection_id)
+                filters &= models.Q(detections__source_image__collections=collection_id)
         except exceptions.ObjectDoesNotExist as e:
             # Raise a 404 if any of the related objects don't exist
             raise NotFound(detail=str(e))
 
-        # @TODO need to return the models.Q filter used, so we can use it for counts and related occurrences.
-        return queryset.distinct(), filter_active
+        return filters
 
-    def filter_by_classification_threshold(self, queryset: QuerySet) -> QuerySet:
+    def add_filtered_occurrences(self, queryset: QuerySet, occurrence_filters: models.Q) -> QuerySet:
         """
-        Filter taxa by their best determination score in occurrences.
-
-        This is only applicable to list queries that are not filtered by occurrence, project, deployment, or event.
+        Add list of actual occurrences to a Taxon detail response.
         """
-
-        queryset = (
-            queryset.annotate(best_determination_score=models.Max("occurrences__determination_score"))
-            .filter(best_determination_score__gte=get_active_classification_threshold(self.request))
-            .distinct()
-        )
-
-        # If ordering is not specified, order by best determination score
-        if not self.request.query_params.get("ordering"):
-            queryset = queryset.order_by("-best_determination_score")
-
-        return queryset
-
-    def get_occurrences_filters(self, queryset: QuerySet) -> tuple[QuerySet, models.Q]:
-        # @TODO this should check what the user has access to
-        project_id = self.request.query_params.get("project")
-        taxon_occurrences_query = (
-            Occurrence.objects.filter(
-                determination_score__gte=get_active_classification_threshold(self.request),
-                event__isnull=False,
-            )
-            .distinct()
-            .annotate(
-                first_appearance_timestamp=models.Min("detections__timestamp"),
-                last_appearance_timestamp=models.Max("detections__timestamp"),
-            )
-            .order_by("-first_appearance_timestamp")
-        )
-        taxon_occurrences_count_filter = models.Q(
-            occurrences__determination_score__gte=get_active_classification_threshold(self.request),
-            occurrences__event__isnull=False,
-        )
-        if project_id:
-            taxon_occurrences_query = taxon_occurrences_query.filter(project=project_id)
-            taxon_occurrences_count_filter &= models.Q(occurrences__project=project_id)
-
-        return taxon_occurrences_query, taxon_occurrences_count_filter
-
-    def add_occurrence_counts(self, queryset: QuerySet, occurrences_count_filter: models.Q) -> QuerySet:
-        qs = queryset.annotate(
-            occurrences_count=models.Count(
-                "occurrences",
-                filter=occurrences_count_filter,
-                distinct=True,
-            ),
-            last_detected=models.Max("classifications__detection__timestamp"),
-        )
-        return qs
-
-    def add_filtered_occurrences(self, queryset: QuerySet, occurrences_query: QuerySet) -> QuerySet:
-        qs = queryset.prefetch_related(Prefetch("occurrences", queryset=occurrences_query))
+        qs = queryset.prefetch_related(Prefetch("occurrences", queryset=Occurrence.objects.filter(occurrence_filters)))
         return qs
 
     def zero_occurrences(self, queryset: QuerySet) -> QuerySet:
@@ -1227,47 +1182,47 @@ class TaxonViewSet(DefaultViewSet):
         return qs
 
     def get_queryset(self) -> QuerySet:
-        qs = super().get_queryset()
+        occurrence_filters = self.get_occurrence_filters()
 
-        # First filter out taxa that have no occurrences
-        # qs = qs.filter(occurrences__isnull=False).distinct()
+        # @TODO make this recursive into child taxa and cache
+        occurrences_count = models.Subquery(
+            Occurrence.objects.filter(
+                occurrence_filters,
+                determination_id=models.OuterRef("id"),
+            )
+            .values("determination_id")
+            .annotate(count=models.Count("id"))
+            .values("count"),
+            output_field=models.IntegerField(),
+        )
 
-        occurrences_filter, occurrences_count_filter = self.get_occurrences_filters(qs)
+        last_detected = models.Subquery(
+            Occurrence.objects.filter(
+                occurrence_filters,
+                determination_id=models.OuterRef("id"),
+                detections__timestamp__isnull=False,  # ensure we have a timestamp
+            )
+            .values("determination_id")
+            .annotate(last_detected=models.Max("detections__timestamp"))
+            .values("last_detected"),
+            output_field=models.DateTimeField(),
+        )
 
-        qs = qs.select_related("parent")
-
-        if self.action == "retrieve":
-            qs = self.add_filtered_occurrences(qs, occurrences_filter)
-            qs = self.add_occurrence_counts(qs, occurrences_count_filter)
-
-        if self.action == "list":
-            qs, filter_active = self.filter_taxa_by_observed(qs)
-            if filter_active:
-                qs = self.filter_by_classification_threshold(qs)
-                qs = self.add_occurrence_counts(qs, occurrences_count_filter)
-                # Filter out taxa that have no occurrences or occurrences count is null
-                qs = qs.filter(occurrences_count__gt=0).filter(occurrences_count__isnull=False)
-            else:
-                # If no filter don't return anything related to occurrences
-                # in a list view.
-                # @TODO event detail views should be filtered by project
-                # @TODO check permissions to show project occurrences
-                qs = self.zero_occurrences(qs)
-
-        return qs
+        return Taxon.objects.filter(
+            models.Exists(
+                Occurrence.objects.filter(
+                    occurrence_filters,
+                    determination_id=models.OuterRef("id"),
+                ),
+            ),
+        ).annotate(
+            occurrences_count=Coalesce(occurrences_count, 0),
+            last_detected=last_detected,
+        )
 
     @extend_schema(parameters=[project_id_doc_param])
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
-
-    # def retrieve(self, request: Request, *args, **kwargs) -> Response:
-    #     """
-    #     Override the serializer to include the recursive occurrences count
-    #     """
-    #     taxon: Taxon = self.get_object()
-    #     taxon.occurrences_count = taxon.occurrences_count_recursive()  # type: ignore
-    #     response = Response(TaxonSerializer(taxon, context={"request": request}).data)
-    #     return response
 
 
 class ClassificationViewSet(DefaultViewSet):
@@ -1325,13 +1280,12 @@ class SummaryView(GenericAPIView):
                     # determination_score__gte=confidence_threshold,
                     event__isnull=False,
                 ).count(),
-                "taxa_count": Taxon.objects.annotate(occurrences_count=models.Count("occurrences"))
-                .filter(
-                    occurrences_count__gt=0,
-                    occurrences__determination_score__gte=confidence_threshold,
-                    occurrences__project=project,
+                "taxa_count": Occurrence.objects.filter(
+                    project=project,
+                    event__isnull=False,
                 )
-                .distinct()
+                .values("determination_id")
+                .distinct("id")
                 .count(),
             }
         else:

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1280,14 +1280,7 @@ class SummaryView(GenericAPIView):
                     # determination_score__gte=confidence_threshold,
                     event__isnull=False,
                 ).count(),
-                "taxa_count": Occurrence.objects.filter(
-                    project=project,
-                    event__isnull=False,
-                )
-                .order_by()
-                .values("determination_id")
-                .distinct("determination_id")
-                .count(),
+                "taxa_count": Occurrence.objects.all().unique_taxa(project=project).count(),  # type: ignore
             }
         else:
             data = {
@@ -1300,11 +1293,7 @@ class SummaryView(GenericAPIView):
                     # determination_score__gte=confidence_threshold,
                     event__isnull=False
                 ).count(),
-                "taxa_count": Occurrence.objects.filter()
-                .order_by()
-                .values("determination_id")
-                .distinct("determination_id")
-                .count(),
+                "taxa_count": Occurrence.objects.all().unique_taxa().count(),  # type: ignore
                 "last_updated": timezone.now(),
             }
 

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1157,29 +1157,10 @@ class TaxonViewSet(DefaultViewSet):
 
         return filters
 
-    def add_filtered_occurrences(self, queryset: QuerySet, occurrence_filters: models.Q) -> QuerySet:
-        """
-        Add list of actual occurrences to a Taxon detail response.
-        """
-        qs = queryset.prefetch_related(Prefetch("occurrences", queryset=Occurrence.objects.filter(occurrence_filters)))
-        return qs
-
-    def zero_occurrences(self, queryset: QuerySet) -> QuerySet:
-        """
-        Return a queryset with zero occurrences but compatible with the original queryset.
-        """
-        qs = queryset.prefetch_related(Prefetch("occurrences", queryset=Occurrence.objects.none()))
-        qs = qs.annotate(
-            occurrences_count=models.Value(0),
-            # events_count=models.Value(0),
-            last_detected=models.Value(None, output_field=models.DateTimeField()),
-        )
-        return qs
-
     def get_queryset(self) -> QuerySet:
         """
         If a project is passed, only return taxa that have been observed.
-        Otherwise return all taxa t
+        Otherwise return all taxa that are active.
         """
         qs = super().get_queryset()
         project = get_active_project(self.request)

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1313,7 +1313,6 @@ class SummaryView(GenericAPIView):
         Return counts of all models.
         """
         project = get_active_project(request)
-        confidence_threshold = get_active_classification_threshold(request)
         if project:
             data = {
                 "projects_count": Project.objects.count(),  # @TODO filter by current user, here and everywhere!
@@ -1323,7 +1322,7 @@ class SummaryView(GenericAPIView):
                 # "detections_count": Detection.objects.filter(occurrence__project=project).count(),
                 "occurrences_count": Occurrence.objects.filter(
                     project=project,
-                    determination_score__gte=confidence_threshold,
+                    # determination_score__gte=confidence_threshold,
                     event__isnull=False,
                 ).count(),
                 "taxa_count": Taxon.objects.annotate(occurrences_count=models.Count("occurrences"))
@@ -1343,11 +1342,10 @@ class SummaryView(GenericAPIView):
                 "captures_count": SourceImage.objects.count(),
                 # "detections_count": Detection.objects.count(),
                 "occurrences_count": Occurrence.objects.filter(
-                    determination_score__gte=confidence_threshold, event__isnull=False
+                    # determination_score__gte=confidence_threshold,
+                    event__isnull=False
                 ).count(),
-                "taxa_count": Taxon.objects.annotate(occurrences_count=models.Count("occurrences"))
-                .filter(occurrences_count__gt=0, occurrences__determination_score__gte=confidence_threshold)
-                .count(),
+                "taxa_count": 0,
                 "last_updated": timezone.now(),
             }
 

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1286,7 +1286,7 @@ class SummaryView(GenericAPIView):
                 )
                 .order_by()
                 .values("determination_id")
-                .distinct("id")
+                .distinct("determination_id")
                 .count(),
             }
         else:
@@ -1300,7 +1300,11 @@ class SummaryView(GenericAPIView):
                     # determination_score__gte=confidence_threshold,
                     event__isnull=False
                 ).count(),
-                "taxa_count": 0,
+                "taxa_count": Occurrence.objects.filter()
+                .order_by()
+                .values("determination_id")
+                .distinct("determination_id")
+                .count(),
                 "last_updated": timezone.now(),
             }
 

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1054,9 +1054,8 @@ class TaxonViewSet(DefaultViewSet):
         "created_at",
         "updated_at",
         "occurrences_count",
-        "detections_count",
         "last_detected",
-        "best_determination_score",
+        # "best_determination_score",
         "name",
     ]
     search_fields = ["name", "parent__name"]
@@ -1076,7 +1075,7 @@ class TaxonViewSet(DefaultViewSet):
         if query and len(query) >= min_query_length:
             taxa = (
                 Taxon.objects.filter(active=True)
-                .select_related("parent")
+                # .select_related("parent")
                 .filter(models.Q(name__icontains=query) | models.Q(search_names__icontains=query))
                 .annotate(
                     # Calculate similarity for the name field

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1284,6 +1284,7 @@ class SummaryView(GenericAPIView):
                     project=project,
                     event__isnull=False,
                 )
+                .order_by()
                 .values("determination_id")
                 .distinct("id")
                 .count(),

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -2670,7 +2670,11 @@ class Taxon(BaseModel):
         # This is handled by an annotation if we are filtering by project, deployment or event
         return None
 
-    def occurrence_images(
+    def occurrence_images(self, limit: int | None = 10) -> list[str]:
+        # This is handled by an annotation if we are filtering by project, deployment or event
+        return []
+
+    def get_occurrence_images(
         self,
         limit: int | None = 10,
         project_id: int | None = None,

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -2088,6 +2088,17 @@ class OccurrenceQuerySet(models.QuerySet):
             "identifications__user",
         )
 
+    def unique_taxa(self, project: Project | None = None) -> models.QuerySet:
+        qs = self
+        if project:
+            qs = self.filter(project=project)
+        qs = (
+            qs.filter(determination__isnull=False, event__isnull=False)
+            .order_by("determination_id")
+            .distinct("determination_id")
+        )
+        return qs
+
 
 class OccurrenceManager(models.Manager):
     def get_queryset(self) -> OccurrenceQuerySet:
@@ -2114,7 +2125,7 @@ class Occurrence(BaseModel):
     detections: models.QuerySet[Detection]
     identifications: models.QuerySet[Identification]
 
-    objects = OccurrenceManager()
+    objects: OccurrenceManager = OccurrenceManager()
 
     def __str__(self) -> str:
         name = f"Occurrence #{self.pk}"

--- a/ui/src/components/blueprint-collection/blueprint-collection.tsx
+++ b/ui/src/components/blueprint-collection/blueprint-collection.tsx
@@ -22,9 +22,11 @@ export const BlueprintCollection = ({ items }: { items: BlueprintItem[] }) => (
       [styles.empty]: items.length === 0,
     })}
   >
-    <div className={styles.licenseInfoContent}>
-      <LicenseInfo />
-    </div>
+    {items.length > 0 && (
+      <div className={styles.licenseInfoContent}>
+        <LicenseInfo />
+      </div>
+    )}
     <div className={styles.blueprintContent}>
       {items.map((item) => (
         <BlueprintItem key={item.id} item={item} />

--- a/ui/src/data-services/hooks/species/useSpeciesDetails.ts
+++ b/ui/src/data-services/hooks/species/useSpeciesDetails.ts
@@ -23,7 +23,9 @@ export const useSpeciesDetails = (
     useAuthorizedQuery<SpeciesDetails>({
       enabled: !!id,
       queryKey: [API_ROUTES.SPECIES, id],
-      url: `${API_URL}/${API_ROUTES.SPECIES}/${id}/?project=${projectId || ''}`,
+      url: `${API_URL}/${API_ROUTES.SPECIES}/${id}/?project_id=${
+        projectId || ''
+      }`,
     })
 
   const species = useMemo(

--- a/ui/src/data-services/models/species.ts
+++ b/ui/src/data-services/models/species.ts
@@ -38,7 +38,7 @@ export class Species extends Taxon {
   }
 
   get score(): number {
-    return this._species.best_determination_score
+    return this._species.best_determination_score || 0
   }
 
   get scoreLabel(): string {

--- a/ui/src/pages/species-details/species-details.tsx
+++ b/ui/src/pages/species-details/species-details.tsx
@@ -47,9 +47,7 @@ export const SpeciesDetails = ({ species }: { species: Species }) => {
     {
       label: translate(STRING.FIELD_LABEL_OCCURRENCES),
       value:
-        species.numOccurrences !== undefined
-          ? species.numOccurrences
-          : 'View all',
+        species.numOccurrences !== null ? species.numOccurrences : 'View all',
       to: getAppRoute({
         to: APP_ROUTES.OCCURRENCES({ projectId: projectId as string }),
         filters: { taxon: species.id },

--- a/ui/src/pages/species/species-columns.tsx
+++ b/ui/src/pages/species/species-columns.tsx
@@ -32,17 +32,6 @@ export const columns: (projectId: string) => TableColumn<Species>[] = (
     ),
   },
   {
-    id: 'score',
-    sortField: 'best_determination_score',
-    name: translate(STRING.FIELD_LABEL_BEST_SCORE),
-    styles: {
-      textAlign: TextAlign.Right,
-    },
-    renderCell: (item: Species) => (
-      <BasicTableCell value={item.scoreLabel} style={{ textAlign: 'right' }} />
-    ),
-  },
-  {
     id: 'occurrences',
     sortField: 'occurrences_count',
     name: translate(STRING.FIELD_LABEL_OCCURRENCES),
@@ -62,6 +51,26 @@ export const columns: (projectId: string) => TableColumn<Species>[] = (
         />
       </Link>
     ),
+  },
+  {
+    id: 'score',
+    sortField: 'best_determination_score',
+    name: translate(STRING.FIELD_LABEL_BEST_SCORE),
+    styles: {
+      textAlign: TextAlign.Right,
+    },
+    renderCell: (item: Species) => (
+      <BasicTableCell value={item.scoreLabel} style={{ textAlign: 'right' }} />
+    ),
+  },
+  {
+    id: 'rank',
+    sortField: 'rank',
+    name: 'Taxon rank',
+    styles: {
+      textAlign: TextAlign.Right,
+    },
+    renderCell: (item: Species) => <BasicTableCell value={item.rank} />,
   },
   {
     id: 'training-images',

--- a/ui/src/pages/species/species-columns.tsx
+++ b/ui/src/pages/species/species-columns.tsx
@@ -56,7 +56,10 @@ export const columns: (projectId: string) => TableColumn<Species>[] = (
           filters: { taxon: item.id },
         })}
       >
-        <BasicTableCell value={item.numOccurrences} theme={CellTheme.Bubble} />
+        <BasicTableCell
+          value={item.numOccurrences || 'View all'}
+          theme={CellTheme.Bubble}
+        />
       </Link>
     ),
   },

--- a/ui/src/pages/species/species-columns.tsx
+++ b/ui/src/pages/species/species-columns.tsx
@@ -1,10 +1,8 @@
 import { TaxonInfo } from 'components/taxon/taxon-info/taxon-info'
 import { Species } from 'data-services/models/species'
 import { BasicTableCell } from 'design-system/components/table/basic-table-cell/basic-table-cell'
-import { ImageTableCell } from 'design-system/components/table/image-table-cell/image-table-cell'
 import {
   CellTheme,
-  ImageCellTheme,
   TableColumn,
   TextAlign,
 } from 'design-system/components/table/types'
@@ -16,28 +14,6 @@ import { STRING, translate } from 'utils/language'
 export const columns: (projectId: string) => TableColumn<Species>[] = (
   projectId: string
 ) => [
-  {
-    id: 'snapshots',
-    name: translate(STRING.FIELD_LABEL_SNAPSHOTS),
-    styles: {
-      textAlign: TextAlign.Center,
-    },
-    renderCell: (item: Species) => {
-      const detailsRoute = getAppRoute({
-        to: APP_ROUTES.TAXON_DETAILS({ projectId, taxonId: item.id }),
-        keepSearchParams: true,
-      })
-
-      return (
-        <ImageTableCell
-          images={item.images}
-          total={item.numOccurrences}
-          theme={ImageCellTheme.Light}
-          to={detailsRoute}
-        />
-      )
-    },
-  },
   {
     id: 'name',
     sortField: 'name',

--- a/ui/src/utils/language.ts
+++ b/ui/src/utils/language.ts
@@ -321,7 +321,7 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.FIELD_LABEL_NAME]: 'Name',
   [STRING.FIELD_LABEL_NEW_PASSWORD]: 'New password',
   [STRING.FIELD_LABEL_NUM_PIPELINES_REGISTERED]: 'Pipelines registered',
-  [STRING.FIELD_LABEL_OCCURRENCES]: 'Occurrences',
+  [STRING.FIELD_LABEL_OCCURRENCES]: 'Direct occurrences',
   [STRING.FIELD_LABEL_PASSWORD]: 'Password',
   [STRING.FIELD_LABEL_PASSWORD_CURRENT]: 'Current password',
   [STRING.FIELD_LABEL_PASSWORD_NEW]: 'New password',


### PR DESCRIPTION
## Summary

Recover the Taxa page and stats bar by refactoring how taxa queries are made. 
Addresses #723 & #411 and greatly speeds up the species page (makes them usable again). Removes some data (image thumbnails) that can be returned when the page design is updated.

### List of Changes

- Ensure that all taxa views are filtered by project
- Remove occurrence images from taxa list
- Refactor queries with occurrence counts
- Fix all n+1 queries for taxa in list view

### Screenshots

![image](https://github.com/user-attachments/assets/c629a5fa-9617-4631-97c9-892bd9ebd222)
![image](https://github.com/user-attachments/assets/9db9853b-b2bb-4f1b-a67a-c6849671d298)

## Deployment Notes

Requires one migration

## Checklist

- [x] I have tested these changes appropriately.
- [x] I have added and/or modified relevant tests.
- [x] I updated relevant documentation or comments.
- [x] I have verified that this PR follows the project's coding standards.
- [x] Any dependent changes have already been merged to main.

## Follow up tasks

- Show number of category maps / algorithms that this Taxon is known by
- Add dedicated cover_image field for each taxon
- Add management script for importing fieldguide cover images
- Fix occurrences list view endpoint (require project)
- Fix classifications list view endpoints (require project)
- Add recursive counts for occurrences that include counts from all child taxa 
- Add "view all" link
- Add filters for score & taxon rank