### PR TITLE
Improve bulk identification workflow

### DIFF
--- a/ui/src/data-services/hooks/identifications/useCreateIdentification.ts
+++ b/ui/src/data-services/hooks/identifications/useCreateIdentification.ts
@@ -15,7 +15,10 @@ const convertToServerFieldValues = (
   comment: fieldValues.comment,
 })
 
-export const useCreateIdentification = (onSuccess?: () => void) => {
+export const useCreateIdentification = (
+  onSuccess?: () => void,
+  invalidate: boolean = true
+) => {
   const { user } = useUser()
   const queryClient = useQueryClient()
 
@@ -29,8 +32,10 @@ export const useCreateIdentification = (onSuccess?: () => void) => {
         }
       ),
     onSuccess: () => {
-      queryClient.invalidateQueries([API_ROUTES.IDENTIFICATIONS])
-      queryClient.invalidateQueries([API_ROUTES.OCCURRENCES])
+      if (invalidate) {
+        queryClient.invalidateQueries([API_ROUTES.IDENTIFICATIONS])
+        queryClient.invalidateQueries([API_ROUTES.OCCURRENCES])
+      }
       onSuccess?.()
     },
   })

--- a/ui/src/data-services/hooks/identifications/useCreateIdentifications.ts
+++ b/ui/src/data-services/hooks/identifications/useCreateIdentifications.ts
@@ -1,4 +1,5 @@
-import { SUCCESS_TIMEOUT } from 'data-services/constants'
+import { useQueryClient } from '@tanstack/react-query'
+import { API_ROUTES, SUCCESS_TIMEOUT } from 'data-services/constants'
 import { useEffect, useState } from 'react'
 import { IdentificationFieldValues } from './types'
 import { useCreateIdentification } from './useCreateIdentification'
@@ -6,13 +7,14 @@ import { useCreateIdentification } from './useCreateIdentification'
 export const useCreateIdentifications = (
   params: IdentificationFieldValues[]
 ) => {
+  const queryClient = useQueryClient()
   const [results, setResults] = useState<PromiseSettledResult<any>[]>()
   const { createIdentification, isLoading, isSuccess, reset } =
     useCreateIdentification(() => {
       setTimeout(() => {
         reset()
       }, SUCCESS_TIMEOUT)
-    })
+    }, false)
 
   const numRejected = results?.filter(
     (result) => result.status === 'rejected'
@@ -47,6 +49,8 @@ export const useCreateIdentifications = (
       setResults(undefined)
       const result = await Promise.allSettled(promises)
       setResults(result)
+      queryClient.invalidateQueries([API_ROUTES.IDENTIFICATIONS])
+      queryClient.invalidateQueries([API_ROUTES.OCCURRENCES])
     },
   }
 }

--- a/ui/src/pages/occurrence-details/reject-id/useRecentOptions.ts
+++ b/ui/src/pages/occurrence-details/reject-id/useRecentOptions.ts
@@ -1,7 +1,7 @@
 import { useUserPreferences } from 'utils/userPreferences/userPreferencesContext'
 import { REJECT_OPTIONS } from './constants'
 
-const DISPLAY_LIST_SIZE = 1 // Limit how many identifications are displayed
+const DISPLAY_LIST_SIZE = 5 // Limit how many identifications are displayed
 const STORAGE_LIST_SIZE = 5 // Limit how many identifications are stored
 
 export const useRecentIdentifications = () => {


### PR DESCRIPTION
## Summary

Improvements to the bulk ID workflow. Changes by @annavik 

### List of Changes

- Extend list of recently used taxa from 1 to 5 
- Wait with invalidating query for occurrence data until all id requests has completed. I think refetching data just once might help with some confusions. It could also be an optimization that will avoid requests queuing up a bit?

### Related Issues

- Closes #831 
- Addresses issue that 2 identifiers experience on a regular basis: IDing more than 2-3 occurrences at a time does not always update the list view.

## Detailed Description

.

### How to Test the Changes

.

### Screenshots

.

## Deployment Notes

.

## Checklist

- [ ] I have tested these changes appropriately.
- [ ] I have added and/or modified relevant tests.
- [ ] I updated relevant documentation or comments.
- [ ] I have verified that this PR follows the project's coding standards.
- [ ] Any dependent changes have already been merged to main.
