### PR TITLE
Fix pre-commit configuration warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: "^docs/|/migrations/|ui/"
-default_stages: [commit]
+default_stages: [pre-commit]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
- Updated pre-commit config to remove deprecated stage names.
- Ran 'pre-commit migrate-config' to fix warnings.
