### PR TITLE
Modify docker compose configuration for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,23 +16,33 @@ Antenna uses [Docker](https://docs.docker.com/get-docker/) & [Docker Compose](ht
     127.0.0.1 minio
     127.0.0.1 django
 ```
+3) The following commands will build all services, run them in the background, and then stream the logs.
+   1) Standard development
+      ```sh
+      docker compose up -d
+      docker compose logs -f django celeryworker ui
+      # Ctrl+c to close the logs
+      ```
+   2) Backend only: will use a pre-built version of the frontend that will not have hot-reloading enabled, but makes startup time faster when restarting the stack.
+      ```sh
+      # Build the frontend (only needed the first time starting the stack, or if the frontend changed since your last build)
+      (cd ui && yarn build)
+      ```
+      ```sh
+      # Run docker compose with the override config
+      docker compose -f docker-compose.yml -f docker-compose-backend-dev.override.yml up -d
+      ```
+      If there's a need to update the frontend while using this override, simply re-build the frontend with the `(cd ui && yarn build)` after modifying the frontend code.
 
-2) The following commands will build all services, run them in the background, and then stream the logs.
 
-```sh
-    docker compose up -d
-    docker compose logs -f django celeryworker ui
-    # Ctrl+c to close the logs
-```
-
-3) Optionally, run additional ML processing services: `processing_services` defines ML backends which wrap detections in our FastAPI response schema. The `example` app demos how to add new pipelines, algorithms, and models. See the detailed instructions in `processing_services/README.md`.
+4) Optionally, run additional ML processing services: `processing_services` defines ML backends which wrap detections in our FastAPI response schema. The `example` app demos how to add new pipelines, algorithms, and models. See the detailed instructions in `processing_services/README.md`.
 
 ```
 docker compose -f processing_services/example/docker-compose.yml up -d
 # Once running, in Antenna register a new processing service called: http://ml_backend_example:2000
 ```
 
-4) Access the platform the following URLs:
+5) Access the platform the following URLs:
 
 - Primary web interface: http://localhost:4000
 - API browser: http://localhost:8000/api/v2/
@@ -44,7 +54,7 @@ A default user will be created with the following credentials. Use these to log 
 - Email: `antenna@insectai.org`
 - Password: `localadmin`
 
-5) Stop all services with:
+6) Stop all services with:
 
     $ docker compose down
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Antenna uses [Docker](https://docs.docker.com/get-docker/) & [Docker Compose](ht
       docker compose logs -f django celeryworker ui
       # Ctrl+c to close the logs
       ```
-   2) Backend only: will use a pre-built version of the frontend that will not have hot-reloading enabled, but makes startup time faster when restarting the stack.
+   2) Backend only: will use a pre-built version of the frontend that will not have hot-reloading enabled, but will make startup time faster when restarting the stack.
       ```sh
       # Build the frontend (only needed the first time starting the stack, or if the frontend changed since your last build)
       (cd ui && yarn build)

--- a/README.md
+++ b/README.md
@@ -17,23 +17,29 @@ Antenna uses [Docker](https://docs.docker.com/get-docker/) & [Docker Compose](ht
     127.0.0.1 django
 ```
 3) The following commands will build all services, run them in the background, and then stream the logs.
-   1) Standard development
+   1) Standard development: will use a pre-built version of the frontend that will not have hot-reloading enabled, but will make startup time faster when restarting the stack.
       ```sh
+      # Build the frontend (only needed the first time starting the stack and after modification to the frontend component)
+      (cd ui && yarn install && yarn build)
+      ```
+      ```sh
+      # Start the whole compose stack
       docker compose up -d
+
+      # To stream the logs
       docker compose logs -f django celeryworker ui
       # Ctrl+c to close the logs
       ```
-   2) Backend only: will use a pre-built version of the frontend that will not have hot-reloading enabled, but will make startup time faster when restarting the stack.
+      If there's a need to update the frontend while using this override, simply re-build the frontend to load the new changes.
       ```sh
-      # Build the frontend (only needed the first time starting the stack, or if the frontend changed since your last build)
       (cd ui && yarn build)
       ```
