### PR TITLE
fix(jobs): finalize async job when 0 images need processing

### DIFF
--- a/ami/jobs/models.py
+++ b/ami/jobs/models.py
@@ -480,13 +480,12 @@ class MLJob(JobType):
                 return
             # When all stages are already complete (e.g. 0 images to process),
             # finalize the job now since no async results will arrive to trigger completion.
-            # Derive status from stages rather than assuming SUCCESS — a stage could be
-            # in FAILURE if some images were skipped during collection.
             if job.progress.is_complete():
-                has_failure = any(s.status == JobState.FAILURE for s in job.progress.stages)
-                job.update_status(JobState.FAILURE if has_failure else JobState.SUCCESS)
+                has_failure = any(s.status in JobState.failed_states() for s in job.progress.stages)
+                job.update_status(JobState.FAILURE if has_failure else JobState.SUCCESS, save=False)
                 job.finished_at = datetime.datetime.now()
                 job.save()
+                cleanup_async_job_if_needed(job)
         else:
             cls.process_images(job, images)
 

--- a/ami/jobs/models.py
+++ b/ami/jobs/models.py
@@ -478,6 +478,15 @@ class MLJob(JobType):
                 job.finished_at = datetime.datetime.now()
                 job.save()
                 return
+            # When all stages are already complete (e.g. 0 images to process),
+            # finalize the job now since no async results will arrive to trigger completion.
+            # Derive status from stages rather than assuming SUCCESS — a stage could be
+            # in FAILURE if some images were skipped during collection.
+            if job.progress.is_complete():
+                has_failure = any(s.status == JobState.FAILURE for s in job.progress.stages)
+                job.update_status(JobState.FAILURE if has_failure else JobState.SUCCESS)
+                job.finished_at = datetime.datetime.now()
+                job.save()
         else:
             cls.process_images(job, images)
 

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -111,6 +111,37 @@ class TestJobProgress(TestCase):
         self.assertEqual(job.status, initial_status)
         self.assertNotEqual(job.status, JobState.SUCCESS.value)
 
+    def test_async_job_completes_when_zero_images(self):
+        """Job with 0 images to process should finalize immediately, not stay STARTED."""
+        from unittest.mock import patch
+
+        job = Job.objects.create(
+            job_type_key=MLJob.key,
+            project=self.project,
+            name="Test zero images job",
+            pipeline=self.pipeline,
+            source_image_collection=self.source_image_collection,
+            dispatch_mode=JobDispatchMode.ASYNC_API,
+        )
+
+        def mock_queue(job, images):
+            """Simulate queue_images_to_nats with 0 images: sets stages to SUCCESS, returns True."""
+            job.progress.update_stage("process", status=JobState.SUCCESS, progress=1.0)
+            job.progress.update_stage("results", status=JobState.SUCCESS, progress=1.0)
+            job.save()
+            return True
+
+        with (
+            patch.object(job.pipeline, "collect_images", return_value=[]),
+            patch("ami.ml.orchestration.jobs.queue_images_to_nats", side_effect=mock_queue),
+            patch("ami.jobs.tasks.cleanup_async_job_if_needed"),
+        ):
+            job.run()
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobState.SUCCESS.value)
+        self.assertIsNotNone(job.finished_at)
+
     def test_job_status_allows_failure_states_immediately(self):
         """
         Test that FAILURE and REVOKED states bypass the completion guard


### PR DESCRIPTION
## Summary

- When an `async_api` job finds 0 images to process (all already processed by the pipeline), `queue_images_to_nats` correctly sets all stages to SUCCESS, but `MLJob.run()` returns without updating the job-level status
- The job stays `STARTED` forever since no async results will arrive to trigger the completion check in `update_job_progress`
- Fix: check `job.progress.is_complete()` after NATS dispatch and finalize immediately if all stages are already done

Found during demo environment 500/504 investigation. Jobs 18 and 26 on demo both hit this — 0 images to process, stages all SUCCESS, but job stuck at STARTED.

## Test plan

- [ ] Run an async_api job where all images have already been processed by the pipeline
- [ ] Verify job status transitions to SUCCESS (not stuck at STARTED)
- [ ] Verify normal async jobs with images still complete via the NATS result pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed job completion handling for edge cases in async operations, particularly when no images are provided for processing. Jobs now properly determine their final status based on stage results and finalize immediately rather than depending on delayed external callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->