### PR TITLE
fix(celery): update worker concurrency defaults

### DIFF
--- a/.envs/.local/.django
+++ b/.envs/.local/.django
@@ -19,6 +19,11 @@ NATS_URL=nats://nats:4222
 CELERY_FLOWER_USER=QSocnxapfMvzLqJXSsXtnEZqRkBtsmKT
 CELERY_FLOWER_PASSWORD=BEQgmCtgyrFieKNoGTsux9YIye0I7P5Q7vEgfJD2C4jxmtHDetFaE2jhS7K7rxaf
 
+# Celery worker concurrency (prefork pool size).
+# Default in settings is 8. Lower to 2-4 on memory-constrained dev laptops —
+# each prefork worker is a separate Python process with its own DB connection.
+# CELERY_WORKER_CONCURRENCY=4
+
 # RabbitMQ
 CELERY_BROKER_URL=amqp://rabbituser:rabbitpass@rabbitmq:5672/
 CELERY_RESULT_BACKEND=rpc:// # Use RabbitMQ for results backend

--- a/.envs/.production/.django-example
+++ b/.envs/.production/.django-example
@@ -20,6 +20,13 @@ REDIS_URL=redis://redis:6379/0
 # Celery
 # ------------------------------------------------------------------------------
 
+# Worker concurrency (prefork pool size). Settings default is 8.
+# Recommended for production: 16 on an 8-core host — process_nats_pipeline_result
+# and create_detection_images are DB/Redis-bound, so ~2x cpu_count roughly matches
+# observed drain vs ingress on the antenna queue without saturating pgbouncer.
+# Tune higher only after confirming postgres connection-pool headroom.
+CELERY_WORKER_CONCURRENCY=16
+
 # Flower
 CELERY_FLOWER_USER=
 CELERY_FLOWER_PASSWORD=

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -393,6 +393,13 @@ CELERY_REDIS_BACKEND_HEALTH_CHECK_INTERVAL = 30  # Check health every 30s
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 CELERY_WORKER_ENABLE_PREFETCH_COUNT_REDUCTION = True
 
+# Worker concurrency (prefork pool size)
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-concurrency
+# Default when unset is os.cpu_count(), which underutilises this workload because
+# process_nats_pipeline_result is DB/Redis-bound and spends most of its time on I/O.
+# Override via CELERY_WORKER_CONCURRENCY env var per deployment.
+CELERY_WORKER_CONCURRENCY = env.int("CELERY_WORKER_CONCURRENCY", default=16)
+
 # Cancel & return to queue if connection is lost
 # https://docs.celeryq.dev/en/latest/userguide/configuration.html#worker-cancel-long-running-tasks-on-connection-loss
 CELERY_WORKER_CANCEL_LONG_RUNNING_TASKS_ON_CONNECTION_LOSS = True

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -395,10 +395,13 @@ CELERY_WORKER_ENABLE_PREFETCH_COUNT_REDUCTION = True
 
 # Worker concurrency (prefork pool size)
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-concurrency
-# Default when unset is os.cpu_count(), which underutilises this workload because
-# process_nats_pipeline_result is DB/Redis-bound and spends most of its time on I/O.
-# Override via CELERY_WORKER_CONCURRENCY env var per deployment.
-CELERY_WORKER_CONCURRENCY = env.int("CELERY_WORKER_CONCURRENCY", default=16)
+# Celery's own default when unset is os.cpu_count(), which on the production
+# 8-core host produced an 8-process pool that could not keep up with the antenna
+# queue's DB/Redis-bound tasks (process_nats_pipeline_result, create_detection_images).
+# 8 is a conservative default that keeps local/staging/demo memory footprints
+# reasonable (each prefork worker is a separate Python process with imports +
+# DB connection). Production should override to 16 (see .envs/.production/.django-example).
+CELERY_WORKER_CONCURRENCY = env.int("CELERY_WORKER_CONCURRENCY", default=8)
 
 # Cancel & return to queue if connection is lost
 # https://docs.celeryq.dev/en/latest/userguide/configuration.html#worker-cancel-long-running-tasks-on-connection-loss


### PR DESCRIPTION
## Summary

