### PR TITLE
Adjust page size based on page width to avoid gallery gaps

### DIFF
--- a/ui/src/pages/projects/projects.tsx
+++ b/ui/src/pages/projects/projects.tsx
@@ -10,6 +10,7 @@ import { UserPermission } from 'utils/user/types'
 import { useUser } from 'utils/user/userContext'
 import { useUserInfo } from 'utils/user/userInfoContext'
 import { useSelectedView } from 'utils/useSelectedView'
+import { useWindowSize } from 'utils/useWindowSize'
 import { ProjectGallery } from './project-gallery'
 
 export const TABS = {
@@ -22,7 +23,10 @@ export const Projects = () => {
   const { userInfo } = useUserInfo()
   const { selectedView: selectedTab, setSelectedView: setSelectedTab } =
     useSelectedView(user.loggedIn ? TABS.MY_PROJECTS : TABS.ALL_PROJECTS)
-  const { pagination, setPage } = usePagination()
+  const [windowWidth] = useWindowSize()
+  const { pagination, setPage } = usePagination({
+    perPage: windowWidth > 1024 ? 21 : 20, // Adjust page size based on page width to avoid gallery gaps
+  })
   const filters =
     user.loggedIn && selectedTab === TABS.MY_PROJECTS
       ? [{ field: 'user_id', value: userInfo?.id }]

--- a/ui/src/pages/projects/projects.tsx
+++ b/ui/src/pages/projects/projects.tsx
@@ -39,7 +39,7 @@ export const Projects = () => {
     <>
       <PageHeader
         title={translate(STRING.NAV_ITEM_PROJECTS)}
-        subTitle={translate(STRING.RESULTS, { total: projects?.length ?? 0 })}
+        subTitle={translate(STRING.RESULTS, { total: total ?? 0 })}
         isLoading={isLoading}
         isFetching={isFetching}
       >

--- a/ui/src/utils/useWindowSize.ts
+++ b/ui/src/utils/useWindowSize.ts
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react'
 
 export const useWindowSize = () => {
   const [windowSize, setWindowSize] = useState([
-    window.innerHeight,
-    window.innerWidth,
+    Math.max(document.documentElement.clientWidth, window.innerWidth),
+    Math.max(document.documentElement.clientHeight, window.innerHeight),
   ])
 
   useEffect(() => {

--- a/ui/src/utils/useWindowSize.ts
+++ b/ui/src/utils/useWindowSize.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+
+export const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState([
+    window.innerHeight,
+    window.innerWidth,
+  ])
+
+  useEffect(() => {
+    const windowSizeHandler = () =>
+      setWindowSize([window.innerWidth, window.innerHeight])
+
+    window.addEventListener('resize', windowSizeHandler)
+
+    return () => {
+      window.removeEventListener('resize', windowSizeHandler)
+    }
+  }, [])
+
+  return windowSize
+}


### PR DESCRIPTION
## Summary

This is a small fix to a address an issue that was brought up on Slack. For the project overview, we will now adjust the page size depending on window width to avoid gaps in the grid (making it more clear when a gallery page has reached its end).

If page width is > 1024 px (meaning we will show 3 columns), we will use page size 21. If not, we will use default page size 20.

We will update the page size if window is resized and refetch projects if needed.

## Screenshot

<img width="1728" alt="Screenshot 2025-03-10 at 22 08 10" src="https://github.com/user-attachments/assets/a042ef66-49f5-4d7e-849b-edb89055fead" />