### PR TITLE
Update pagination logic

### DIFF
--- a/ui/src/components/empty-state/empty-state.tsx
+++ b/ui/src/components/empty-state/empty-state.tsx
@@ -1,26 +1,44 @@
 import { Button } from 'nova-ui-kit'
+import { ReactNode } from 'react'
 import { STRING, translate } from 'utils/language'
 import { useFilters } from 'utils/useFilters'
+import { usePagination } from 'utils/usePagination'
 
 export const EmptyState = () => {
   const { filters, activeFilters, clearFilter } = useFilters()
+  const { pagination, resetPage } = usePagination()
 
-  return (
-    <div className="flex flex-col gap-6 items-center py-24">
-      <span className="body-base text-muted-foreground">
-        {translate(
-          activeFilters.length
-            ? STRING.MESSAGE_NO_RESULTS_FOR_FILTERING
-            : STRING.MESSAGE_NO_RESULTS
-        )}
-      </span>
-      {activeFilters.length ? (
+  if (pagination.page) {
+    return (
+      <Container>
+        <p>{translate(STRING.MESSAGE_NO_RESULTS_FOR_PAGE)}</p>
+        <Button onClick={() => resetPage()}>
+          {translate(STRING.RESET_PAGE)}
+        </Button>
+      </Container>
+    )
+  }
+
+  if (activeFilters.length) {
+    return (
+      <Container>
+        <p>{translate(STRING.MESSAGE_NO_RESULTS_FOR_FILTERING)}</p>
         <Button
           onClick={() => filters.map((filter) => clearFilter(filter.field))}
         >
           {translate(STRING.CLEAR_FILTERS)}
         </Button>
-      ) : null}
-    </div>
+      </Container>
+    )
+  }
+
+  return (
+    <Container>
+      <p>{translate(STRING.MESSAGE_NO_RESULTS)}</p>
+    </Container>
   )
 }
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div className="flex flex-col gap-6 items-center py-24">{children}</div>
+)

--- a/ui/src/utils/language.ts
+++ b/ui/src/utils/language.ts
@@ -24,6 +24,7 @@ export enum STRING {
   QUEUED,
   REFRESH,
   RESET,
+  RESET_PAGE,
   RETRY,
   RERUN,
   SAVE,
@@ -165,6 +166,7 @@ export enum STRING {
   MESSAGE_NO_IMAGE,
   MESSAGE_NO_RESULTS,
   MESSAGE_NO_RESULTS_FOR_FILTERING,
+  MESSAGE_NO_RESULTS_FOR_PAGE,
   MESSAGE_PASSWORD_FORMAT,
   MESSAGE_PASSWORD_UPDATED,
   MESSAGE_PERMISSIONS_MISSING,
@@ -293,6 +295,7 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.QUEUED]: 'Queued',
   [STRING.REFRESH]: 'Refresh',
   [STRING.RESET]: 'Reset',
+  [STRING.RESET_PAGE]: 'Reset page',
   [STRING.RETRY]: 'Retry',
   [STRING.RERUN]: 'Re-run',
   [STRING.SAVE]: 'Save',
@@ -443,7 +446,9 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.MESSAGE_NO_IMAGE]: 'No image',
   [STRING.MESSAGE_NO_RESULTS]: 'No results to show.',
   [STRING.MESSAGE_NO_RESULTS_FOR_FILTERING]:
-    'No results to show for the current fitering.',
+    'No results to show for the current filtering.',
+  [STRING.MESSAGE_NO_RESULTS_FOR_PAGE]:
+    'No results to show for the current page.',
   [STRING.MESSAGE_PASSWORD_FORMAT]:
     'The password must contain at least 8 characters and cannot be entirely numeric.',
   [STRING.MESSAGE_PASSWORD_UPDATED]: 'Your password has been updated!',

--- a/ui/src/utils/useFilters.ts
+++ b/ui/src/utils/useFilters.ts
@@ -1,5 +1,6 @@
 import { isBefore, isValid } from 'date-fns'
 import { useSearchParams } from 'react-router-dom'