- Add explicit `CELERY_WORKER_CONCURRENCY = env.int("CELERY_WORKER_CONCURRENCY", default=8)` to `config/settings/base.py`, next to the existing `CELERY_WORKER_PREFETCH_MULTIPLIER` / `CELERY_WORKER_ENABLE_PREFETCH_COUNT_REDUCTION` block.
- Overridable per deployment via the `CELERY_WORKER_CONCURRENCY` env var.
- Production should override to **16** — committed as an example in `.envs/.production/.django-example` with guidance.
- Local dev can lower to **2–4** on memory-constrained laptops — guidance added to `.envs/.local/.django`.

## Why

The default celery worker concurrency when the setting is unset is `os.cpu_count()`. On the current production celery worker host (8 cores) this means an 8-process prefork pool. The dominant tasks on the `antenna` queue — `process_nats_pipeline_result` and `create_detection_images` — are DB/Redis-bound rather than CPU-bound: each task spends most of its time waiting on postgres/pgbouncer and Redis round-trips, not crunching numbers.

Direct observation during a high-throughput `async_api` job:

- Queue ingress rate ~640/min (two active jobs with 280–900 images each; redelivery amplifies ingress further when any of the bugs around #1219/#1221 trigger)
- Single-consumer drain rate ~283/min at 8-way concurrency
- Net accumulation ~360/min; the queue grew into the tens of thousands of messages over ~30 min
- Container-level utilisation at 8-way concurrency: ~1.6% CPU, ~1.3 GiB of 29 GiB resident. Plenty of headroom.
- RabbitMQ `consumer_utilisation` on the antenna queue: ~0.0016, i.e. the single AMQP consumer's prefetch window is fully occupied essentially all the time. This is the "worker pool too small" signature, not a broker-side issue.

Raising the prefork pool size directly addresses the bottleneck. A hotfix override of 16 was applied in production via the env var ahead of this PR and confirmed to drain the backlog on the active jobs.

## Why default=8, prod override=16

The previous revision of this PR used `default=16` everywhere. Review flagged the blast radius across local dev laptops and the smaller staging/demo VMs — 16 prefork workers = 16 separate Python processes with imports + persistent DB connections, which is a real memory bump where it isn't needed.

The current default of **8** is Celery's typical out-of-the-box behaviour on an 8-core host (matches `os.cpu_count()` there) and a safer memory footprint everywhere else. Production overrides to **16** via env var — committed as an example in `.envs/.production/.django-example` with the rationale inline. This keeps the bottleneck fix in place where it matters without making every other environment pay for it.

16 is the smallest power-of-2 step above 8 that roughly matches the empirical gap between ingress and drain on the production incident that motivated this PR, without risking pgbouncer saturation. A larger default can be considered once we have measured postgres connection-pool headroom (see "what we still need to verify" below).

## What this does not change

- **Prefetch multiplier** stays at `1` — that was already set and fairness behaviour is unchanged.
- **Routing / queue topology** is unchanged. Splitting the `antenna` queue into a dedicated "ingest fast path" vs "housekeeping / status-check" queue is a larger follow-up, filed separately.
- **Pool class** stays `prefork`. Switching to `gevent` for this queue may give much higher effective concurrency on an IO-bound workload, but every task on this queue would need to be audited for gevent-safety (blocking C extensions, thread-locals in PyTorch paths, etc.) first. Out of scope here.

## Deploy note

The production host is already running with `CELERY_WORKER_CONCURRENCY=16` in its env file from the earlier hotfix — lowering the settings default to 8 does **not** regress prod. Confirm the env var is still set at next deploy; if for any reason it isn't, prod will drop to 8 until the env is fixed.

## What we still need to verify

- Postgres / pgbouncer connection pool usage after deploy — 16 prefork workers × persistent connections should be well within pgbouncer's `default_pool_size`, but worth confirming under load.
- Whether the 16-prod override is still the right ceiling, or whether larger backlogs warrant raising it (gated on pgbouncer headroom).
- Whether this change exposes any new memory-pressure pattern at peak load (current `--max-tasks-per-child=100` / `--max-memory-per-child=2 GiB` already bound each process).

## Related

- #1219 — code-path brittleness that lets a single transient Redis error mark an active job FAILURE and delete state (independent of this PR).
- #1221 — django-redis cache connection keepalive fix that reduces how often the #1219 path triggers (independent of this PR).
- #1231 — code-path fix for #1219 (retry transient Redis errors instead of failing the job).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable worker concurrency setting to control parallel background task processing (default: 8, adjustable via environment variable).

* **Documentation**
  * Included example environment entries for local (commented example: 4) and production (example: 16) configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->