### PR TITLE
Check export job status instead of progress

### DIFF
--- a/ui/src/pages/export-details/export-details-dialog.tsx
+++ b/ui/src/pages/export-details/export-details-dialog.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import { FormRow, FormSection } from 'components/form/layout/layout'
 import { useExportDetails } from 'data-services/hooks/exports/useExportDetails'
 import { Export } from 'data-services/models/export'
+import { JobStatusType } from 'data-services/models/job'
 import * as Dialog from 'design-system/components/dialog/dialog'
 import { InputContent, InputValue } from 'design-system/components/input/input'
 import inputStyles from 'design-system/components/input/input.module.scss'
@@ -124,7 +125,8 @@ const ExportDetailsContent = ({ exportDetails }: { exportDetails: Export }) => {
       </FormSection>
       <FormSection title={translate(STRING.FIELD_LABEL_RESULT)}>
         <div>
-          {exportDetails.job && exportDetails.job.progress.value !== 1 ? (
+          {exportDetails.job &&
+          exportDetails.job.status.type !== JobStatusType.Success ? (
             <StatusBar
               color={exportDetails.job.status.color}
               progress={exportDetails.job.progress.value}

--- a/ui/src/pages/project/exports/exports-columns.tsx
+++ b/ui/src/pages/project/exports/exports-columns.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames'
 import { API_ROUTES } from 'data-services/constants'
 import { Export } from 'data-services/models/export'
+import { JobStatusType } from 'data-services/models/job'
 import { StatusBar } from 'design-system/components/status/status-bar'
 import { BasicTableCell } from 'design-system/components/table/basic-table-cell/basic-table-cell'
 import {
@@ -45,7 +46,7 @@ export const columns: (projectId: string) => TableColumn<Export>[] = (
     name: translate(STRING.FIELD_LABEL_RESULT),
     renderCell: (item: Export) => (
       <BasicTableCell>
-        {item.job && item.job.progress.value !== 1 ? (
+        {item.job && item.job.status.type !== JobStatusType.Success ? (
           <div className="w-min">
             <StatusBar
               color={item.job.status.color}


### PR DESCRIPTION
## Summary

Before my latest demo I realized that export jobs are sometimes done, even though the job progress is not updated to 100%. In situations like this, the effect was download links were not presented in UI.

In this PR we include a small fix I added for the demo. We check the job status instead of the progress, to know when the job can be considered as done. It would still be nice if progress and status values were in sync, but a less urgent problem now.

## Screenshots

Before (this job is actually finished):
<img width="1728" height="1117" alt="Screenshot 2025-08-13 at 09 35 04" src="https://github.com/user-attachments/assets/a2fdab21-98bd-4c76-92bb-d5928b0f3a38" />

After:
<img width="1728" height="1117" alt="Screenshot 2025-08-13 at 09 35 57" src="https://github.com/user-attachments/assets/6a2d010f-124e-4c02-aa63-b45daac1c0e2" />

