### PR TITLE
Fix permission denied errors when accessing local files

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -28,13 +28,13 @@ services:
     command: /start-celeryworker
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
     command: minio server --console-address ":9001" /data
     env_file:
       - ./.envs/.ci/.django
 
   minio-init:
-    image: minio/mc
+    image: minio/mc:RELEASE.2025-03-12T17-29-24Z
     env_file:
       - ./.envs/.ci/.django
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
       - ./data/flower/:/data/
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
     command: minio server --console-address ":9001" /data
     volumes:
       - "minio_data:/data"
@@ -134,7 +134,7 @@ services:
       - minio
 
   minio-init:
-    image: minio/mc
+    image: minio/mc:RELEASE.2025-03-12T17-29-24Z
     env_file:
       - ./.envs/.local/.django
     depends_on:


### PR DESCRIPTION
## Summary

Test files were suddenly getting permission denied errors in the test suite and in any development environments that were recently created. This is because MinIO made some updates that broke our script that sets the test/local buckets to public after they are created. This PR pins MinIO to the last known working version. Further work should be done to update the commands and keep up-to-date with MinIO, but pinning the versions is a good idea nevertheless.

## Deployment Notes

To fix this locally, run `docker compose pull minio minio-init` and then `docker compose up -d`. The changes do not apply to the production or staging environments because they used a hosted object storage service. If you haven't updated your Docker compose environment in a few months, then you shouldn't have run into this issue.

## Checklist

- [x] I have tested these changes appropriately.
- [x] I have added and/or modified relevant tests.
- [x] I updated relevant documentation or comments.
- [x] I have verified that this PR follows the project's coding standards.
- [x] Any dependent changes have already been merged to main.
