### PR TITLE
fix: add host alias to NATS in production

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -20,6 +20,7 @@ services:
       - "db:${DATABASE_IP}"
       - "rabbitmq:${RABBITMQ_IP}"
       - "redis:${REDIS_IP}"
+      - "nats:${NATS_IP}"
     command: /start
     scale: 1  # Can't scale until the load balancer is within the compose config
     restart: always

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -16,6 +16,7 @@ services:
       - "db:${DATABASE_IP}"
       - "rabbitmq:${RABBITMQ_IP}"
       - "redis:${REDIS_IP}"
+      - "nats:${NATS_IP}"
     command: /start
     scale: 0  # We don't need the Django service running, but we inherit the worker settings from it.
     restart: always


### PR DESCRIPTION
Add missing host alias in docker compose config to allow production web app and workers to connect to external NATS server.