### PR TITLE
Filter out occurrences without determination

### DIFF
--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1118,7 +1118,9 @@ class OccurrenceViewSet(DefaultViewSet, ProjectMixin):
         qs = qs.with_detections_count().with_timestamps()  # type: ignore
         qs = qs.with_identifications()  # type: ignore
 
-        if self.action != "list":
+        if self.action == "list":
+            qs = qs.has_determination()  # type: ignore
+        else:
             qs = qs.prefetch_related(
                 Prefetch(
                     "detections", queryset=Detection.objects.order_by("-timestamp").select_related("source_image")

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -2235,6 +2235,12 @@ class OccurrenceQuerySet(models.QuerySet["Occurrence"]):
     def valid(self):
         return self.exclude(detections__isnull=True)
 
+    def has_determination(self):
+        """
+        Filter out occurrences that are missing a determination.
+        """
+        return self.filter(determination__isnull=False)
+
     def with_detections_count(self):
         return self.annotate(detections_count=models.Count("detections", distinct=True))
 


### PR DESCRIPTION
## Summary

Occurrences are missing determinations when they are first created for a short while and that breaks the occurrence list view momentarily. This filters out occurrences from the list view API that don't have a determination. The detail view will still render. 

<img width="814" alt="image" src="https://github.com/user-attachments/assets/b2c8eb2f-c30e-4200-b2c3-87fb4062f888" />

<img width="818" alt="image" src="https://github.com/user-attachments/assets/6324337b-1518-4d2d-b5ff-bbdd41b3ba6a" />

