### PR TITLE
Fix production build

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -1,5 +1,7 @@
 # define an alias for the specific python version used in this file.
-FROM python:3.11.4-slim-bullseye as python
+# 3.11.12 has a bug with an incompatible version of wheel
+# will be fixed in 3.11.13
+FROM python:3.11.11-slim-bullseye as python
 
 # Python build stage
 FROM python as python-build-stage

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -1,5 +1,7 @@
 # define an alias for the specific python version used in this file.
-FROM python:3.11-slim-bullseye as python
+# 3.11.12 has a bug with an incompatible version of wheel
+# will be fixed in 3.11.13
+FROM python:3.11.11-slim-bullseye as python
 
 # Python build stage
 FROM python as python-build-stage


### PR DESCRIPTION
The Docker base image for Python was broken yesterday, which is preventing us from deploying production at the moment. I am pinning the base image to a specific patch build until they fix the issue in the next build of the base image. They have already made a fix in the source for the image here:

https://github.com/docker-library/python/commit/5f041dab48cbaa33eef235fb94ddf07c61a53ad7#diff-850147019edc70a9bbb4e950d83d5fd93ccb26c5714ddef959ceb2be79173fc2R99-R100

Here is the documented issue
https://github.com/docker-library/python/issues/1023

