### PR TITLE
Add page "Code of conduct" to UI

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -11,6 +11,8 @@ import { TermsOfServicePage } from 'components/info-page/terms-of-service-page/t
 import { Menu } from 'components/menu/menu'
 import { TermsOfServiceInfo } from 'components/terms-of-service-info/terms-of-service-info'
 import { useProjectDetails } from 'data-services/hooks/projects/useProjectDetails'
+import { AlertCircleIcon, ChevronRightIcon } from 'lucide-react'
+import { buttonVariants } from 'nova-ui-kit'
 import { Auth } from 'pages/auth/auth'
 import { Login } from 'pages/auth/login'
 import { ResetPassword } from 'pages/auth/reset-password'
@@ -27,7 +29,14 @@ import { Species } from 'pages/species/species'
 import { UnderConstruction } from 'pages/under-construction/under-construction'
 import { ReactNode, useContext, useEffect } from 'react'
 import { Helmet, HelmetProvider } from 'react-helmet-async'
-import { Navigate, Outlet, Route, Routes, useParams } from 'react-router-dom'
+import {
+  Link,
+  Navigate,
+  Outlet,
+  Route,
+  Routes,
+  useParams,
+} from 'react-router-dom'
 import {
   BreadcrumbContext,
   BreadcrumbContextProvider,
@@ -36,6 +45,7 @@ import { APP_ROUTES } from 'utils/constants'
 import { CookieConsentContextProvider } from 'utils/cookieConsent/cookieConsentContext'
 import { STRING, translate } from 'utils/language'
 import { usePageBreadcrumb } from 'utils/usePageBreadcrumb'
+import { DEFAULT_PAGE_TITLE } from 'utils/usePageTitle'
 import { UserContextProvider } from 'utils/user/userContext'
 import { UserInfoContextProvider } from 'utils/user/userInfoContext'
 import { UserPreferencesContextProvider } from 'utils/userPreferences/userPreferencesContext'
@@ -48,7 +58,7 @@ const INTRO_CONTAINER_ID = 'intro'
 export const App = () => (
   <AppProviders>
     <Helmet>
-      <title>Antenna Data Platform</title>
+      <title>{DEFAULT_PAGE_TITLE}</title>
       <meta
         name="description"
         content="An interdisciplinary platform to upload, classify, and analyse in-the-wild images of invertebrates for research and conservation efforts."
@@ -107,6 +117,7 @@ export const App = () => (
             </InfoPageContainer>
           }
         />
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </div>
     <ReactQueryDevtools initialIsOpen={false} />
@@ -208,4 +219,30 @@ const InfoPageContainer = ({ children }: { children: ReactNode }) => (
       <ErrorBoundary>{children}</ErrorBoundary>
     </div>
   </main>
+)
+
+const NotFound = () => (
+  <>
+    <Helmet>
+      <title>Page not found | {DEFAULT_PAGE_TITLE}</title>
+    </Helmet>
+    <main className={styles.main}>
+      <div className={styles.content}>
+        <div className="flex flex-col items-center py-24">
+          <AlertCircleIcon className="w-8 h-8 text-destructive mb-8" />
+          <span className="body-large font-medium mb-2">Page not found</span>
+          <span className="body-base text-muted-foreground mb-8">
+            Sorry, we couldn't find the page you are looking for.
+          </span>
+          <Link
+            to={APP_ROUTES.HOME}
+            className={buttonVariants({ variant: 'link' })}
+          >
+            <span>To homepage</span>
+            <ChevronRightIcon className="w-4 h-4 ml-2" />
+          </Link>
+        </div>
+      </div>
+    </main>
+  </>
 )

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -6,7 +6,8 @@ import { Analytics } from 'components/analytics'
 import { CookieDialog } from 'components/cookie-dialog/cookie-dialog'
 import { ErrorBoundary } from 'components/error-boundary/error-boundary'
 import { Header } from 'components/header/header'
-import { InfoPage } from 'components/info-page/info-page'
+import { CodeOfConductPage } from 'components/info-page/code-of-conduct-page/code-of-conduct-page'
+import { TermsOfServicePage } from 'components/info-page/terms-of-service-page/terms-of-service-page'
 import { Menu } from 'components/menu/menu'
 import { TermsOfServiceInfo } from 'components/terms-of-service-info/terms-of-service-info'
 import { useProjectDetails } from 'data-services/hooks/projects/useProjectDetails'
@@ -90,7 +91,22 @@ export const App = () => (
           <Route path="collections/:id" element={<CollectionDetails />} />
           <Route path="*" element={<UnderConstruction />} />
         </Route>
-        <Route path="/:slug" element={<InfoPageContainer />} />
+        <Route
+          path="/terms-of-service"
+          element={
+            <InfoPageContainer>
+              <TermsOfServicePage />
+            </InfoPageContainer>
+          }
+        />
+        <Route
+          path="/code-of-conduct"
+          element={
+            <InfoPageContainer>
+              <CodeOfConductPage />
+            </InfoPageContainer>
+          }
+        />
       </Routes>
     </div>
     <ReactQueryDevtools initialIsOpen={false} />
@@ -186,16 +202,10 @@ const ProjectContainer = () => {
   )
 }
 
-const InfoPageContainer = () => {
-  const { slug } = useParams()
-
-  return (
-    <main className={styles.main}>
-      <div className={styles.content}>
-        <ErrorBoundary>
-          <InfoPage slug={slug as string} />
-        </ErrorBoundary>
-      </div>
-    </main>
-  )
-}
+const InfoPageContainer = ({ children }: { children: ReactNode }) => (
+  <main className={styles.main}>
+    <div className={styles.content}>
+      <ErrorBoundary>{children}</ErrorBoundary>
+    </div>
+  </main>
+)

--- a/ui/src/components/header/header.tsx
+++ b/ui/src/components/header/header.tsx
@@ -54,7 +54,13 @@ export const Header = () => {
             to={APP_ROUTES.TERMS_OF_SERVICE}
             className={classNames(buttonStyles.button, buttonStyles.plain)}
           >
-            <span className={buttonStyles.label}>Terms of Service</span>
+            <span className={buttonStyles.label}>Terms of service</span>
+          </Link>
+          <Link
+            to={APP_ROUTES.CODE_OF_CONDUCT}
+            className={classNames(buttonStyles.button, buttonStyles.plain)}
+          >
+            <span className={buttonStyles.label}>Code of conduct</span>
           </Link>
         </div>
         {user.loggedIn ? (

--- a/ui/src/components/info-page/code-of-conduct-page/code-of-conduct-page.tsx
+++ b/ui/src/components/info-page/code-of-conduct-page/code-of-conduct-page.tsx
@@ -2,5 +2,5 @@ import { InfoPage } from '../info-page'
 import markdown from './code-of-conduct.md'
 
 export const CodeOfConductPage = () => (
-  <InfoPage anchorPrefix="chapter" markdown={markdown} />
+  <InfoPage anchorPrefix="section" markdown={markdown} />
 )

--- a/ui/src/components/info-page/code-of-conduct-page/code-of-conduct-page.tsx
+++ b/ui/src/components/info-page/code-of-conduct-page/code-of-conduct-page.tsx
@@ -1,0 +1,6 @@
+import { InfoPage } from '../info-page'
+import markdown from './code-of-conduct.md'
+
+export const CodeOfConductPage = () => (
+  <InfoPage anchorPrefix="chapter" markdown={markdown} />
+)

--- a/ui/src/components/info-page/code-of-conduct-page/code-of-conduct.md
+++ b/ui/src/components/info-page/code-of-conduct-page/code-of-conduct.md
@@ -8,7 +8,7 @@ Antenna fills the data gap to help understand insects and protect biodiversity b
 
 Antenna is a highly collaborative community and aspires to be a safe and welcoming space for all. Therefore, we have prepared guidelines for our community in which we outline the expected behavior from everyone, as well as steps for reporting unacceptable behavior.
 
-These guidelines coexist harmoniously with our [Terms of service](https://antenna.insectai.org/terms-of-service) and are not intended to replace them in any way.
+These guidelines coexist harmoniously with our [Terms of service](/terms-of-service) and are not intended to replace them in any way.
 
 1. ## **Scope**
 

--- a/ui/src/components/info-page/code-of-conduct-page/code-of-conduct.md
+++ b/ui/src/components/info-page/code-of-conduct-page/code-of-conduct.md
@@ -1,0 +1,51 @@
+# **Code of conduct**
+
+Hi Friends!
+
+Antenna is an interdisciplinary platform to upload, classify, and analyse in-the-wild images of invertebrates for research and conservation efforts.
+
+Antenna fills the data gap to help understand insects and protect biodiversity by enabling the scale-up of data collection with greater spatial, temporal, and taxonomic coverage than has ever been possible. It is an online platform where entomologists, ecologists, and machine learning (ML) and computer scientists collaborate to build trustworthy datasets by implementing and improving upon ML research designed specifically for real-world applications. Antenna cost-effectively and rapidly classifies a wide range of species in a large number of images, building a rich dataset that grows and updates over time.
+
+Antenna is a highly collaborative community and aspires to be a safe and welcoming space for all. Therefore, we have prepared guidelines for our community in which we outline the expected behavior from everyone, as well as steps for reporting unacceptable behavior.
+
+These guidelines coexist harmoniously with our [Terms of service](https://antenna.insectai.org/terms-of-service) and are not intended to replace them in any way.
+
+1. ## **Scope**
+
+These guidelines do not address behavior beyond Antenna.
+
+2. ## **What we expect from you - _The Do’s_**
+
+- Be empathetic, polite and kind toward other people.
+- Be respectful of people’s projects and contributions.
+- Be respectful of differing opinions, viewpoints, and experiences.
+- Use welcoming and inclusive language.
+- Give and gracefully accept constructive feedback.
+- Accept responsibility and apologise to those affected by our mistakes, and learn from the experience.
+- Focus on what is best not just for us as individuals, but for the overall community.
+
+3. ## **Behaviors that are not welcome - _The Don’ts_**
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind.
+- Trolling, insulting or making derogatory comments, and personal or political attacks.
+- Discrimination against people based on age, race, gender, income, physical ability, country of origin, educational background, or any other trait that they can't control.
+- Public or private harassment.
+- Disruptive behavior.
+- Publishing others' private information, such as a physical or email address, without their explicit permission.
+  Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+4. ## **Conflict Resolution & Reporting**
+
+Healthy debate is always welcomed & encouraged. However, it is never acceptable to be disrespectful or to engage in behavior that violates Antenna’s community guidelines.
+
+If you notice someone going against our community guidelines, you are encouraged to address the behavior directly with those involved. If you are unable to resolve the matter for any reason, or if the behavior involves threatening or harassing, report it to admin.antenna@mila.quebec.
+
+All complaints will be reviewed and investigated promptly and fairly with respect to the privacy and security of the reporter of any incident.
+
+We will use our discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from our platform. We will notify the accused of the report and provide them an opportunity to discuss it before any action is taken. In potentially harmful situations, such as ongoing harassment or threats to anyone's safety, we may take action without notice.
+
+Also, keep in mind that moderators may, at their sole discretion & without warning, remove content that we deem harmful to Antenna’s community or data quality, including but not limited to : intentionally false content, content created by sockpuppet accounts, hate speech, pornography, etc.
+
+5. ## **Attribution**
+
+This Code of Conduct is inspired from the [Contributor Covenant](https://www.contributor-covenant.org/), [version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/ui/src/components/info-page/info-page.module.scss
+++ b/ui/src/components/info-page/info-page.module.scss
@@ -78,17 +78,31 @@
     font-weight: 600;
   }
 
-  ol {
+  ul {
     display: block;
-    list-style-type: decimal;
-    margin: 0 0 32px 64px;
+    margin: 0 0 32px 16px;
 
     li {
       display: list-item;
       @include paragraph-small();
 
       &:not(:last-child) {
-        margin-bottom: 32px;
+        margin-bottom: 8px;
+      }
+    }
+  }
+
+  ol {
+    display: block;
+    list-style-type: decimal;
+    margin: 0 0 32px 16px;
+
+    li {
+      display: list-item;
+      @include paragraph-small();
+
+      &:not(:last-child) {
+        margin-bottom: 8px;
       }
     }
 

--- a/ui/src/components/info-page/terms-of-service-page/constants.ts
+++ b/ui/src/components/info-page/terms-of-service-page/constants.ts
@@ -1,1 +1,0 @@
-export const TERMS_OF_SERVICE_SLUG = 'terms-of-service'

--- a/ui/src/components/info-page/terms-of-service-page/terms-of-service-page.tsx
+++ b/ui/src/components/info-page/terms-of-service-page/terms-of-service-page.tsx
@@ -1,64 +1,6 @@
-import { LoadingSpinner } from 'design-system/components/loading-spinner/loading-spinner'
-import { ReactElement, useEffect, useState } from 'react'
-import ReactMarkdown from 'react-markdown'
-import styles from '../info-page.module.scss'
+import { InfoPage } from '../info-page'
 import markdown from './terms-of-service.md'
 
-export const TermsOfServicePage = () => {
-  const [markdownContent, setMarkdownContent] = useState<string>()
-
-  useEffect(() => {
-    const loadContent = async () => {
-      const response = await fetch(markdown)
-      const markdownContent = await response.text()
-      setMarkdownContent(markdownContent)
-    }
-
-    loadContent()
-  })
-
-  if (!markdownContent) {
-    return (
-      <div className={styles.wrapper}>
-        <div className={styles.loadingWrapper}>
-          <LoadingSpinner />
-        </div>
-      </div>
-    )
-  }
-
-  return (
-    <div className={styles.wrapper}>
-      <div className={styles.container}>
-        <ReactMarkdown
-          className={styles.content}
-          components={{
-            ol: (props) => {
-              const start = props.start ?? 1
-              const children = (props.children as ReactElement[]).filter(
-                (element) => element.type === 'li'
-              )
-
-              // TODO: Can we find a better way to detect what is a term title?
-              if (children.length === 1) {
-                const id = `term-${start}`
-
-                return (
-                  <a href={`#${id}`}>
-                    <ol id={id} start={start}>
-                      {props.children}
-                    </ol>
-                  </a>
-                )
-              }
-
-              return <ol start={start}>{props.children}</ol>
-            },
-          }}
-        >
-          {markdownContent}
-        </ReactMarkdown>
-      </div>
-    </div>
-  )
-}
+export const TermsOfServicePage = () => (
+  <InfoPage anchorPrefix="term" markdown={markdown} />
+)

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -6,6 +6,7 @@ export const APP_ROUTES = {
   RESET_PASSWORD: '/auth/reset-password',
   RESET_PASSWORD_CONFIRM: '/auth/reset-password-confirm',
   TERMS_OF_SERVICE: '/terms-of-service',
+  CODE_OF_CONDUCT: '/code-of-conduct',
   PROJECTS: '/projects',
 
   /* Dynamic app routes */

--- a/ui/src/utils/usePageTitle.ts
+++ b/ui/src/utils/usePageTitle.ts
@@ -1,8 +1,8 @@
 import { useContext, useEffect, useState } from 'react'
 import { BreadcrumbContext } from './breadcrumbContext'
 
-const DEFAULT_PAGE_TITLE = 'Antenna Data Platform'
 const SEPARATOR = ' | '
+export const DEFAULT_PAGE_TITLE = 'Antenna Data Platform'
 
 export const usePageTitle = () => {
   const [pageTitle, setPageTitle] = useState(DEFAULT_PAGE_TITLE)


### PR DESCRIPTION
## Summary

In this PR we include our new page "Code of conduct" in Antenna. The page is setup in a similar way as the page "Terms of service". We use same style and structure.

The content for this new page can be edited from a markdown file, see `ui/src/components/info-page/code-of-conduct-page/code-of-conduct.md`.

Since I modified our routing a bit as part of this PR, I also included a simple 404 page in this PR. We were missing that! For now, we use it if the current route can't be matched to a page.

## Screenshots
<img width="1728" alt="Screenshot 2025-03-12 at 09 50 15" src="https://github.com/user-attachments/assets/08c8dbad-358c-4628-8fd5-58c1213b2053" />

<img width="1728" alt="Screenshot 2025-03-12 at 10 27 43" src="https://github.com/user-attachments/assets/d00dd536-24c7-4fa1-844f-cd7e12018016" />
