### PR TITLE
Add best score filtering and column settings support

### DIFF
--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -786,6 +786,7 @@ class TaxonSerializer(DefaultSerializer):
             "cover_image_url",
             "cover_image_credit",
             "unknown_species",
+            "best_determination_score",
         ]
 
     def get_cover_image_url(self, obj):

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1229,6 +1229,9 @@ class TagInverseFilter(filters.BaseFilterBackend):
         return queryset.distinct()
 
 
+TaxonBestScoreFilter = ThresholdFilter.create("best_determination_score")
+
+
 class TaxonViewSet(DefaultViewSet, ProjectMixin):
     """
     API endpoint that allows taxa to be viewed or edited.
@@ -1241,6 +1244,7 @@ class TaxonViewSet(DefaultViewSet, ProjectMixin):
         TaxonCollectionFilter,
         TaxonTaxaListFilter,
         TaxonUnknownSpeciesFilter,
+        TaxonBestScoreFilter,
         TaxonTagFilter,
         TagInverseFilter,
     ]

--- a/ui/src/components/determination-score.tsx
+++ b/ui/src/components/determination-score.tsx
@@ -1,0 +1,28 @@
+import { BasicTooltip } from 'design-system/components/tooltip/basic-tooltip'
+import { IdentificationScore } from 'nova-ui-kit'
+import { STRING, translate } from 'utils/language'
+
+export const DeterminationScore = ({
+  confirmed,
+  score,
+  scoreLabel,
+  tooltip,
+}: {
+  confirmed?: boolean
+  score?: number
+  scoreLabel?: string
+  tooltip?: string
+}) => {
+  if (score === undefined || scoreLabel === undefined) {
+    return <span>{translate(STRING.VALUE_NOT_AVAILABLE)}</span>
+  }
+
+  return (
+    <BasicTooltip content={tooltip}>
+      <div className="flex items-center gap-3">
+        <IdentificationScore confirmed={confirmed} confidenceScore={score} />
+        <span>{scoreLabel}</span>
+      </div>
+    </BasicTooltip>
+  )
+}

--- a/ui/src/components/filtering/filter-control.tsx
+++ b/ui/src/components/filtering/filter-control.tsx
@@ -25,6 +25,7 @@ const ComponentMap: {
   [key: string]: (props: FilterProps) => JSX.Element
 } = {
   algorithm: AlgorithmFilter,
+  best_determination_score: ScoreFilter,
   classification_threshold: ScoreFilter,
   determination_ood_score: OODScoreFilter,
   collection: CollectionFilter,

--- a/ui/src/data-services/models/occurrence.ts
+++ b/ui/src/data-services/models/occurrence.ts
@@ -67,14 +67,16 @@ export class Occurrence {
     return determinationPrediction ? `${determinationPrediction.id}` : undefined
   }
 
-  get determinationScore(): number {
+  get determinationScore(): number | undefined {
     const score = this._occurrence.determination_details.score
 
-    if (!score) {
-      return 0
+    if (score || score === 0) {
+      return score
     }
 
-    return this._occurrence.determination_score
+    if (!score) {
+      return undefined
+    }
   }
 
   get determinationOODScore(): number | undefined {
@@ -87,8 +89,12 @@ export class Occurrence {
     return undefined
   }
 
-  get determinationScoreLabel(): string {
-    return this.determinationScore.toFixed(2)
+  get determinationScoreLabel(): string | undefined {
+    if (this.determinationScore !== undefined) {
+      return this.determinationScore.toFixed(2)
+    }
+
+    return undefined
   }
 
   get determinationOODScoreLabel(): string | undefined {

--- a/ui/src/data-services/models/species.ts
+++ b/ui/src/data-services/models/species.ts
@@ -77,12 +77,22 @@ export class Species extends Taxon {
     return `https://leps.fieldguide.ai/categories?category=${this._species.fieldguide_id}`
   }
 
-  get score(): number {
-    return this._species.best_determination_score || 0
+  get score(): number | undefined {
+    const score = this._species.best_determination_score
+
+    if (score || score === 0) {
+      return score
+    }
+
+    return undefined
   }
 
-  get scoreLabel(): string {
-    return this.score.toFixed(2)
+  get scoreLabel(): string | undefined {
+    if (this.score !== undefined) {
+      return this.score.toFixed(2)
+    }
+
+    return undefined
   }
 
   get tags(): Tag[] {

--- a/ui/src/pages/occurrence-details/occurrence-details.tsx
+++ b/ui/src/pages/occurrence-details/occurrence-details.tsx
@@ -147,22 +147,24 @@ export const OccurrenceDetails = ({
           taxon={occurrence.determinationTaxon}
         />
         <div className={styles.taxonActions}>
-          <BasicTooltip
-            content={
-              occurrence.determinationVerified
-                ? translate(STRING.VERIFIED_BY, {
-                    name: occurrence.determinationVerifiedBy?.name,
-                  })
-                : translate(STRING.MACHINE_PREDICTION_SCORE, {
-                    score: `${occurrence.determinationScore}`,
-                  })
-            }
-          >
-            <IdentificationScore
-              confirmed={occurrence.determinationVerified}
-              confidenceScore={occurrence.determinationScore}
-            />
-          </BasicTooltip>
+          {occurrence.determinationScore !== undefined ? (
+            <BasicTooltip
+              content={
+                occurrence.determinationVerified
+                  ? translate(STRING.VERIFIED_BY, {
+                      name: occurrence.determinationVerifiedBy?.name,
+                    })
+                  : translate(STRING.MACHINE_PREDICTION_SCORE, {
+                      score: `${occurrence.determinationScore}`,
+                    })
+              }
+            >
+              <IdentificationScore
+                confirmed={occurrence.determinationVerified}
+                confidenceScore={occurrence.determinationScore}
+              />
+            </BasicTooltip>
+          ) : null}
           {canUpdate && (
             <>
               <Agree

--- a/ui/src/pages/occurrences/occurrence-columns.tsx
+++ b/ui/src/pages/occurrences/occurrence-columns.tsx
@@ -1,3 +1,4 @@
+import { DeterminationScore } from 'components/determination-score'
 import { OODScore } from 'components/ood-score'
 import { Occurrence } from 'data-services/models/occurrence'
 import { BasicTableCell } from 'design-system/components/table/basic-table-cell/basic-table-cell'
@@ -8,8 +9,7 @@ import {
   TableColumn,
   TextAlign,
 } from 'design-system/components/table/types'
-import { BasicTooltip } from 'design-system/components/tooltip/basic-tooltip'
-import { IdentificationScore, TaxonDetails } from 'nova-ui-kit'
+import { TaxonDetails } from 'nova-ui-kit'
 import { Agree } from 'pages/occurrence-details/agree/agree'
 import { IdQuickActions } from 'pages/occurrence-details/reject-id/id-quick-actions'
 import { SuggestIdPopover } from 'pages/occurrence-details/suggest-id/suggest-id-popover'
@@ -69,7 +69,24 @@ export const columns: (
     id: 'score',
     name: translate(STRING.FIELD_LABEL_SCORE),
     sortField: 'determination_score',
-    renderCell: (item: Occurrence) => <ScoreCell item={item} />,
+    renderCell: (item: Occurrence) => (
+      <BasicTableCell>
+        <DeterminationScore
+          confirmed={item.determinationVerified}
+          score={item.determinationScore}
+          scoreLabel={item.determinationScoreLabel}
+          tooltip={
+            item.determinationVerified
+              ? translate(STRING.VERIFIED_BY, {
+                  name: item.determinationVerifiedBy?.name,
+                })
+              : translate(STRING.MACHINE_PREDICTION_SCORE, {
+                  score: `${item.determinationScore}`,
+                })
+          }
+        />
+      </BasicTableCell>
+    ),
   },
   {
     id: 'ood-score',
@@ -210,31 +227,3 @@ const TaxonCell = ({
     </div>
   )
 }
-
-const ScoreCell = ({ item }: { item: Occurrence }) => (
-  <div className={styles.scoreCell}>
-    <BasicTableCell>
-      <BasicTooltip
-        content={
-          item.determinationVerified
-            ? translate(STRING.VERIFIED_BY, {
-                name: item.determinationVerifiedBy?.name,
-              })
-            : translate(STRING.MACHINE_PREDICTION_SCORE, {
-                score: `${item.determinationScore}`,
-              })
-        }
-      >
-        <div className={styles.scoreCellContent}>
-          <IdentificationScore
-            confirmed={item.determinationVerified}
-            confidenceScore={item.determinationScore}
-          />
-          <span className={styles.scoreCellLabel}>
-            {item.determinationScoreLabel}
-          </span>
-        </div>
-      </BasicTooltip>
-    </BasicTableCell>
-  </div>
-)

--- a/ui/src/pages/occurrences/occurrences.module.scss
+++ b/ui/src/pages/occurrences/occurrences.module.scss
@@ -16,18 +16,3 @@
     gap: 8px;
   }
 }
-
-.scoreCell {
-  .scoreCellContent {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    gap: 12px;
-  }
-
-  .scoreCellLabel {
-    display: block;
-    @include paragraph-medium();
-    color: $color-neutral-700;
-  }
-}

--- a/ui/src/pages/species-details/new-unknown-species-button.tsx
+++ b/ui/src/pages/species-details/new-unknown-species-button.tsx
@@ -1,6 +1,6 @@
 import { useCreateSpecies } from 'data-services/hooks/species/useCreateSpecies'
-import { Loader2Icon, PlusIcon } from 'lucide-react'
-import { Button } from 'nova-ui-kit'
+import { Button } from 'design-system/components/button/button'
+import { IconType } from 'design-system/components/icon/icon'
 import { useNavigate, useParams } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
@@ -24,6 +24,9 @@ export const NewUnknownSpeciesButton = () => {
 
   return (
     <Button
+      icon={IconType.Plus}
+      label={translate(STRING.ENTITY_CREATE, { type: 'cluster' })}
+      loading={isLoading}
       onClick={() =>
         createSpecies({
           projectId: projectId as string,
@@ -32,16 +35,6 @@ export const NewUnknownSpeciesButton = () => {
           unknownSpecies: true,
         })
       }
-      size="small"
-      variant="outline"
-    >
-      <PlusIcon className="w-4 h-4" />
-      <span>
-        {translate(STRING.ENTITY_CREATE, {
-          type: 'cluster',
-        })}
-      </span>
-      {isLoading ? <Loader2Icon className="w-4 h-4 ml-2 animate-spin" /> : null}
-    </Button>
+    />
   )
 }

--- a/ui/src/pages/species-details/species-details.tsx
+++ b/ui/src/pages/species-details/species-details.tsx
@@ -1,4 +1,5 @@
 import { BlueprintCollection } from 'components/blueprint-collection/blueprint-collection'
+import { DeterminationScore } from 'components/determination-score'
 import { Tag } from 'components/taxon-tags/tag'
 import { TagsForm } from 'components/taxon-tags/tags-form'
 import { SpeciesDetails as Species } from 'data-services/models/species-details'
@@ -111,6 +112,19 @@ export const SpeciesDetails = ({ species }: { species: Species }) => {
                   }),
                   filters: { taxon: species.id },
                 })}
+              />
+            </InfoBlockField>
+            <InfoBlockField label={translate(STRING.FIELD_LABEL_BEST_SCORE)}>
+              <DeterminationScore
+                score={species.score}
+                scoreLabel={species.scoreLabel}
+                tooltip={
+                  species.score
+                    ? translate(STRING.MACHINE_PREDICTION_SCORE, {
+                        score: `${species.score}`,
+                      })
+                    : undefined
+                }
               />
             </InfoBlockField>
             {hasResources ? (

--- a/ui/src/pages/species/species-columns.tsx
+++ b/ui/src/pages/species/species-columns.tsx
@@ -94,7 +94,7 @@ export const columns: (projectId: string) => TableColumn<Species>[] = (
     ),
   },
   {
-    id: 'best_determination_score',
+    id: 'best-determination-score',
     name: translate(STRING.FIELD_LABEL_BEST_SCORE),
     sortField: 'best_determination_score',
     renderCell: (item: Species) => (

--- a/ui/src/pages/species/species-columns.tsx
+++ b/ui/src/pages/species/species-columns.tsx
@@ -1,3 +1,4 @@
+import { DeterminationScore } from 'components/determination-score'
 import { Tag } from 'components/taxon-tags/tag'
 import { Species } from 'data-services/models/species'
 import { BasicTableCell } from 'design-system/components/table/basic-table-cell/basic-table-cell'
@@ -90,6 +91,22 @@ export const columns: (projectId: string) => TableColumn<Species>[] = (
       >
         <BasicTableCell value={item.numOccurrences} theme={CellTheme.Bubble} />
       </Link>
+    ),
+  },
+  {
+    id: 'best_determination_score',
+    name: translate(STRING.FIELD_LABEL_BEST_SCORE),
+    sortField: 'best_determination_score',
+    renderCell: (item: Species) => (
+      <BasicTableCell>
+        <DeterminationScore
+          score={item.score}
+          scoreLabel={item.scoreLabel}
+          tooltip={translate(STRING.MACHINE_PREDICTION_SCORE, {
+            score: `${item.score}`,
+          })}
+        />
+      </BasicTableCell>
     ),
   },
   {

--- a/ui/src/pages/species/species.tsx
+++ b/ui/src/pages/species/species.tsx
@@ -9,6 +9,7 @@ import { IconType } from 'design-system/components/icon/icon'
 import { PageFooter } from 'design-system/components/page-footer/page-footer'
 import { PageHeader } from 'design-system/components/page-header/page-header'
 import { PaginationBar } from 'design-system/components/pagination-bar/pagination-bar'
+import { ColumnSettings } from 'design-system/components/table/column-settings/column-settings'
 import { Table } from 'design-system/components/table/table/table'
 import { ToggleGroup } from 'design-system/components/toggle-group/toggle-group'
 import { NewUnknownSpeciesButton } from 'pages/species-details/new-unknown-species-button'
@@ -19,9 +20,11 @@ import { BreadcrumbContext } from 'utils/breadcrumbContext'
 import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
+import { useColumnSettings } from 'utils/useColumnSettings'
 import { useFilters } from 'utils/useFilters'
 import { usePagination } from 'utils/usePagination'
 import { UserPermission } from 'utils/user/types'
+import { useUserPreferences } from 'utils/userPreferences/userPreferencesContext'
 import { useSelectedView } from 'utils/useSelectedView'
 import { useSort } from 'utils/useSort'
 import { columns } from './species-columns'
@@ -29,9 +32,22 @@ import { SpeciesGallery } from './species-gallery'
 
 export const Species = () => {
   const { projectId, id } = useParams()
+  const { columnSettings, setColumnSettings } = useColumnSettings('species', {
+    'cover-image': true,
+    name: true,
+    rank: true,
+    'last-seen': true,
+    occurrences: true,
+    'best-determination-score': true,
+    'created-at': true,
+    'updated-at': true,
+  })
+  const { userPreferences } = useUserPreferences()
   const { sort, setSort } = useSort({ field: 'name', order: 'asc' })
   const { pagination, setPage } = usePagination()
-  const { filters } = useFilters()
+  const { filters } = useFilters({
+    best_detection_score: `${userPreferences.scoreThreshold}`,
+  })
   const { species, total, isLoading, isFetching, error, userPermissions } =
     useSpecies({
       projectId,
@@ -84,11 +100,18 @@ export const Species = () => {
               value={selectedView}
               onValueChange={setSelectedView}
             />
+            <ColumnSettings
+              columns={columns(projectId as string)}
+              columnSettings={columnSettings}
+              onColumnSettingsChange={setColumnSettings}
+            />
             {canCreate ? <NewUnknownSpeciesButton /> : null}
           </PageHeader>
           {selectedView === 'table' && (
             <Table
-              columns={columns(projectId as string)}
+              columns={columns(projectId as string).filter(
+                (column) => !!columnSettings[column.id]
+              )}
               error={error}
               isLoading={!id && isLoading}
               items={species}

--- a/ui/src/pages/species/species.tsx
+++ b/ui/src/pages/species/species.tsx
@@ -54,9 +54,9 @@ export const Species = () => {
           {taxaLists.length > 0 && (
             <FilterControl data={taxaLists} field="taxa_list_id" />
           )}
+          <FilterControl clearable={false} field="best_determination_score" />
           <FilterControl data={tags} field="include_unobserved" />
           <FilterControl field="unknown_species" />
-          <FilterControl data={tags} field="tag_id" />
           <FilterControl data={tags} field="not_tag_id" />
         </FilterSection>
         <div className="w-full overflow-hidden">

--- a/ui/src/utils/useFilters.ts
+++ b/ui/src/utils/useFilters.ts
@@ -132,6 +132,10 @@ export const AVAILABLE_FILTERS: {
     label: 'Show unobserved taxa',
     field: 'include_unobserved',
   },
+  {
+    label: 'Best score threshold',
+    field: 'best_determination_score',
+  },
 ]
 
 export const useFilters = (defaultFilters?: { [field: string]: string }) => {


### PR DESCRIPTION
## Summary

Add support for:
- Present best determination score for taxa in UI
- Add best score filter for taxa
- Add column settings support in taxa view

## Screenshots

<img width="1728" alt="Screenshot 2025-05-23 at 00 03 10" src="https://github.com/user-attachments/assets/80e86d01-1936-4951-b65a-b51d9f8f8991" />