### PR TITLE
Add thumbnails to taxa search

### DIFF
--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -495,6 +495,7 @@ class TaxonSearchResultSerializer(TaxonNestedSerializer):
             "name",
             "rank",
             "parent",
+            "cover_image_url",
         ]
 
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,7 +30,7 @@
     "leaflet": "^1.9.3",
     "lodash": "^4.17.21",
     "lucide-react": "^0.454.0",
-    "nova-ui-kit": "^1.1.30",
+    "nova-ui-kit": "^1.1.31",
     "plotly.js": "^2.25.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/ui/src/components/taxon-search/taxon-search.tsx
+++ b/ui/src/components/taxon-search/taxon-search.tsx
@@ -28,6 +28,7 @@ export const TaxonSearch = ({
         label: taxon.name,
         details: taxon.rank,
         parentId: taxon.parentId,
+        image: taxon.image,
       }))
     )
   }, [data])
@@ -76,13 +77,14 @@ const CommandTreeItem = ({
   onSelect: (treeItem: TreeItem) => void
 }) => (
   <>
-    <Command.Item onSelect={() => onSelect(treeItem)}>
+    <Command.Item className="h-16 pr-2" onSelect={() => onSelect(treeItem)}>
       <Command.Taxon
         hasChildren={treeItem.children.length > 0}
         label={treeItem.label}
         level={level}
         rank={treeItem.details ?? 'Unknown'}
         selected={treeItem.id === selectedId}
+        image={treeItem.image}
       />
     </Command.Item>
     {treeItem.children.map((child) => (

--- a/ui/src/components/taxon-search/types.ts
+++ b/ui/src/components/taxon-search/types.ts
@@ -3,6 +3,7 @@ export type Node = {
   label: string
   details?: string
   parentId?: string
+  image?: string
 }
 
 export type TreeItem = Node & { children: TreeItem[] }

--- a/ui/src/data-services/models/taxa.ts
+++ b/ui/src/data-services/models/taxa.ts
@@ -2,6 +2,7 @@ export type ServerTaxon = {
   id: string
   name: string
   rank: string
+  cover_image_url: string | null
   parent?: ServerTaxon
   parents?: ServerTaxon[]
 }
@@ -25,12 +26,14 @@ export class Taxon {
   readonly parentId?: string
   readonly rank: string
   readonly ranks: { id: string; name: string; rank: string }[]
+  readonly image?: string
 
   public constructor(taxon: ServerTaxon) {
     this.id = `${taxon.id}`
     this.name = taxon.name
     this.parentId = taxon.parent ? `${taxon.parent?.id}` : undefined
     this.rank = taxon.rank
+    this.image = taxon.cover_image_url ?? undefined
 
     if (taxon.parents) {
       this.ranks = taxon.parents

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4940,7 +4940,7 @@ __metadata:
     leaflet: "npm:^1.9.3"
     lodash: "npm:^4.17.21"
     lucide-react: "npm:^0.454.0"
-    nova-ui-kit: "npm:^1.1.30"
+    nova-ui-kit: "npm:^1.1.31"
     plotly.js: "npm:^2.25.2"
     postcss: "npm:^8.4.47"
     prettier: "npm:2.8.4"
@@ -10317,9 +10317,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nova-ui-kit@npm:^1.1.30":
-  version: 1.1.30
-  resolution: "nova-ui-kit@npm:1.1.30"
+"nova-ui-kit@npm:^1.1.31":
+  version: 1.1.31
+  resolution: "nova-ui-kit@npm:1.1.31"
   dependencies:
     "@radix-ui/react-checkbox": "npm:^1.1.4"
     "@radix-ui/react-collapsible": "npm:^1.1.1"
@@ -10338,7 +10338,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     tailwind-merge: "npm:^2.5.4"
     tailwindcss-animate: "npm:^1.0.7"
-  checksum: e8b041d06ca4333abef7bfca7b13867e17ba55cc195ff9f5dace83fb9379cfa0b32e08135ce39637d09773950c9dd6657ffdf1f8d3b160469f31ed176d9ed4a4
+  checksum: a9c150152359299d1b09436bfe0cbd525f317845922149eb53d8597196f8dd67d1079519b4d592cd6a522053122446f626ebe6de5fc9a964bda75d3d144416fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In this PR we add thumbnails to taxa search. Main work here was to update our UI lib component.

This change also required a small backend extension.

Before:
<img width="336" alt="Screenshot 2025-05-15 at 17 38 44" src="https://github.com/user-attachments/assets/4c6bec9b-bc7a-4e4a-bfa6-6b18133fc384" />

After:
<img width="360" alt="Screenshot 2025-05-15 at 17 34 20" src="https://github.com/user-attachments/assets/b416e308-d054-4e61-a868-9af9e8b8d082" />
