### PR TITLE
Expand support for date formats in image filenames

### DIFF
--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import QuerySet
 from guardian.shortcuts import get_perms
 from rest_framework import serializers
@@ -13,7 +14,6 @@ from ami.ml.models import Algorithm
 from ami.ml.serializers import AlgorithmSerializer
 from ami.users.models import User
 from ami.users.roles import ProjectManager
-from ami.utils.dates import get_image_timestamp_from_filename
 
 from ..models import (
     Classification,
@@ -32,6 +32,7 @@ from ..models import (
     SourceImageUpload,
     TaxaList,
     Taxon,
+    validate_filename_timestamp,
 )
 
 
@@ -1024,13 +1025,10 @@ class SourceImageUploadSerializer(DefaultSerializer):
 
     def validate_image(self, value):
         # Ensure that image filename contains a timestamp
-        timestamp = get_image_timestamp_from_filename(value.name)
-        if timestamp is None:
-            # @TODO bring back EXIF support
-            raise serializers.ValidationError(
-                "Image filename does not contain a timestamp in the format YYYYMMDDHHMMSS "
-                " (e.g. 20210101120000-snapshot.jpg). EXIF support coming soon."
-            )
+        try:
+            validate_filename_timestamp(value.name)
+        except DjangoValidationError as e:
+            raise serializers.ValidationError(str(e))
         return value
 
 

--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -1098,8 +1098,6 @@ class SourceImageCollectionSerializer(DefaultSerializer):
         ]
 
     def get_permissions(self, instance, instance_data):
-        request = self.context.get("request")
-
         request: Request = self.context["request"]
         user = request.user
         project = instance.get_project()

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -1242,7 +1242,7 @@ def validate_filename_timestamp(filename: str) -> None:
     # Ensure filename has a timestamp
     timestamp = ami.utils.dates.get_image_timestamp_from_filename(filename)
     if not timestamp:
-        raise ValidationError("Filename must contain a timestamp in the format YYYYMMDDHHMMSS")
+        raise ValidationError("Image filename does not contain a valid timestamp (e.g. YYMMDDHHMMSS-snapshot.jpg).")
 
 
 def create_source_image_from_upload(image: ImageFieldFile, deployment: Deployment, request=None) -> "SourceImage":

--- a/ami/utils/tests.py
+++ b/ami/utils/tests.py
@@ -1,0 +1,34 @@
+import datetime
+from unittest import TestCase
+
+
+class TestUtils(TestCase):
+    def test_extract_timestamps(self):
+        from ami.utils.dates import get_image_timestamp_from_filename
+
+        filenames_and_expected_dates = [
+            ("aarhus/20220810231507-00-07.jpg", "2022-08-10 23:15:07"),
+            ("diopsis/20230124191342.jpg", "2023-01-24 19:13:42"),
+            ("vermont_snapshots/20220622000459-108-snapshot.jpg", "2022-06-22 00:04:59"),
+            ("cyprus_snapshots/84-20220916202959-snapshot.jpg", "2022-09-16 20:29:59"),
+            ("wingscape/Project_20230801023001_4393.JPG", "2023-08-01 02:30:01"),
+            ("nikon/DSC_1974.JPG", None),  # Example with no date
+            ("not_a_date/happybirthday.jpg", None),  # Example with no date
+            ("cannon/IMG_20230801_123456.jpg", "2023-08-01 12:34:56"),
+            ("mothbox/2024_01_01 12_00_00.jpg", "2024-01-01 12:00:00"),
+            ("other_common/2024-01-01 12:00:00.jpg", "2024-01-01 12:00:00"),
+            ("other_common/2024-01-01T12:00:00.jpg", "2024-01-01 12:00:00"),
+        ]
+
+        for filename, expected_date in filenames_and_expected_dates:
+            with self.subTest(filename=filename):
+                # Convert the expected date string to a datetime object
+                if expected_date is not None:
+                    expected_date = datetime.datetime.strptime(expected_date, "%Y-%m-%d %H:%M:%S")
+                # Call the function and compare the result with the expected date
+                # Only use raise_error=True when we expect a date to be present
+                raise_error = expected_date is not None
+                result = get_image_timestamp_from_filename(filename, raise_error=raise_error)
+                self.assertEqual(
+                    result, expected_date, f"Failed for {filename}: expected {expected_date}, got {result}"
+                )

--- a/ui/src/utils/language.ts
+++ b/ui/src/utils/language.ts
@@ -418,7 +418,7 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
 
   /* MESSAGE */
   [STRING.MESSAGE_CAPTURE_FILENAME]:
-    'Image filename must contain a timestamp in the format YYYYMMDDHHMMSS (e.g. 20210101120000-snapshot.jpg).',
+    'Image filename must contain a timestamp with year, month, day, hours, minutes and seconds (e.g. 20210101120000-snapshot.jpg).',
   [STRING.MESSAGE_CAPTURE_LIMIT]:
     'A maximum of {{numCaptures}} images can be uploaded through the web browser. Configure a data source to upload data in bulk.',
   [STRING.MESSAGE_CAPTURE_SYNC_HIDDEN]:


### PR DESCRIPTION
## Summary

Previously we only supported filenames with timestamps that match YYYYMMDDHHMMSS. This works for all AMI systems, but not users of other camera systems. We now support timestamps that contain delimiters between the date components e.g. YYYY-MM-SS HH:MM:SS. This should reduce frustration while users are testing images from new cameras using the manual image upload interface.

We are avoiding reading EXIF data because it requires reading the file contents, which is not an option when indexing images during the batch sync. If we separate the manual/single image uploads from batch syncing then we can considering reading EXIF. Or perhaps it can be done with javascript on the client machine?\


## Checklist

- [x] I have tested these changes appropriately.
- [x] I have added and/or modified relevant tests.
- [x] I updated relevant documentation or comments.
- [x] I have verified that this PR follows the project's coding standards.
- [x] Any dependent changes have already been merged to main.
