### PR TITLE
Backend support for OOD score threshold filter

### DIFF
--- a/ami/base/filters.py
+++ b/ami/base/filters.py
@@ -27,7 +27,7 @@ class ThresholdFilter(BaseFilterBackend):
     Example:
 
     DeterminationScoreFilter = ThresholdFilter.create(
-        query_param="classification_treshold",
+        query_param="classification_threshold",
         filter_param="determination_score",
     )
     OODScoreFilter = ThresholdFilter.create("determination_ood_score")

--- a/ami/base/filters.py
+++ b/ami/base/filters.py
@@ -1,5 +1,6 @@
 from django.db.models import F, OrderBy
-from rest_framework.filters import OrderingFilter
+from django.forms import FloatField
+from rest_framework.filters import BaseFilterBackend, OrderingFilter
 
 
 class NullsLastOrderingFilter(OrderingFilter):
@@ -8,3 +9,56 @@ class NullsLastOrderingFilter(OrderingFilter):
         if not values:
             return values
         return [OrderBy(F(value.lstrip("-")), descending=value.startswith("-"), nulls_last=True) for value in values]
+
+
+class ThresholdFilter(BaseFilterBackend):
+    """
+    Filter a numeric field by a minimum value.
+
+    Usage:
+
+    Filter occurrences by their determination score:
+    GET /occurrences/?score=0.5
+    This will return all occurrences with a determination score greater than or equal to 0.5.
+
+    Customize the query_param and filter_param to match your API and model fields using
+    the create method.
+
+    Example:
+
+    DeterminationScoreFilter = ThresholdFilter.create(
+        query_param="classification_treshold",
+        filter_param="determination_score",
+    )
+    OODScoreFilter = ThresholdFilter.create("determination_ood_score")
+
+    class OccurrenceViewSet(DefaultViewSet):
+        filter_backends = DefaultViewSetMixin.filter_backends + [
+            DeterminationScoreFilter,
+            OODScoreFilter,
+        ]
+    """
+
+    query_param = "score"
+    filter_param = "score"
+
+    def filter_queryset(self, request, queryset, view):
+        value = FloatField(required=False).clean(request.query_params.get(self.query_param))
+        if value:
+            filters = {f"{self.filter_param}__gte": value}
+            queryset = queryset.filter(**filters)
+        return queryset
+
+    @classmethod
+    def create(cls, query_param: str, filter_param: str | None = None) -> type["ThresholdFilter"]:
+        class_name = f"{cls.__name__}_{query_param}"
+        if filter_param is None:
+            filter_param = query_param
+        return type(
+            class_name,
+            (cls,),
+            {
+                "query_param": query_param,
+                "filter_param": filter_param,
+            },
+        )

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1126,7 +1126,36 @@ class OccurrenceViewSet(DefaultViewSet, ProjectMixin):
 
         return qs
 
-    @extend_schema(parameters=[project_id_doc_param])
+    @extend_schema(
+        parameters=[
+            project_id_doc_param,
+            OpenApiParameter(
+                name="classification_threshold",
+                description="Filter occurrences by minimum determination score.",
+                required=False,
+                type=OpenApiTypes.FLOAT,
+            ),
+            OpenApiParameter(
+                name="determination_ood_score",
+                description="Filter occurrences by minimum out-of-distribution score.",
+                required=False,
+                type=OpenApiTypes.FLOAT,
+            ),
+            OpenApiParameter(
+                name="taxon",
+                description="Filter occurrences by determination taxon ID. Shows occurrences determined as this taxon "
+                "or any of its child taxa.",
+                required=False,
+                type=OpenApiTypes.INT,
+            ),
+            OpenApiParameter(
+                name="collection_id",
+                description="Filter occurrences by the collection their detections' source images belong to.",
+                required=False,
+                type=OpenApiTypes.INT,
+            ),
+        ]
+    )
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
 

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -23,7 +23,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from ami.base.filters import NullsLastOrderingFilter
+from ami.base.filters import NullsLastOrderingFilter, ThresholdFilter
 from ami.base.pagination import LimitOffsetPaginationWithPermissions
 from ami.base.permissions import (
     CanDeleteIdentification,
@@ -1048,6 +1048,9 @@ class TaxonCollectionFilter(filters.BaseFilterBackend):
             return queryset
 
 
+OccurrenceOODScoreFilter = ThresholdFilter.create("determination_ood_score")
+
+
 class OccurrenceViewSet(DefaultViewSet, ProjectMixin):
     """
     API endpoint that allows occurrences to be viewed or edited.
@@ -1065,12 +1068,12 @@ class OccurrenceViewSet(DefaultViewSet, ProjectMixin):
         OccurrenceVerified,
         OccurrenceVerifiedByMeFilter,
         OccurrenceTaxaListFilter,
+        OccurrenceOODScoreFilter,
     ]
     filterset_fields = [
         "event",
         "deployment",
         "determination__rank",
-        "determination_ood_score",
     ]
     ordering_fields = [
         "created_at",
@@ -1086,7 +1089,6 @@ class OccurrenceViewSet(DefaultViewSet, ProjectMixin):
         "determination_ood_score",
         "event",
         "detections_count",
-        "created_at",
     ]
 
     def get_serializer_class(self):


### PR DESCRIPTION
## Summary

Allows filtering occurrences by OOD score and implements a generic ThresholdFilter class.

### List of Changes

* Create generic ThresholdFilter for Django Rest Framework views
* Implement OOD score filter
* Switch `classification_threshold` filter to use the new generic ThresholdFilter

### Related Issues

This was the remaining backend requirement for #811 

## Checklist

- [x] I have tested these changes appropriately.
- [ ] I have added and/or modified relevant tests.
- [x] I updated relevant documentation or comments.
- [x] I have verified that this PR follows the project's coding standards.
- [x] Any dependent changes have already been merged to main.