+import { SEARCH_PARAM_KEY_PAGE } from './usePagination'
 
 export const AVAILABLE_FILTERS: {
   label: string
@@ -141,6 +142,12 @@ export const useFilters = (defaultFilters?: { [field: string]: string }) => {
   const addFilter = (field: string, value: string) => {
     if (AVAILABLE_FILTERS.some((filter) => filter.field === field)) {
       searchParams.set(field, value)
+
+      // Reset page param if set, when filters are updated
+      if (searchParams.has(SEARCH_PARAM_KEY_PAGE)) {
+        searchParams.delete(SEARCH_PARAM_KEY_PAGE)
+      }
+
       setSearchParams(searchParams)
     }
   }
@@ -148,6 +155,12 @@ export const useFilters = (defaultFilters?: { [field: string]: string }) => {
   const clearFilter = (field: string) => {
     if (AVAILABLE_FILTERS.some((filter) => filter.field === field)) {
       searchParams.delete(field)
+
+      // Reset page param if set, when filters are updated
+      if (searchParams.has(SEARCH_PARAM_KEY_PAGE)) {
+        searchParams.delete(SEARCH_PARAM_KEY_PAGE)
+      }
+
       setSearchParams(searchParams)
     }
   }

--- a/ui/src/utils/usePagination.ts
+++ b/ui/src/utils/usePagination.ts
@@ -39,7 +39,7 @@ const useSearchParam = ({
   return { value, setValue, resetValue }
 }
 
-export const usePagination = ({ perPage }: { perPage?: number } = {}) => {
+const usePagination = ({ perPage }: { perPage?: number } = {}) => {
   const {
     value: page,
     setValue: setPage,
@@ -58,3 +58,5 @@ export const usePagination = ({ perPage }: { perPage?: number } = {}) => {
     setPage,
   }
 }
+
+export { SEARCH_PARAM_KEY_PAGE, usePagination }

--- a/ui/src/utils/usePagination.ts
+++ b/ui/src/utils/usePagination.ts
@@ -29,18 +29,22 @@ const useSearchParam = ({
     }
   }
 
-  const clearValue = () => {
+  const resetValue = () => {
     if (searchParams.has(key)) {
       searchParams.delete(key)
       setSearchParams(searchParams)
     }
   }
 
-  return { value, setValue, clearValue }
+  return { value, setValue, resetValue }
 }
 
 export const usePagination = ({ perPage }: { perPage?: number } = {}) => {
-  const { value: page, setValue: setPage } = useSearchParam({
+  const {
+    value: page,
+    setValue: setPage,
+    resetValue: resetPage,
+  } = useSearchParam({
     key: SEARCH_PARAM_KEY_PAGE,
     defaultValue: DEFAULT_PAGINATION.page,
   })
@@ -50,6 +54,7 @@ export const usePagination = ({ perPage }: { perPage?: number } = {}) => {
       page,
       perPage: perPage ?? DEFAULT_PAGINATION.perPage,
     },
+    resetPage,
     setPage,
   }
 }


### PR DESCRIPTION
## Summary

@mihow noticed that if a user is inspecting records from a different page than then first page, the page settings will remain when the filtering is updated. This can be a bit confusing, especially if data is no longer visible for the current page.

In this PR, we reset the current page when filters are modified from the UI. We also update the empty state component to consider page settings. To see no data because the current page is not the first page should be an edge case now, but it can still happen if page is set from URL.

## Detailed Description

### Screenshots
No data and page is not first page (see URL):
<img width="1728" alt="Screenshot 2025-05-19 at 11 23 59" src="https://github.com/user-attachments/assets/2f132547-25db-44ac-ac46-93e389d14a23" />

No data and filters are set:
<img width="1728" alt="Screenshot 2025-05-19 at 11 27 41" src="https://github.com/user-attachments/assets/272fa5eb-e7d5-48d3-8717-31bdca8484a7" />

No data:
<img width="1728" alt="Screenshot 2025-05-19 at 11 28 23" src="https://github.com/user-attachments/assets/05cdc371-33fc-4529-9910-d5e4cd1f36aa" />