### PR TITLE
Make session info optional for occurrences

### DIFF
--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1065,9 +1065,9 @@ class OccurrenceViewSet(DefaultViewSet, ProjectMixin):
         else:
             return OccurrenceSerializer
 
-    def get_queryset(self) -> QuerySet:
+    def get_queryset(self) -> QuerySet["Occurrence"]:
         project = self.get_active_project()
-        qs = super().get_queryset()
+        qs = super().get_queryset().valid()  # type: ignore
         if project:
             qs = qs.filter(project=project)
         qs = qs.select_related(
@@ -1081,10 +1081,7 @@ class OccurrenceViewSet(DefaultViewSet, ProjectMixin):
         if self.action == "list":
             qs = (
                 qs.all()
-                .exclude(detections=None)
-                .exclude(event=None)
                 .filter(determination_score__gte=get_active_classification_threshold(self.request))
-                .exclude(first_appearance_timestamp=None)  # This must come after annotations
                 .order_by("-determination_score")
             )
 
@@ -1422,11 +1419,7 @@ class SummaryView(GenericAPIView, ProjectMixin):
                 "events_count": Event.objects.filter(deployment__project=project, deployment__isnull=False).count(),
                 "captures_count": SourceImage.objects.filter(deployment__project=project).count(),
                 # "detections_count": Detection.objects.filter(occurrence__project=project).count(),
-                "occurrences_count": Occurrence.objects.filter(
-                    project=project,
-                    # determination_score__gte=confidence_threshold,
-                    event__isnull=False,
-                ).count(),
+                "occurrences_count": Occurrence.objects.valid().filter(project=project).count(),  # type: ignore
                 "taxa_count": Occurrence.objects.all().unique_taxa(project=project).count(),  # type: ignore
             }
         else:
@@ -1436,10 +1429,7 @@ class SummaryView(GenericAPIView, ProjectMixin):
                 "events_count": Event.objects.filter(deployment__isnull=False).count(),
                 "captures_count": SourceImage.objects.count(),
                 # "detections_count": Detection.objects.count(),
-                "occurrences_count": Occurrence.objects.filter(
-                    # determination_score__gte=confidence_threshold,
-                    event__isnull=False
-                ).count(),
+                "occurrences_count": Occurrence.objects.valid().count(),  # type: ignore
                 "taxa_count": Occurrence.objects.all().unique_taxa().count(),  # type: ignore
                 "last_updated": timezone.now(),
             }

--- a/ui/src/data-services/models/occurrence.ts
+++ b/ui/src/data-services/models/occurrence.ts
@@ -120,11 +120,19 @@ export class Occurrence {
     return this._occurrence.detections_count
   }
 
