### PR TITLE
Enable real classifiers in local dev by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,9 +149,9 @@ services:
 
   ml_backend:
     build:
-      context: ./processing_services/minimal
+      context: ./processing_services/example
     volumes:
-      - ./processing_services/minimal/:/app
+      - ./processing_services/example/:/app
     ports:
       - "2005:2000"
     networks:


### PR DESCRIPTION
TODO
- Consider adding global moth model after the zero shot classifier
- Update the constant classifier to return the 4 corners of the image (something static but also useful)