### PR TITLE
Fix missing example images after clustering

### DIFF
--- a/ami/ml/models/pipeline.py
+++ b/ami/ml/models/pipeline.py
@@ -781,6 +781,9 @@ def create_and_update_occurrences_for_detections(
                 "determination",
                 "determination_score",
                 "determination_ood_score",
+                "best_detection",
+                "best_prediction",
+                "best_identification",
                 "updated_at",
             ],
         )


### PR DESCRIPTION
## Summary

Make sure best_detection and other fields are saved in the bulk update after clusters are created.

<img width="645" alt="image" src="https://github.com/user-attachments/assets/5ac67736-eca9-4ed9-96fb-4b4db8cf35bc" />

