### PR TITLE
Enable API root page & path extensions in production

### DIFF
--- a/config/api_router.py
+++ b/config/api_router.py
@@ -1,8 +1,7 @@
-from django.conf import settings
 from django.urls import path
 from django.urls.conf import include
 from djoser.views import UserViewSet
-from rest_framework.routers import DefaultRouter, SimpleRouter
+from rest_framework.routers import DefaultRouter
 
 from ami.exports import views as export_views
 from ami.jobs import views as job_views

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -10,10 +10,7 @@ from ami.labelstudio import views as labelstudio_views
 from ami.main.api import views
 from ami.ml import views as ml_views
 
-if settings.DEBUG:
-    router = DefaultRouter()
-else:
-    router = SimpleRouter()
+router = DefaultRouter()
 
 router.register(r"users", UserViewSet)
 router.register(r"storage", views.StorageSourceViewSet)


### PR DESCRIPTION
## Summary

Adds two helpful features for using the API that were previously only available in local development:
- Enabling the root / index page to the interactive API docs. (api.antenna.insectai.org/api/v2/)
- Allowing adding `.json` to the end of API urls to force the response to be json instead of the interactive html docs. (api.antenna.insectai.org/api/v2/projects.json)

This will help increase the understanding and usability of the Antenna API, but allowing the self-documenting API pages to show (almost) all endpoints that are available.  

### Screenshots

<img width="1510" height="1278" alt="image" src="https://github.com/user-attachments/assets/0fdd0fbe-2f36-4ccb-afcc-e4246832d7a4" />
<img width="1322" height="808" alt="image" src="https://github.com/user-attachments/assets/e75a6fd3-8f37-4bb7-85d5-39c4c83dc24f" />


