### PR TITLE
Handle undefined detections

### DIFF
--- a/ui/src/data-services/models/species-details.ts
+++ b/ui/src/data-services/models/species-details.ts
@@ -21,7 +21,7 @@ export class SpeciesDetails extends Species {
       (d: any) => `${d.id}` === id
     )
 
-    if (!occurrence) {
+    if (!occurrence || !occurrence.best_detection) {
       return
     }
 


### PR DESCRIPTION
## Summary

In this PR we will address a small runtime issue that was recently seen on Sentry. It seems we should not assume the field `best_detection` will be defined for occurrences returned with species details. The problem can be seen here: 
https://antenna.insectai.org/projects/23/taxa/3111

After the fix, we will be able to display the detail view without a crash, however I think the data seems to be a bit inconsistent. In the taxa view context, it looks like this species should have 2 occurrences. However when filtering occurrences for this species, we get 0.

## Screenshots
Detail view can be displayed without crash. No occurrence image, but I think it's fine, it seems to be an edge case :)
<img width="1728" alt="Screenshot 2025-03-10 at 21 52 21" src="https://github.com/user-attachments/assets/32191709-7326-4333-8ccf-1c3aa652e710" />

Count is matching in list view:
<img width="1728" alt="Screenshot 2025-03-10 at 21 51 05" src="https://github.com/user-attachments/assets/23d011a2-db44-482b-98e0-51618a4ddd61" />

However when filtering occurrences, count is not matching:
<img width="1728" alt="Screenshot 2025-03-10 at 21 51 14" src="https://github.com/user-attachments/assets/88b9f8d0-a05f-46a0-bed3-55159675d0c6" />