### PR TITLE
fix: change name of the new docker network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     command: /start
     networks:
       - default
-      - ml_network
+      - antenna_network
 
   postgres:
     build:
@@ -157,6 +157,6 @@ services:
           - processing_service
 
 networks:
-  ml_network:
+  antenna_network:
     external: true
-    name: ml_network
+    name: antenna_network

--- a/processing_services/README.md
+++ b/processing_services/README.md
@@ -20,7 +20,7 @@ If your goal is to run an ML backend locally, simply copy the `example` director
 
 1. Update `processing_services/example/requirements.txt` with required packages (i.e. PyTorch, etc)
 2. Rebuild container to install updated dependencies. Start the minimal and example ML backends: `docker compose -f processing_services/docker-compose.yml up -d --build ml_backend_example`
-3. To test that everything works, register a new processing service in Antenna with endpoint URL http://ml_backend_example:2000. All ML backends are connected to the main docker compose stack using the `ml_network`.
+3. To test that everything works, register a new processing service in Antenna with endpoint URL http://ml_backend_example:2000. All ML backends are connected to the main docker compose stack using the `antenna_network`.
 
 
 ## Add Algorithms, Pipelines, and ML Backend/Processing Services

--- a/processing_services/docker-compose.yml
+++ b/processing_services/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     extra_hosts:
       - minio:host-gateway
     networks:
-      - ml_network
+      - antenna_network
 
   ml_backend_example:
     build:
@@ -21,8 +21,8 @@ services:
     extra_hosts:
       - minio:host-gateway
     networks:
-      - ml_network
+      - antenna_network
 
 networks:
-  ml_network:
-    name: ml_network
+  antenna_network:
+    name: antenna_network

--- a/processing_services/example/docker-compose.yml
+++ b/processing_services/example/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     extra_hosts:
       - minio:host-gateway
     networks:
-      - ml_network
+      - antenna_network
     deploy:
       resources:
         reservations:
@@ -19,5 +19,5 @@ services:
               capabilities: [gpu]
 
 networks:
-  ml_network:
-    name: ml_network
+  antenna_network:
+    name: antenna_network

--- a/processing_services/minimal/docker-compose.yml
+++ b/processing_services/minimal/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     extra_hosts:
       - minio:host-gateway
     networks:
-      - ml_network
+      - antenna_network
 
 networks:
-  ml_network:
-    name: ml_network
+  antenna_network:
+    name: antenna_network


### PR DESCRIPTION
## Summary

#798 introduced a named Docker network to make it easier to use simultaneous compose stacks. This quick PR modifies the name of that network to be more clear it belongs to this project.
