### PR TITLE
fix: update invalid filters in Project admin

### DIFF
--- a/ami/main/admin.py
+++ b/ami/main/admin.py
@@ -71,7 +71,7 @@ class ProjectAdmin(GuardedModelAdmin):
 
     list_display = ("name", "owner", "priority", "active", "created_at", "updated_at")
     list_filter = ("active", "owner")
-    search_fields = ("name", "owner__username", "members__username")
+    search_fields = ("name", "owner__email", "members__email")
     filter_horizontal = ("members",)
 
     inlines = [ProjectPipelineConfigInline]


### PR DESCRIPTION
The Project admin was attempting to filter on the username field, which doesn't exist and throws a 500 when you try to use the search box. This PR fixes the search filter field names.

![image](https://github.com/user-attachments/assets/4096da07-c02a-464d-af0a-c33c8ba4c6b1)

![image](https://github.com/user-attachments/assets/db0ccf9c-2637-4a5d-aba0-8ce9d8c787b8)
