### PR TITLE
PSv2: Improve task fetching & web worker concurrency configuration

### DIFF
--- a/ami/ml/orchestration/nats_queue.py
+++ b/ami/ml/orchestration/nats_queue.py
@@ -42,7 +42,7 @@ async def get_connection(nats_url: str) -> tuple[nats.NATS, JetStreamContext]:
     return nc, js
 
 
-TASK_TTR = 300  # Default Time-To-Run (visibility timeout) in seconds
+TASK_TTR = getattr(settings, "NATS_TASK_TTR", 30)  # Visibility timeout in seconds (configurable)
 
 
 class TaskQueueManager:
@@ -56,8 +56,9 @@ class TaskQueueManager:
             await manager.acknowledge_task(tasks[0].reply_subject)
     """
 
-    def __init__(self, nats_url: str | None = None):
+    def __init__(self, nats_url: str | None = None, max_ack_pending: int | None = None):
         self.nats_url = nats_url or getattr(settings, "NATS_URL", "nats://nats:4222")
+        self.max_ack_pending = max_ack_pending or getattr(settings, "NATS_MAX_ACK_PENDING", 100)
         self.nc: nats.NATS | None = None
         self.js: JetStreamContext | None = None
 
@@ -141,7 +142,7 @@ class TaskQueueManager:
                         ack_wait=TASK_TTR,  # Visibility timeout (TTR)
                         max_deliver=5,  # Max retry attempts
                         deliver_policy=DeliverPolicy.ALL,
-                        max_ack_pending=100,  # Max unacked messages
+                        max_ack_pending=self.max_ack_pending,
                         filter_subject=subject,
                     ),
                 ),

--- a/ami/ml/orchestration/nats_queue.py
+++ b/ami/ml/orchestration/nats_queue.py
@@ -49,6 +49,11 @@ class TaskQueueManager:
     """
     Manager for NATS JetStream task queue operations.
 
+    Args:
+        nats_url: NATS server URL. Falls back to settings.NATS_URL, then "nats://nats:4222".
+        max_ack_pending: Max unacknowledged messages per consumer. Falls back to
+            settings.NATS_MAX_ACK_PENDING, then 100.
+
     Use as an async context manager:
         async with TaskQueueManager() as manager:
             await manager.publish_task(123, {'data': 'value'})
@@ -58,7 +63,9 @@ class TaskQueueManager:
 
     def __init__(self, nats_url: str | None = None, max_ack_pending: int | None = None):
         self.nats_url = nats_url or getattr(settings, "NATS_URL", "nats://nats:4222")
-        self.max_ack_pending = max_ack_pending or getattr(settings, "NATS_MAX_ACK_PENDING", 100)
+        self.max_ack_pending = (
+            max_ack_pending if max_ack_pending is not None else getattr(settings, "NATS_MAX_ACK_PENDING", 100)
+        )
         self.nc: nats.NATS | None = None
         self.js: JetStreamContext | None = None
 

--- a/compose/local/django/start
+++ b/compose/local/django/start
@@ -6,10 +6,26 @@ set -o nounset
 
 python manage.py migrate
 
-# Launch VS Code debug server if DEBUGGER environment variable is set to 1
-# Note that the --reload flag is not compatible with debugpy, so manually restart the server when code changes
+# Set USE_UVICORN=1 to use the original raw uvicorn dev server instead of gunicorn
+if [ "${USE_UVICORN:-0}" = "1" ]; then
+    if [ "${DEBUGGER:-0}" = "1" ]; then
+        exec python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:5678 -m uvicorn config.asgi:application --host 0.0.0.0
+    else
+        exec uvicorn config.asgi:application --host 0.0.0.0 --reload --reload-include '*.html'
+    fi
+fi
+
+# Gunicorn with UvicornWorker (production-parity mode, now the default)
+# WEB_CONCURRENCY controls worker count (default: 1 for dev with auto-reload)
+WORKERS=${WEB_CONCURRENCY:-1}
+
 if [ "${DEBUGGER:-0}" = "1" ]; then
