### PR TITLE
Enable basic type checking for Python by default in VS Code project

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,5 +42,6 @@
     },
     "files.eol": "\n",
     "files.insertFinalNewline": true,
-    "files.trimTrailingWhitespace": true
+    "files.trimTrailingWhitespace": true,
+    "python.analysis.typeCheckingMode": "basic"
 }


### PR DESCRIPTION
## Summary

Add default type checking when working in Python in VScode. This is the setting I have been using since the beginning, but realized it was in my user settings and not the workspace settings.

### List of Changes

- Updates default VScode settings for the project

### For follow-up 

- Resolve existing type issues (red squiggly lines). There some that I have not been able to resolve, for example for custom QuerySet methods for a Django model. We may need to use `type: ignore` until more time can be dedicated to them. 