### PR TITLE
Fix broken docker compose start-up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,5 +158,4 @@ services:
 
 networks:
   antenna_network:
-    external: true
     name: antenna_network


### PR DESCRIPTION
## Summary

The Docker network was required to exist before starting the compose stack. This change fixes that so the network will be created if it does not already exist.