-    exec python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:5678 -m uvicorn config.asgi:application --host 0.0.0.0
+    echo "Starting Gunicorn with debugpy (1 worker)..."
+    exec python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:5678 -m gunicorn config.asgi --bind 0.0.0.0:8000 --workers 1 -k uvicorn.workers.UvicornWorker
+elif [ "$WORKERS" -eq 1 ]; then
+    echo "Starting Gunicorn with 1 worker (auto-reload enabled)..."
+    exec gunicorn config.asgi --bind 0.0.0.0:8000 --workers 1 -k uvicorn.workers.UvicornWorker --reload
 else
-    exec uvicorn config.asgi:application --host 0.0.0.0 --reload --reload-include '*.html'
+    echo "Starting Gunicorn with $WORKERS workers..."
+    exec gunicorn config.asgi --bind 0.0.0.0:8000 --workers "$WORKERS" -k uvicorn.workers.UvicornWorker
 fi

--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -7,10 +7,9 @@ set -o nounset
 python /app/manage.py collectstatic --noinput
 
 # Gunicorn natively reads WEB_CONCURRENCY as its --workers default.
-# If not set, auto-detect based on CPU cores (capped at 8 for async ASGI workers).
+# If not set, default to CPU core count.
 if [ -z "${WEB_CONCURRENCY:-}" ]; then
-    CPU_CORES=$(nproc)
-    export WEB_CONCURRENCY=$(( CPU_CORES > 8 ? 8 : CPU_CORES ))
+    export WEB_CONCURRENCY=$(nproc)
 fi
 
 echo "Starting Gunicorn with $WEB_CONCURRENCY worker(s)..."

--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -6,4 +6,13 @@ set -o nounset
 
 python /app/manage.py collectstatic --noinput
 
+# Gunicorn natively reads WEB_CONCURRENCY as its --workers default.
+# If not set, auto-detect based on CPU cores (capped at 8 for async ASGI workers).
+if [ -z "${WEB_CONCURRENCY:-}" ]; then
+    CPU_CORES=$(nproc)
+    export WEB_CONCURRENCY=$(( CPU_CORES > 8 ? 8 : CPU_CORES ))
+fi
+
+echo "Starting Gunicorn with $WEB_CONCURRENCY worker(s)..."
+
 exec newrelic-admin run-program /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker


### PR DESCRIPTION
## Summary

This pull request introduces performance tuning for the NATS task queue and configurable Gunicorn worker counts.

See: https://github.com/RolnickLab/ami-data-companion/pull/113

Task queue management improvements:

* Added support for configurable `max_ack_pending` in `TaskQueueManager`, allowing customization of the maximum number of unacknowledged tasks per consumer (default: 100, settable via `settings.NATS_MAX_ACK_PENDING`).
* Reduced the default NATS visibility timeout (TASK_TTR) from 300s to 30s, now configurable via `settings.NATS_TASK_TTR`.
* Updated local and production Django start scripts to allow configurable Gunicorn worker counts based on environment variables and CPU cores.

### Changes added but not visible after merging with #1135

These changes were part of the original PR but were superseded by #1135 (`fix/nats-connection-safety`) during rebase:

