### PR TITLE
fix: unusable views in the interactive api browser, and new filters

### DIFF
--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1293,8 +1293,9 @@ class ClassificationViewSet(DefaultViewSet, ProjectMixin):
 
     queryset = Classification.objects.all().select_related("taxon", "algorithm")  # , "detection")
     serializer_class = ClassificationSerializer
-    # https://www.django-rest-framework.org/topics/browsable-api/#handling-choicefield-with-large-numbers-of-items
     filterset_fields = [
+        # Docs about slow loading API browser because of large choice fields
+        # https://www.django-rest-framework.org/topics/browsable-api/#handling-choicefield-with-large-numbers-of-items
         "taxon",
         "algorithm",
         "detection__source_image__project",

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1004,7 +1004,6 @@ class OccurrenceViewSet(DefaultViewSet, ProjectMixin):
         "event",
         "deployment",
         "determination__rank",
-        "detections__source_image",
     ]
     ordering_fields = [
         "created_at",
@@ -1287,26 +1286,32 @@ class TaxonViewSet(DefaultViewSet, ProjectMixin):
         return super().list(request, *args, **kwargs)
 
 
-class ClassificationViewSet(DefaultViewSet):
+class ClassificationViewSet(DefaultViewSet, ProjectMixin):
     """
     API endpoint for viewing and adding classification results from a model.
     """
 
-    queryset = Classification.objects.all()  # .select_related("taxon", "algorithm", "detection")
+    queryset = Classification.objects.all().select_related("taxon", "algorithm")  # , "detection")
     serializer_class = ClassificationSerializer
+    # https://www.django-rest-framework.org/topics/browsable-api/#handling-choicefield-with-large-numbers-of-items
     filterset_fields = [
-        "detection",
-        "detection__occurrence",
         "taxon",
         "algorithm",
-        "detection__source_image",
         "detection__source_image__project",
+        "detection__source_image__collections",
     ]
     ordering_fields = [
         "created_at",
         "updated_at",
         "score",
     ]
+
+    def get_queryset(self) -> QuerySet:
+        qs = super().get_queryset()
+        project = self.get_active_project()
+        if project:
+            qs = qs.filter(detection__source_image__project=project)
+        return qs
 
     def get_serializer_class(self):
         """


### PR DESCRIPTION
Several endpoints in the interactive API browser time out and are unusable, however their json-only equivalents do not have this issue.

For example these never load:
https://api.beluga.insectai.org/api/v2/occurrences/?limit=1&offset=1000
https://api.beluga.insectai.org/api/v2/classifications/?limit=1

But these load fine:
https://api.beluga.insectai.org/api/v2/occurrences.jsonlimit=1&offset=1000
https://api.beluga.insectai.org/api/v2/classifications.json?limit=1

It turns out this is because the interactive API view populates the full list of choices available to users for the filters. And these two endpoints had filters that triggered a long full-scan query.

This PR disables those filters. It also adds two filters to the classifications endpoint, one for Project and one for Source Image Collection, based on a user request.

Follow-up TODOs
- Use the auto-complete or another widget for the interactive API browser
- Add a default time-limit to all DB queries 
- Find other endpoints with similar issues