-  get sessionId(): string {
+  get sessionId(): string | undefined {
+    if (!this._occurrence.event) {
+      return undefined
+    }
+
     return `${this._occurrence.event.id}`
   }
 
-  get sessionLabel(): string {
+  get sessionLabel(): string | undefined {
+    if (!this._occurrence.event) {
+      return undefined
+    }
+
     return this._occurrence.event.name
   }
 

--- a/ui/src/pages/occurrence-details/occurrence-details.tsx
+++ b/ui/src/pages/occurrence-details/occurrence-details.tsx
@@ -69,20 +69,22 @@ export const OccurrenceDetails = ({
             )
             .map((item) => ({
               ...item,
-              to: pathname.includes(
-                APP_ROUTES.SESSIONS({ projectId: projectId as string })
-              )
-                ? undefined
-                : getAppRoute({
-                    to: APP_ROUTES.SESSION_DETAILS({
-                      projectId: projectId as string,
-                      sessionId: occurrence.sessionId,
+              to:
+                !occurrence.sessionId ||
+                pathname.includes(
+                  APP_ROUTES.SESSIONS({ projectId: projectId as string })
+                )
+                  ? undefined
+                  : getAppRoute({
+                      to: APP_ROUTES.SESSION_DETAILS({
+                        projectId: projectId as string,
+                        sessionId: occurrence.sessionId,
+                      }),
+                      filters: {
+                        occurrence: occurrence.id,
+                        capture: item.captureId,
+                      },
                     }),
-                    filters: {
-                      occurrence: occurrence.id,
-                      capture: item.captureId,
-                    },
-                  }),
             }))
         : [],
     [occurrence]
@@ -97,17 +99,19 @@ export const OccurrenceDetails = ({
     {
       label: translate(STRING.FIELD_LABEL_SESSION),
       value: occurrence.sessionLabel,
-      to: pathname.includes(
-        APP_ROUTES.SESSIONS({ projectId: projectId as string })
-      )
-        ? undefined
-        : getAppRoute({
-            to: APP_ROUTES.SESSION_DETAILS({
-              projectId: projectId as string,
-              sessionId: occurrence.sessionId,
+      to:
+        !occurrence.sessionId ||
+        pathname.includes(
+          APP_ROUTES.SESSIONS({ projectId: projectId as string })
+        )
+          ? undefined
+          : getAppRoute({
+              to: APP_ROUTES.SESSION_DETAILS({
+                projectId: projectId as string,
+                sessionId: occurrence.sessionId,
+              }),
+              filters: { occurrence: occurrence.id },
             }),
-            filters: { occurrence: occurrence.id },
-          }),
     },
     {
       label: translate(STRING.FIELD_LABEL_DATE),

--- a/ui/src/pages/occurrences/occurrence-columns.tsx
+++ b/ui/src/pages/occurrences/occurrence-columns.tsx
@@ -97,58 +97,34 @@ export const columns: (
     id: 'session',
     name: translate(STRING.FIELD_LABEL_SESSION),
     sortField: 'event',
-    renderCell: (item: Occurrence) => (
-      <Link
-        to={APP_ROUTES.SESSION_DETAILS({
-          projectId,
-          sessionId: item.sessionId,
-        })}
-      >
-        <BasicTableCell value={item.sessionLabel} theme={CellTheme.Primary} />
-      </Link>
-    ),
+    renderCell: (item: Occurrence) => {
+      if (!item.sessionId) {
+        return <></>
+      }
+
+      return (
+        <Link
+          to={APP_ROUTES.SESSION_DETAILS({
+            projectId,
+            sessionId: item.sessionId,
+          })}
+        >
+          <BasicTableCell value={item.sessionLabel} theme={CellTheme.Primary} />
+        </Link>
+      )
+    },
   },
   {
     id: 'date',
     name: translate(STRING.FIELD_LABEL_DATE_OBSERVED),
     sortField: 'first_appearance_timestamp',
-    renderCell: (item: Occurrence) => (
-      <Link
-        to={getAppRoute({
-          to: APP_ROUTES.SESSION_DETAILS({
-            projectId,
-            sessionId: item.sessionId,
-          }),
-          filters: {
-            occurrence: item.id,
-            timestamp: item.firstAppearanceTimestamp,
-          },
-        })}
-      >
-        <BasicTableCell value={item.dateLabel} />
-      </Link>
-    ),
+    renderCell: (item: Occurrence) => <BasicTableCell value={item.dateLabel} />,
   },
   {
     id: 'time',
     sortField: 'first_appearance_time',
     name: translate(STRING.FIELD_LABEL_TIME_OBSERVED),
-    renderCell: (item: Occurrence) => (
-      <Link
-        to={getAppRoute({
-          to: APP_ROUTES.SESSION_DETAILS({
-            projectId,
-            sessionId: item.sessionId,
-          }),
-          filters: {
-            occurrence: item.id,
-            timestamp: item.firstAppearanceTimestamp,
-          },
-        })}
-      >
-        <BasicTableCell value={item.timeLabel} />
-      </Link>
-    ),
+    renderCell: (item: Occurrence) => <BasicTableCell value={item.timeLabel} />,
   },
   {
     id: 'duration',


### PR DESCRIPTION
## Summary

In this PR we make session info optional for occurrences. See #791 for background.

## Screenshots

After the fix, we will display occurrences without a session like this. Also any links to session details are disabled. See https://deploy-preview-794--antenna-preview.netlify.app/projects/84/occurrences/125214 for live example.

<img width="1728" alt="Screenshot 2025-04-02 at 13 13 34" src="https://github.com/user-attachments/assets/9c9d87af-1af8-4503-820b-7446c6e6d297" />