* Refactored the `reserve_task` method to support batch reservation of tasks (`ntasks` parameter), returning a list of tasks instead of a single task. (Now handled by #1135's `reserve_tasks(count=...)` API.)
* Batch fetching in `views.py` — replaced sequential single-task fetching with batch calls. (Already implemented differently in #1135.)
* Test updates for the batch API. (Superseded by #1135's test suite.)

### Testing

- Validated significant improvements in the task fetching performance via the ami worker

**Test:**
```
docker compose run --rm django python manage.py test_ml_job_e2e "ami-1000" quebec_vermont_moths_2023 --dispatch-mode async_api
```
**Before this change and with current ami worker (sync results)**:
```
✅ Job completed successfully

⏱ Total runtime: 192.54 seconds

📊 Final Results:
  Collect: 100.0% (SUCCESS)
    Total Images: 1000
  Process: 100.0% (SUCCESS)
    Processed: 1000
  Results: 100.0% (SUCCESS)
    Captures: 1000
    Detections: 5626
    Classifications: 5626
```
**Before this change and with https://github.com/RolnickLab/ami-data-companion/pull/113 (async results)**
Across multiple tests ~5% of tasks failed to process and had to be re-delivered by NATS 5 mins later, hence the much longer time.
**TASK_TTR=300**
```
✅ Job completed successfully
⏱ Total runtime: 647.46 seconds
📊 Final Results:
  Collect: 100.0% (SUCCESS)
    Total Images: 1000
  Process: 100.0% (SUCCESS)
    Processed: 1000
  Results: 100.0% (SUCCESS)
    Captures: 1000
    Detections: 5626
    Classifications: 5626
```
Repeated test with lower **TASK_TTR=30**
```
✅ Job completed successfully
⏱ Total runtime: 154.36 seconds
📊 Final Results:
  Collect: 100.0% (SUCCESS)
    Total Images: 1000
  Process: 100.0% (SUCCESS)
    Processed: 1000
  Results: 100.0% (SUCCESS)
    Captures: 1000
    Detections: 5626
    Classifications: 5626
```


**After this change and with https://github.com/RolnickLab/ami-data-companion/pull/113: (no NATS re-delivers)**
```
✅ Job completed successfully
⏱ Total runtime: 102.23 seconds
📊 Final Results:
  Collect: 100.0% (SUCCESS)
    Total Images: 1000
  Process: 100.0% (SUCCESS)
    Processed: 1000
  Results: 100.0% (SUCCESS)
    Captures: 1000
    Detections: 5626
    Classifications: 5626
```
**After this change and with current ami worker**
```
✅ Job completed successfully
⏱ Total runtime: 200.61 seconds
📊 Final Results:
  Collect: 100.0% (SUCCESS)
    Total Images: 1000
  Process: 100.0% (SUCCESS)
    Processed: 1000
  Results: 100.0% (SUCCESS)
    Captures: 1000
    Detections: 5626
    Classifications: 5626
```
#### Performance Summary Table
(seconds)
| Configuration | AMI Sync Results | AMI Async Results |
|---------------|------------------|-------------------|
| **Before this change** | 192.54  | 647.46  (TASK_TTR=300)<br> 154.36  (TASK_TTR=30) |
| **After this change** | 200.61  | 102.23  |


**Dataloader Benchmark**

without changes:
```
python -m trapdata.antenna.benchmark --job-id 98 --num-workers 4 --batch-size 16
Throughput:
  9.82 images/second (total)
```

with changes:
```
python -m trapdata.antenna.benchmark --job-id 97 --num-workers 4 --batch-size 16
Throughput:
  14.88 images/second (total)
```



- Verified in logs the number of workers and that the get created:
```
django-1  | Starting Gunicorn with 48 worker(s)...
django-1  | Starting Gunicorn in production mode with 48 workers...
django-1  | /usr/local/lib/python3.11/site-packages/gunicorn/util.py:25: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
django-1  |   import pkg_resources
django-1  | [2026-02-20 17:29:06 +0000] [1] [INFO] Starting gunicorn 20.1.0
django-1  | [2026-02-20 17:29:06 +0000] [1] [INFO] Listening at: http://0.0.0.0:8000 (1)
django-1  | [2026-02-20 17:29:06 +0000] [1] [INFO] Using worker: uvicorn.workers.UvicornWorker
django-1  | [2026-02-20 17:29:06 +0000] [57] [INFO] Booting worker with pid: 57
django-1  | [2026-02-20 17:29:06 +0000] [58] [INFO] Booting worker with pid: 58
django-1  | [2026-02-20 17:29:06 +0000] [59] [INFO] Booting worker with pid: 59
django-1  | [2026-02-20 17:29:06 +0000] [60] [INFO] Booting worker with pid: 60
django-1  | [2026-02-20 17:29:06 +0000] [61] [INFO] Booting worker with pid: 61
```

## Deployment Notes

Include instructions if this PR requires specific steps for its deployment (database migrations, config changes, etc.)

## Checklist

- [x] I have tested these changes appropriately.
- [x] I have added and/or modified relevant tests.
- [x] I updated relevant documentation or comments.
- [x] I have verified that this PR follows the project's coding standards.
- [x] Any dependent changes have already been merged to main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made task queue acknowledgment capacity configurable (default: 100, via `NATS_MAX_ACK_PENDING`).
  * Reduced NATS visibility timeout from 300s to 30s (configurable via `NATS_TASK_TTR`).
  * Improved local and production startup controls: Gunicorn worker auto-sizing and optional direct dev server mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->