### PR TITLE
Handle undefined OOD scores in UI

### DIFF
--- a/ui/src/components/ood-score.tsx
+++ b/ui/src/components/ood-score.tsx
@@ -8,6 +8,10 @@ import { STRING, translate } from 'utils/language'
 const OOD_SCORE_THRESHOLD = 0.3
 
 export const OODScore = ({ occurrence }: { occurrence: Occurrence }) => {
+  if (occurrence.determinationOODScore === undefined) {
+    return <span>{translate(STRING.VALUE_NOT_AVAILABLE)}</span>
+  }
+
   const color = (() => {
     if (occurrence.determinationOODScore >= OOD_SCORE_THRESHOLD) {
       return CONSTANTS.COLORS.secondary[500]

--- a/ui/src/data-services/models/occurrence.ts
+++ b/ui/src/data-services/models/occurrence.ts
@@ -77,22 +77,26 @@ export class Occurrence {
     return this._occurrence.determination_score
   }
 
-  get determinationOODScore(): number {
+  get determinationOODScore(): number | undefined {
     const ood_score = this._occurrence.determination_ood_score
 
-    if (!ood_score) {
-      return 0
+    if (ood_score || ood_score === 0) {
+      return ood_score
     }
 
-    return ood_score
+    return undefined
   }
 
   get determinationScoreLabel(): string {
     return this.determinationScore.toFixed(2)
   }
 
-  get determinationOODScoreLabel(): string {
-    return this.determinationOODScore.toFixed(2)
+  get determinationOODScoreLabel(): string | undefined {
+    if (this.determinationOODScore !== undefined) {
+      return this.determinationOODScore.toFixed(2)
+    }
+
+    return undefined
   }
 
   get determinationTaxon(): Taxon {


### PR DESCRIPTION
If the OOD score is undefined or null, we want to present it as "n/a" in UI, not 0.

Defined:
<img width="289" alt="Screenshot 2025-05-15 at 08 55 03" src="https://github.com/user-attachments/assets/0d680442-aacb-4c9d-8ab0-57d0f0434469" />

Not defined:
<img width="249" alt="Screenshot 2025-05-15 at 08 55 51" src="https://github.com/user-attachments/assets/74f97384-8a64-4611-a621-bba3f087c7f3" />
