### PR TITLE
fix: ML processing that is causing jobs to fail for medium-large jobs (issue #782)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Remote Attach",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Platform for processing and reviewing images from automated insect monitoring st
 
 Antenna uses [Docker](https://docs.docker.com/get-docker/) & [Docker Compose](https://docs.docker.com/compose/install/) to run all services locally for development.
 
-1) Install Docker for your host operating (Linux, macOS, Windows)
+1) Install Docker for your host operating (Linux, macOS, Windows). Docker Compose `v2.38.2` or later recommended.
 
 2) Add the following to your `/etc/hosts` file in order to see and process the demo source images. This makes the hostname `minio` and `django` alias for `localhost` so the same image URLs can be viewed in the host machine's web browser and be processed by the ML services. This can be skipped if you are using an external image storage service.
 
@@ -24,6 +24,7 @@ Antenna uses [Docker](https://docs.docker.com/get-docker/) & [Docker Compose](ht
     docker compose logs -f django celeryworker ui
     # Ctrl+c to close the logs
 ```
+NOTE: If you see docker build errors such as `At least one invalid signature was encountered`, these could happen if docker runs out of space. Commands like `docker image prune -f` and `docker system prune` can be helpful to clean up space.
 
 3) Optionally, run additional ML processing services: `processing_services` defines ML backends which wrap detections in our FastAPI response schema. The `example` app demos how to add new pipelines, algorithms, and models. See the detailed instructions in `processing_services/README.md`.
 
@@ -32,12 +33,15 @@ docker compose -f processing_services/example/docker-compose.yml up -d
 # Once running, in Antenna register a new processing service called: http://ml_backend_example:2000
 ```
 
-4) Access the platform the following URLs:
+4) Access the platform with the following URLs:
 
 - Primary web interface: http://localhost:4000
 - API browser: http://localhost:8000/api/v2/
 - Django admin: http://localhost:8000/admin/
 - OpenAPI / Swagger documentation: http://localhost:8000/api/v2/docs/
+- Minio UI: http://minio:9001, Minio service: http://minio:9000
+
+NOTE: If one of these services is not working properly, it could be due another process is using the port. You can check for this with `lsof -i :<PORT_NUMBER>`.
 
 A default user will be created with the following credentials. Use these to log into the web UI or the Django admin.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,12 @@ services:
     scale: 1
     ports: []
     command: /start-celeryworker
+    # For remote debugging with debugpy
+    # Uncomment the following lines and adjust the port if needed.
+    # Also make sure to install debugpy in your requirements/local.txt
+    # ports:
+    #   - "5678:5678"
+    # command: python -m debugpy --listen 0.0.0.0:5678 -m celery -A config.celery_app worker -l INFO
 
   celerybeat:
     <<: *django

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,14 +89,11 @@ services:
     <<: *django
     image: ami_local_celeryworker
     scale: 1
-    ports: []
-    command: /start-celeryworker
-    # For remote debugging with debugpy
-    # Uncomment the following lines and adjust the port if needed.
+    # For remote debugging with debugpy, should get overridden for production
     # Also make sure to install debugpy in your requirements/local.txt
-    # ports:
-    #   - "5678:5678"
-    # command: python -m debugpy --listen 0.0.0.0:5678 -m celery -A config.celery_app worker -l INFO
+    ports:
+      - "5678:5678"
+    command: python -m debugpy --listen 0.0.0.0:5678 -m celery -A config.celery_app worker -l INFO
 
   celerybeat:
     <<: *django

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,2 +1,2 @@
 -r base.txt
-# debugpy # For remote debugging with debugpy
+debugpy # For remote debugging with debugpy

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,1 +1,2 @@
 -r base.txt
+# debugpy # For remote debugging with debugpy


### PR DESCRIPTION
## Summary

Avoid adding JobLogHandlers multiple times during the `logger` property access

### List of Changes

* Added check in `ami/jobs/models.py`
* Update README with some notes on running antenna for the first time
* Added configuration for attached the VS Code debugger to the `celeryworker`

### Related Issues

Fixes #782 

## Detailed Description

I was watching the queue worker logs (celery), and I noticed what appeared to be many repeated entries. E.g.:
```
celeryworker-1  | [2025-08-26 18:00:09,068: INFO/ForkPoolWorker-7] Processing image batch 76 of 367
celeryworker-1  | [2025-08-26 18:00:09,075: INFO/ForkPoolWorker-7] Processing image batch 76 of 367
celeryworker-1  | [2025-08-26 18:00:09,082: INFO/ForkPoolWorker-7] Processing image batch 76 of 367
celeryworker-1  | [2025-08-26 18:00:09,089: INFO/ForkPoolWorker-7] Processing image batch 76 of 367
celeryworker-1  | [2025-08-26 18:00:09,095: INFO/ForkPoolWorker-7] Processing image batch 76 of 367
celeryworker-1  | [2025-08-26 18:00:09,102: INFO/ForkPoolWorker-7] Processing image batch 76 of 367
celeryworker-1  | [2025-08-26 18:00:09,109: INFO/ForkPoolWorker-7] Processing image batch 76 of 367
celeryworker-1  | [2025-08-26 18:00:09,115: INFO/ForkPoolWorker-7] Processing image batch 76 of 367
celeryworker-1  | [2025-08-26 18:00:09,122: INFO/ForkPoolWorker-7] Processing image batch 76 of 367
celeryworker-1  | [2025-08-26 18:00:09,129: INFO/ForkPoolWorker-7] Processing image batch 76 of 367
```

Furthermore, the number of entries increased by 7 on each iteration:
```
(base) ➜  antenna git:(main) ✗ cat worker.log| grep "Processing image batch 76 of 367" | sort | uniq | wc
     530    5830   53000
(base) ➜  antenna git:(main) ✗ cat worker.log| grep "Processing image batch 77 of 367" | sort | uniq | wc
     537    5907   53700
(base) ➜  antenna git:(main) ✗ cat worker.log| grep "Processing image batch 78 of 367" | sort | uniq | wc
     544    5984   54400
(base) ➜  antenna git:(main) ✗ cat worker.log| grep "Processing image batch 79 of 367" | sort | uniq | wc
     551    6061   55100
(base) ➜  antenna git:(main) ✗ cat worker.log| grep "Processing image batch 80 of 367" | sort | uniq | wc
     558    6138   55800
```

The problem is that the `.logger` property on the `Job` adds a `JobLogHandler`  when read. Since this property is accessed ~7 times per iteration in the job logic, there are 7 handlers added per iteration. This means that every time the code logs, each of these handlers gets called and this number grows as 7n^2 . Since these JobLogHandler objects write to the DB, there are  7n^2 writes happening. At some point this slows to a crawl and the bigger the job the slower it gets.

### How to Test the Changes

Running processing jobs with 300+ images.

### Screenshots

Successful job processing 369 images in ~6 mins. Prior to the change the job ran for over an hour and was not even half-way done.

<img width="701" height="550" alt="image" src="https://github.com/user-attachments/assets/540bc0e5-9265-4d7b-9b05-1d3d58c34370" />

## Checklist

- [x] I have tested these changes appropriately.
- [ ] I have added and/or modified relevant tests.
- [x] I updated relevant documentation or comments.
- [x] I have verified that this PR follows the project's coding standards.
- [x] Any dependent changes have already been merged to main.