+
+   2) With Hot Reload UI: Hot reload is enabled for frontend development, but the primary web interface will be slow to load at startup and later restarts.
       ```sh
       # Run docker compose with the override config
-      docker compose -f docker-compose.yml -f docker-compose-backend-dev.override.yml up -d
+      docker compose -f docker-compose.yml -f docker-compose-frontend-dev.override.yml up -d
       ```
-      If there's a need to update the frontend while using this override, simply re-build the frontend with the `(cd ui && yarn build)` after modifying the frontend code.
-
 
 4) Optionally, run additional ML processing services: `processing_services` defines ML backends which wrap detections in our FastAPI response schema. The `example` app demos how to add new pipelines, algorithms, and models. See the detailed instructions in `processing_services/README.md`.
 

--- a/compose/local/ui/Dockerfile
+++ b/compose/local/ui/Dockerfile
@@ -14,4 +14,4 @@ ENV BROWSER=none
 EXPOSE 4000
 
 # Check for changed app dependencies on every start
-CMD ["sh", "-c", "yarn install && yarn start --debug --host 0.0.0.0 --port 4000"]
+CMD ["sh", "-c", "yarn preview --debug --host 0.0.0.0 --port 4000"]

--- a/docker-compose-backend-dev.override.yml
+++ b/docker-compose-backend-dev.override.yml
@@ -1,3 +1,5 @@
+# This docker compose configuration should only be used to override the development compose file, docker-compose.yml
+
 services:
   ui:
     entrypoint: ["sh", "-c", "yarn preview --debug --host 0.0.0.0 --port 4000"]

--- a/docker-compose-backend-dev.override.yml
+++ b/docker-compose-backend-dev.override.yml
@@ -1,0 +1,3 @@
+services:
+  ui:
+    entrypoint: ["sh", "-c", "yarn preview --debug --host 0.0.0.0 --port 4000"]

--- a/docker-compose-frontend-dev.override.yml
+++ b/docker-compose-frontend-dev.override.yml
@@ -2,4 +2,4 @@
 
 services:
   ui:
-    entrypoint: ["sh", "-c", "yarn preview --debug --host 0.0.0.0 --port 4000"]
+    entrypoint: ["sh", "-c", "yarn install && yarn start --debug --host 0.0.0.0 --port 4000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,21 +66,6 @@ services:
       - CHOKIDAR_USEPOLLING=true
       - API_PROXY_TARGET=http://django:8000
 
-  docs:
-    image: ami_local_docs
-    build:
-      context: .
-      dockerfile: ./compose/local/docs/Dockerfile
-    env_file:
-      - ./.envs/.local/.django
-    volumes:
-      - ./docs:/docs:z
-      - ./config:/app/config:z
-      - ./ami:/app/ami:z
-    ports:
-      - "9025:9000"
-    command: /start-docs
-
   redis:
     image: redis:6
     container_name: ami_local_redis


### PR DESCRIPTION
## Summary

This PR modifies the default docker compose file and the UI Dockerfile to use a pre-built version of the frontend and improve startup time of the dev compose stack.

### List of Changes

* Adds `docker-compose-frontend-dev.override.yml` file that can be used to override the UI entrypoint command and enable hot reloading of the UI
* Modify the UI local development dockerfile to use a pre-built version of the frontend by default
* Add information documenting these changes in the `README.md` file

### Related Issues

N/A

## Detailed Description

This PR changes the default behavior when initiating a local dev environment. Default configuration now uses a pre-built version of the frontend. 

While this disables hot reloading of the UI, it makes startup time faster when restarting the stack and/or working on the backend components.

An override is provided and described below for those who might prefer doing frontend development using docker instead starting the UI separately from the compose stack. 

### How to Test the Changes

**Running the override for Frontend development:** 

Run the docker compose with the override:
```sh
docker compose -f docker-compose.yml -f docker-compose-backend-dev.override.yml up -d
```

**Standard development**

Running the base docker compose by itself will now run the Frontend from a pre-build version.

```sh
# Build the frontend

(cd ui && yarn install && yarn build)

# Start the whole compose stack
docker compose up -d
```

### Screenshots

N/A

## Deployment Notes

This doesn't affect deployment, as it targets only the local dev environment.

## Checklist

- [x] I have tested these changes appropriately.
- [x] I have added and/or modified relevant tests.
- [x] I updated relevant documentation or comments.
- [x] I have verified that this PR follows the project's coding standards.
- [x] Any dependent changes have already been merged to main.
