### PR TITLE
fix: retry on Redis blips instead of failing the job

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -661,6 +661,44 @@ docker compose run --rm django python manage.py test_ml_job_e2e \
 
 For monitoring running jobs (Django ORM, REST API, NATS consumer state, Redis counters, worker logs, etc.), see `docs/claude/reference/monitoring-async-jobs.md`.
 
+### Chaos testing async_api jobs (Redis/NATS fault injection)
+
+For changes to the async result handler (`ami/jobs/tasks.py::process_nats_pipeline_result`, `ami/ml/orchestration/async_job_state.py`) or to error-handling around Redis/NATS, the unit tests in `ami/jobs/tests/test_tasks.py` and `ami/ml/tests.py` invoke the Celery task body directly and therefore **do not exercise `autoretry_for`, real Celery retry backoff, or the NATS redelivery boundary**. Use the procedure below to verify those under a live stack.
+
+**Prereqs**: Antenna stack up (`docker compose ps` → django/celeryworker/redis/nats/rabbitmq healthy), ADC worker running for the pipeline under test, and a fresh `SourceImageCollection` on project 18 (existing collections have already-processed detections that `pipeline.filter_processed_images()` will skip).
+
+**Fault injection utilities:**
+
+1. **`chaos_monkey` management command** (`ami/jobs/management/commands/chaos_monkey.py`) — wipes state at runtime:
+   ```bash
+   docker compose exec django python manage.py chaos_monkey flush redis   # FLUSHDB
+   docker compose exec django python manage.py chaos_monkey flush nats    # delete all JetStream streams
+   ```
+   `flush redis` simulates the "job state keys genuinely gone" scenario — `update_state()` returns `None` and the caller takes the terminal-fail path.
+
+2. **One-shot transient `RedisError` via sentinel file** — patch `AsyncJobStateManager.update_state` at the top of the method body to consume `/tmp/inject-redis-fault` and raise `RedisError(...)`. Arm with `docker compose exec celeryworker touch /tmp/inject-redis-fault`. The file auto-removes on first hit, so exactly one task invocation sees the fault; retries succeed. Revert the edit and restart celeryworker after the test. `redis-cli CLIENT KILL TYPE normal` does NOT work for this — django-redis's connection pool transparently reconnects and the raised error is absorbed before `update_state` sees it.
+
+3. **Python-level `redis-py` timeout fault** — set `socket_timeout` low in `CACHES['default']['OPTIONS']` and use `DEBUG SLEEP` on Redis. Heavier setup; only useful for timeout-specific tests.
+
+**Procedure for retry-behaviour validation** (e.g., #1231 and future PRs touching the retry path):
+
+1. Create a fresh 20–50 image collection and populate it (large enough that Process stage takes >10s — time to inject mid-flight).
+2. Arm fault injection (sentinel file for transient test; `chaos_monkey` is run inline for the genuine-loss test).
+3. Start a `Monitor` on celery worker logs filtering for your terminal signals:
+   ```bash
+   docker compose logs celeryworker --since 5s --follow 2>&1 | grep --line-buffered -E \
+     'Transient Redis error|Job state keys not found|process_nats_pipeline_result\[[^]]+\] retry|MaxRetriesExceeded|Changing status of job <JOB_ID>'
+   ```
+4. Kick off the job via `POST /api/v2/jobs/?start_now=true` (or `test_ml_job_e2e`) and poll until `progress.stages[process].progress >= 10%` before injecting the fault.
+5. Record the log evidence (retry warning + Celery `retry: Retry in Ns` line OR the `FAILURE` message with the accurate `_fail_job` text) and the terminal job status.
+6. Revert any code patches, restart affected services (`docker compose restart celeryworker`), confirm `git diff` is empty.
+
+**Gotchas:**
+- The first ~1 min after restarting celeryworker, the `check_processing_services_online` beat task monopolises `ForkPoolWorker-16` retrying unreachable services. Populate/job tasks pick up fine on other workers, but logs are noisy.
+- If Django has been up > ~1 day, RabbitMQ AMQP connections go stale (`ConnectionResetError: [Errno 104]` when enqueuing). `docker compose restart django` fixes it — do this before any chaos run.
+- Celery code is volume-mounted; edits to `ami/**` only take effect after `docker compose restart celeryworker`.
+- Fault-injection patches are disruptive — revert them **and** `git diff` to verify before committing anything.
+
 ### Running a Single Test
 
 ```bash

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -50,14 +50,16 @@ def run_job(self, job_id: int) -> None:
 @celery_app.task(
     bind=True,
     # Retry on transient Redis/connection errors so a single connection reset
-    # doesn't flip the job to FAILURE mid-processing. Backoff is bounded well
-    # below soft_time_limit so retries never leak past the task deadline.
-    # Terminal failures (e.g. PipelineResultsError validation) are raised
-    # from other exception types and are not retried here.
+    # doesn't flip the job to FAILURE mid-processing. Backoff is capped at 15s
+    # (half of NATS ack_wait = TASK_TTR = 30s, see nats_queue.py) so a retry
+    # is likely to complete before JetStream redelivers the same payload to
+    # ADC. retries stay well below soft_time_limit so they never leak past
+    # the task deadline. Terminal failures (e.g. PipelineResultsError
+    # validation) are raised from other exception types and not retried here.
     # See RolnickLab/antenna#1219.
     autoretry_for=(RedisError, RedisConnectionError, ConnectionError),
     retry_backoff=True,
-    retry_backoff_max=30,
+    retry_backoff_max=15,
     retry_jitter=True,
     max_retries=5,
     soft_time_limit=300,  # 5 minutes
@@ -102,10 +104,16 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
         )
     except RedisError as e:
         # Transient (connection reset, broker blip, timeout). Celery will retry
-        # via autoretry_for; NATS hasn't been acked yet so redelivery is not
-        # a concern. Log so the real cause is visible in task logs rather than
-        # the misleading "Redis state missing" that users saw in #1219.
-        logger.warning(f"Transient Redis error updating job {job_id} state (stage=process); Celery will retry: {e}")
+        # via autoretry_for. We have NOT yet acked NATS here, so if the retry
+        # budget runs long enough JetStream may redeliver to ADC (ack_wait =
+        # TASK_TTR = 30s, see nats_queue.py); save_results dedupes and SREM is
+        # a no-op on replay, so duplication is cosmetic rather than corrupting.
+        # Log so the real cause is visible in task logs rather than the
+        # misleading "Redis state missing" that users saw in #1219.
+        logger.warning(
+            f"Transient Redis error updating job {job_id} state (stage=process); Celery will retry: {e}",
+            exc_info=True,
+        )
         raise
 
     if not progress_info:
@@ -167,8 +175,7 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
             classifications_count = sum(len(detection.classifications) for detection in pipeline_result.detections)
             captures_count = len(pipeline_result.source_images)
 
-        _ack_task_via_nats(reply_subject, job.logger)
-        acked = True
+        acked = _ack_task_via_nats(reply_subject, job.logger)
         # Update job stage with calculated progress
 
         try:
@@ -177,13 +184,17 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
                 stage="results",
             )
         except RedisError as e:
-            # Transient. NATS is acked and results are saved, but those writes
-            # are idempotent so a Celery retry is safe: save_results dedupes on
-            # re-run and SREM is a no-op on already-removed ids. Log to the
-            # job logger so the cause is visible in the UI task log, then let
-            # autoretry_for pick it up.
+            # Transient. save_results dedupes on re-run (get_or_create_detection)
+            # and SREM is a no-op on already-removed ids, so a Celery retry is
+            # safe for the DB and Redis sets. The caveat is _update_job_progress
+            # accumulates detections/classifications/captures on the results
+            # stage (see _update_job_progress stage=="results" branch); if this
+            # retry runs a second time (or NATS redelivers to ADC because
+            # ack_wait elapsed before we got here), those counters will inflate
+            # cosmetically. Tracked in #1232.
             job.logger.warning(
-                f"Transient Redis error updating job {job_id} state (stage=results); Celery will retry: {e}"
+                f"Transient Redis error updating job {job_id} state (stage=results); Celery will retry: {e}",
+                exc_info=True,
             )
             raise
 
@@ -239,7 +250,14 @@ def _fail_job(job_id: int, reason: str) -> None:
         cleanup_async_job_resources(job_id)
 
 
-def _ack_task_via_nats(reply_subject: str, job_logger: logging.Logger) -> None:
+def _ack_task_via_nats(reply_subject: str, job_logger: logging.Logger) -> bool:
+    """
+    Acknowledge a NATS task. Returns True only when JetStream confirmed the ack.
+
+    Callers that gate retry behavior on ack outcome (e.g. the post-save_results
+    path in process_nats_pipeline_result) MUST check the return value — a False
+    means the message is still live and NATS will redeliver after ack_wait.
+    """
     try:
 
         async def ack_task():
@@ -250,11 +268,12 @@ def _ack_task_via_nats(reply_subject: str, job_logger: logging.Logger) -> None:
 
         if ack_success:
             job_logger.info(f"Successfully acknowledged task via NATS: {reply_subject}")
-        else:
-            job_logger.warning(f"Failed to acknowledge task via NATS: {reply_subject}")
+            return True
+        job_logger.warning(f"Failed to acknowledge task via NATS: {reply_subject}")
+        return False
     except Exception as ack_error:
-        job_logger.error(f"Error acknowledging task via NATS: {ack_error}")
-        # Don't fail the task if ACK fails - data is already saved
+        job_logger.error(f"Error acknowledging task via NATS: {ack_error}", exc_info=True)
+        return False
 
 
 def _get_current_counts_from_job_progress(job, stage: str) -> tuple[int, int, int]:

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 from asgiref.sync import async_to_sync
 from celery.signals import task_failure, task_postrun, task_prerun
 from django.db import transaction
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import RedisError
 
 from ami.ml.orchestration.async_job_state import AsyncJobStateManager
 from ami.ml.orchestration.nats_queue import TaskQueueManager
@@ -47,7 +49,17 @@ def run_job(self, job_id: int) -> None:
 
 @celery_app.task(
     bind=True,
-    max_retries=0,  # don't retry since we already have retry logic in the NATS queue
+    # Retry on transient Redis/connection errors so a single connection reset
+    # doesn't flip the job to FAILURE mid-processing. Backoff is bounded well
+    # below soft_time_limit so retries never leak past the task deadline.
+    # Terminal failures (e.g. PipelineResultsError validation) are raised
+    # from other exception types and are not retried here.
+    # See RolnickLab/antenna#1219.
+    autoretry_for=(RedisError, RedisConnectionError, ConnectionError),
+    retry_backoff=True,
+    retry_backoff_max=30,
+    retry_jitter=True,
+    max_retries=5,
     soft_time_limit=300,  # 5 minutes
     time_limit=360,  # 6 minutes
 )
@@ -84,11 +96,24 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
 
     state_manager = AsyncJobStateManager(job_id)
 
-    progress_info = state_manager.update_state(processed_image_ids, stage="process", failed_image_ids=failed_image_ids)
+    try:
+        progress_info = state_manager.update_state(
+            processed_image_ids, stage="process", failed_image_ids=failed_image_ids
+        )
+    except RedisError as e:
+        # Transient (connection reset, broker blip, timeout). Celery will retry
+        # via autoretry_for; NATS hasn't been acked yet so redelivery is not
+        # a concern. Log so the real cause is visible in task logs rather than
+        # the misleading "Redis state missing" that users saw in #1219.
+        logger.warning(f"Transient Redis error updating job {job_id} state (stage=process); Celery will retry: {e}")
+        raise
+
     if not progress_info:
-        # Acknowledge the task to prevent retries, since we don't know the state
+        # State keys genuinely missing (the total-images key returned None).
+        # Ack so NATS stops redelivering and fail the job — there's no state
+        # left to reconcile against.
         _ack_task_via_nats(reply_subject, logger)
-        _fail_job(job_id, "Redis state missing for job")
+        _fail_job(job_id, "Job state keys not found in Redis (likely cleaned up concurrently)")
         return
 
     try:
@@ -146,13 +171,24 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
         acked = True
         # Update job stage with calculated progress
 
-        progress_info = state_manager.update_state(
-            processed_image_ids,
-            stage="results",
-        )
+        try:
+            progress_info = state_manager.update_state(
+                processed_image_ids,
+                stage="results",
+            )
+        except RedisError as e:
+            # Transient. NATS is acked and results are saved, but those writes
+            # are idempotent so a Celery retry is safe: save_results dedupes on
+            # re-run and SREM is a no-op on already-removed ids. Log to the
+            # job logger so the cause is visible in the UI task log, then let
+            # autoretry_for pick it up.
+            job.logger.warning(
+                f"Transient Redis error updating job {job_id} state (stage=results); Celery will retry: {e}"
+            )
+            raise
 
         if not progress_info:
-            _fail_job(job_id, "Redis state missing for job")
+            _fail_job(job_id, "Job state keys not found in Redis (likely cleaned up concurrently)")
             return
 
         # update complete state based on latest progress info after saving results
@@ -170,6 +206,11 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
             captures=captures_count,
         )
 
+    except RedisError:
+        # Logged above at the specific update_state call site; re-raise so
+        # Celery's autoretry_for handles the transient rather than this broad
+        # except swallowing it.
+        raise
     except Exception as e:
         error = f"Error processing pipeline result for job {job_id}: {e}"
         if not acked:

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 from asgiref.sync import async_to_sync
 from celery.signals import task_failure, task_postrun, task_prerun
 from django.db import transaction
-from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import RedisError
 
 from ami.main.checks.schemas import IntegrityCheckResult
@@ -59,7 +58,7 @@ def run_job(self, job_id: int) -> None:
     # the task deadline. Terminal failures (e.g. PipelineResultsError
     # validation) are raised from other exception types and not retried here.
     # See RolnickLab/antenna#1219.
-    autoretry_for=(RedisError, RedisConnectionError, ConnectionError),
+    autoretry_for=(RedisError, ConnectionError),
     retry_backoff=True,
     retry_backoff_max=15,
     retry_jitter=True,

--- a/ami/jobs/tests/test_tasks.py
+++ b/ami/jobs/tests/test_tasks.py
@@ -289,6 +289,68 @@ class TestProcessNatsPipelineResultError(TransactionTestCase):
         self.assertEqual(progress.total, 3)
         self.assertEqual(mock_manager.acknowledge_task.call_count, 2)
 
+    @patch("ami.jobs.tasks._fail_job")
+    @patch("ami.jobs.tasks._ack_task_via_nats")
+    @patch("ami.jobs.tasks.TaskQueueManager")
+    def test_transient_redis_error_does_not_fail_job_or_ack(self, mock_manager_class, mock_ack, mock_fail):
+        """
+        #1219: A transient RedisError during update_state must NOT flip the job
+        to FAILURE and must NOT ack the NATS reply. Celery's autoretry_for is
+        responsible for retrying; acking or failing prematurely is what caused
+        the production incident.
+
+        We invoke the task body directly (bypassing Celery's retry machinery)
+        so we can assert the raw behavior: the exception propagates, _fail_job
+        is not called, and the NATS ack helper is not called.
+        """
+        from redis.exceptions import RedisError
+
+        self._setup_mock_nats(mock_manager_class)
+        error_data = self._create_error_result(image_id=str(self.images[0].pk))
+
+        with patch.object(AsyncJobStateManager, "update_state", side_effect=RedisError("reset by peer")):
+            with self.assertRaises(RedisError):
+                # Calling the task as a function runs its body once with no retry.
+                process_nats_pipeline_result(
+                    job_id=self.job.pk,
+                    result_data=error_data,
+                    reply_subject="reply.transient",
+                )
+
+        mock_fail.assert_not_called()
+        mock_ack.assert_not_called()
+
+    @patch("ami.jobs.tasks._fail_job")
+    @patch("ami.jobs.tasks._ack_task_via_nats")
+    @patch("ami.jobs.tasks.TaskQueueManager")
+    def test_genuinely_missing_state_acks_and_fails_job(self, mock_manager_class, mock_ack, mock_fail):
+        """
+        #1219 pairs with the transient case: when the job's total-images key
+        is actually gone from Redis (cleanup race / expiry), the task should
+        ack NATS (to stop redelivery) and fail the job — there's no state
+        to reconcile against. This path is now the ONLY reason _fail_job is
+        called from process_nats_pipeline_result's first call site.
+        """
+        self._setup_mock_nats(mock_manager_class)
+        error_data = self._create_error_result(image_id=str(self.images[0].pk))
+
+        # Wipe out the state that setUp's initialize_job created. Now
+        # update_state will see total_raw=None and return None (genuine).
+        self.state_manager.cleanup()
+
+        process_nats_pipeline_result(
+            job_id=self.job.pk,
+            result_data=error_data,
+            reply_subject="reply.missing",
+        )
+
+        mock_ack.assert_called_once()
+        mock_fail.assert_called_once()
+        # New, accurate message — no longer the misleading "Redis state missing"
+        # that users saw in the UI for transient connection drops.
+        args, _ = mock_fail.call_args
+        self.assertIn("Job state keys not found in Redis", args[1])
+
     @patch("ami.jobs.tasks.TaskQueueManager")
     def test_process_nats_pipeline_result_error_job_not_found(self, mock_manager_class):
         """

--- a/ami/ml/orchestration/async_job_state.py
+++ b/ami/ml/orchestration/async_job_state.py
@@ -127,26 +127,30 @@ class AsyncJobStateManager:
             failed_image_ids: Set of image IDs that failed processing (optional)
 
         Returns:
-            JobStateProgress snapshot, or None if Redis state is missing
-            (job expired or not yet initialized).
-        """
-        try:
-            redis = self._get_redis()
-            pending_key = self._get_pending_key(stage)
+            JobStateProgress snapshot, or None if the job's total-images key is
+            genuinely missing from Redis (job expired, cleaned up concurrently,
+            or never initialized).
 
-            with redis.pipeline() as pipe:
-                if processed_image_ids:
-                    pipe.srem(pending_key, *processed_image_ids)
-                if failed_image_ids:
-                    pipe.sadd(self._failed_key, *failed_image_ids)
-                    pipe.expire(self._failed_key, self.TIMEOUT)
-                pipe.scard(pending_key)
-                pipe.scard(self._failed_key)
-                pipe.get(self._total_key)
-                results = pipe.execute()
-        except RedisError as e:
-            logger.error(f"Redis error updating job {self.job_id} state: {e}")
-            return None
+        Raises:
+            redis.exceptions.RedisError: on transient Redis failures (connection
+                reset, timeout, etc.). Callers should retry; swallowing this
+                here would conflate a fixable transient with the terminal
+                "state genuinely gone" signal expressed by the None return.
+                See RolnickLab/antenna#1219.
+        """
+        redis = self._get_redis()
+        pending_key = self._get_pending_key(stage)
+
+        with redis.pipeline() as pipe:
+            if processed_image_ids:
+                pipe.srem(pending_key, *processed_image_ids)
+            if failed_image_ids:
+                pipe.sadd(self._failed_key, *failed_image_ids)
+                pipe.expire(self._failed_key, self.TIMEOUT)
+            pipe.scard(pending_key)
+            pipe.scard(self._failed_key)
+            pipe.get(self._total_key)
+            results = pipe.execute()
 
         # Last 3 results are always scard(pending), scard(failed), get(total)
         # regardless of whether SREM/SADD appear at the front.

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -1366,3 +1366,41 @@ class TestTaskStateManager(TestCase):
         # Verify all state is gone (get_progress returns None when total_key is deleted)
         progress = self.manager.get_progress("process")
         self.assertIsNone(progress)
+
+    def test_update_state_raises_on_redis_error(self):
+        """
+        A transient Redis failure during update_state must propagate, not be
+        swallowed as None. The None return is reserved for the genuine
+        "state actually gone" case (see test below). Conflating the two is
+        the #1219 bug that escalated transient connection resets into fatal
+        job FAILUREs.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from redis.exceptions import RedisError
+
+        self._init_and_verify(self.image_ids)
+
+        # Replace the pipeline context manager with one whose execute() raises.
+        # Everything upstream of execute() is safely called (srem/sadd/scard/get
+        # on a pipeline only queue commands; they don't hit the network until
+        # execute runs), so we only need to blow up at the execute boundary.
+        pipe = MagicMock()
+        pipe.execute.side_effect = RedisError("Connection reset by peer")
+        fake_redis = MagicMock()
+        fake_redis.pipeline.return_value.__enter__.return_value = pipe
+
+        with patch.object(self.manager, "_get_redis", return_value=fake_redis):
+            with self.assertRaises(RedisError):
+                self.manager.update_state({"img1", "img2"}, "process")
+
+    def test_update_state_returns_none_when_state_genuinely_missing(self):
+        """
+        When the job's total-images key is actually missing from Redis (job
+        was never initialized, cleaned up, or TTL expired), update_state
+        returns None. This is the only case that should trigger the
+        terminal "state missing" failure path in the caller.
+        """
+        # Do NOT call initialize_job — the total key doesn't exist.
+        progress = self.manager.update_state({"img1", "img2"}, "process")
+        self.assertIsNone(progress)


### PR DESCRIPTION
When a pooled Redis connection drops for a fraction of a second, the previous code treated it the same as "job state is completely gone" — and killed the job immediately. This PR retries on transient connection errors instead of failing, and teaches the code to distinguish a brief network blip from a genuine missing-state condition. Follow-up fixes from code review address a silent ack-failure window, an incorrect comment about NATS redelivery, and a backoff cap that was too high relative to NATS's redelivery timeout.

## Summary

Closes #1219. Pairs with the already-merged #1221.

`AsyncJobStateManager.update_state()` previously returned `None` for **two very different conditions**: a transient `RedisError` (connection reset, timeout) and a genuine "job state keys not found in Redis" situation. The caller in `process_nats_pipeline_result` treated both as fatal and called `_fail_job`, wiping a live job's NATS stream and Redis state on a single brief connection drop. Production incident on 2026-04-14: a 507/840-images async_api job was marked FAILURE 153 ms after a single pooled Redis connection was reset, while other tasks in the same worker reached Redis successfully milliseconds before and after.

## Changes

**`ami/ml/orchestration/async_job_state.py`**
- `update_state()` no longer swallows `RedisError` as `None`. Transients propagate.
- The `None` return is now reserved for the terminal `total_raw is None` case (state keys genuinely missing — cleanup race or TTL expiry).
- Docstring updated to document the new contract.

**`ami/jobs/tasks.py`** (original + follow-up fixes from review)
- `process_nats_pipeline_result` now has `autoretry_for=(RedisError, RedisConnectionError, ConnectionError)` with `retry_backoff=True`, `retry_backoff_max=15` (see below), `retry_jitter=True`, `max_retries=5`. Worst-case retry span is well below `soft_time_limit=300`.
- Both `update_state` call sites are wrapped in a targeted `try/except RedisError` that logs the real cause with `exc_info=True` (stack trace included) to the job logger (site 2) or module logger (site 1) and re-raises.
- The outer `except Exception` in the second-stage path re-raises `RedisError` so Celery's retry machinery can see it.
- `_fail_job` message for the genuine-missing-state case is renamed to `"Job state keys not found in Redis (likely cleaned up concurrently)"`.
- `_ack_task_via_nats` now returns `bool` — `True` only when JetStream confirmed the ack. Docstring added explaining callers that gate retry behavior on ack outcome must check the return value.
- Post-`save_results` path now uses `acked = _ack_task_via_nats(...)` instead of unconditionally setting `acked = True`. This closes the window where a silent ack failure could leave a message live for redelivery without the caller knowing.
- `retry_backoff_max` lowered from 30 → 15 s (half of `ack_wait = TASK_TTR = 30s` in `nats_queue.py:46,344`) to reduce — but not eliminate — the chance that a retrying task outlives NATS's redelivery window.
- Both `RedisError` warning logs now pass `exc_info=True` so full stack traces land in post-mortem logs.
- Corrected misleading comment at site 1 (old text claimed "NATS hasn't been acked yet so redelivery is not a concern" — backwards: unacked is exactly what gets redelivered). New comment acknowledges redelivery IS possible if retries run past 30 s and explains why it is cosmetic rather than data-corrupting.
- Corrected site-2 comment to document the remaining counter-inflation caveat honestly (see "Known caveat" below).

**`ami/ml/tests.py`**
- `test_update_state_raises_on_redis_error` — patches the Redis pipeline's `execute()` to raise and asserts `update_state` propagates the error instead of returning `None`.
- `test_update_state_returns_none_when_state_genuinely_missing` — asserts the `None` contract still holds for actually-missing state.

**`ami/jobs/tests/test_tasks.py`**
- `test_transient_redis_error_does_not_fail_job_or_ack` — patches `update_state` to raise `RedisError`, invokes the task body directly, and asserts `_fail_job` and `_ack_task_via_nats` are not called.
- `test_genuinely_missing_state_acks_and_fails_job` — wipes the `AsyncJobStateManager` state before invoking the task and asserts this path still acks NATS and calls `_fail_job` with the new message.

## Why this is safe to retry

**Site 1** (`stage="process"`, before `save_results`): nothing has been persisted or acknowledged. A Celery retry re-runs the task body from the top. `SREM` on already-removed ids is a no-op; `SADD` on already-failed ids is idempotent.

**Site 2** (`stage="results"`, after `save_results` + NATS ack): `save_results` is idempotent (`get_or_create_detection` dedupes on re-run) and `SREM` on already-removed ids is a no-op.

**Known caveat (tracked in #1232):** `_update_job_progress` with `stage="results"` accumulates `detections`, `classifications`, and `captures` counters additively (see `tasks.py:313-315`). It is not idempotent on replay. If a `RedisError` at site 2 triggers a Celery retry — or if NATS redelivers the message to ADC because `ack_wait` elapsed — those counters can inflate cosmetically. DB state and the actual occurrence records are not affected. #1232 tracks the structural fix; this PR addresses the structural retry safety, the ack-failure window, and the backoff cap.

If retries exhaust (`max_retries=5`, ~30 s total), the task fails normally. No silent data loss.

## Review feedback addressed

**Copilot flagged:**
- `retry_backoff_max=30` exceeds `ack_wait=30s` — a retry finishing at exactly 30 s could race with NATS redelivery. Fixed: lowered to 15 s.
- The site-1 comment claimed "NATS hasn't been acked so redelivery is not a concern" — backwards. Fixed: comment now correctly describes when redelivery can occur and why it is cosmetic.
- `exc_info` missing from `RedisError` warning logs. Fixed: added to both warning calls and to the broad `except` in `_ack_task_via_nats`.
- `_ack_task_via_nats` had a redundant `ConnectionError` in `autoretry_for` (already a subclass of `OSError`, which `RedisError` can raise). Left as-is for clarity; redundancy is not harmful.

**CodeRabbit flagged:**
- Post-`save_results` path set `acked = True` unconditionally before calling `_ack_task_via_nats`, meaning a silent ack failure was invisible to callers. Fixed: `_ack_task_via_nats` now returns `bool` and the call site uses `acked = _ack_task_via_nats(...)`.

**Not addressed in this PR:**
- `_update_job_progress` counter accumulation on `stage="results"` replay — structural, tracked in #1232.
- `AsyncJobStateManager.get_progress()` swallowing `RedisError` as `None` (`async_job_state.py:189-191`) — dead code, no live callers; kept out of scope.

## Relationship to #1221

Two-layer defence:
- **#1221** (merged) reduces the **frequency** of transients by enabling `SO_KEEPALIVE` on django-redis cache connections so the cloud firewall doesn't silently drop idle pooled connections.
- **This PR** reduces the **severity** of any remaining transients by decoupling "one Redis blip" from "job marked FAILURE".

Either one alone is insufficient.

## What still needs verifying after deploy

- Watch celery logs for `Transient Redis error updating job <id>` warnings — should be rare but non-zero (keepalive reduces frequency, doesn't eliminate). Each such warning should be followed by either a retry-success or an eventual `MaxRetriesExceededError` if the Redis outage is prolonged.
- Watch the rate of `_fail_job` calls with the new message — expected to be very low (only genuine state cleanup races / TTL expiries). Any spike warrants investigation of the job lifecycle.
- Site 2 counter inflation: if cosmetic counter inflation is observed in production (job shows e.g. 2× expected detections in progress UI while final occurrence count is correct), that confirms the accumulation path in `_update_job_progress` and should be tracked against #1232.

## Test plan

- [x] `python manage.py test ami.ml.tests.TestTaskStateManager` — 11 tests pass, including the 2 new ones
- [x] `python manage.py test ami.jobs.tests.test_tasks.TestProcessNatsPipelineResultError` — 7 tests pass, including the 2 new ones
- [x] Local e2e verification (2026-04-14): one-shot transient `RedisError` at `update_state` call site 1 → Celery autoretry → job recovers to `SUCCESS`; `chaos_monkey flush redis` → `update_state` returns `None` → `FAILURE` with the new "Job state keys not found in Redis" message. See "E2E verification" section below.
- [ ] Production verification: watch for `Transient Redis error updating job <id>` warnings — expected rare but non-zero, each followed by retry-success or (if Redis outage is prolonged) `MaxRetriesExceededError`. Site 2 counter inflation is a known cosmetic risk tracked in #1232.

## E2E verification (2026-04-14, local stack)

Both branches of the new decision tree exercised end-to-end against a live Antenna stack (Django + Celery + NATS + Redis + ADC worker on project 18, pipeline `quebec_vermont_moths_2023`) to confirm behaviour under real Celery retry machinery, not just unit-test fakes.

### Test 1 — transient `RedisError` at site 1 → Celery retry → `SUCCESS`

**Method.** Temporarily patched `AsyncJobStateManager.update_state` to raise `RedisError("injected fault")` once per process, gated by a sentinel file `/tmp/inject-redis-fault` that self-disarms on first hit. Ran `test_ml_job_e2e` with a fresh 20-image collection.

Note: `redis-cli CLIENT KILL TYPE normal` does not surface errors — the django-redis connection pool transparently reconnects. A sentinel-file patch is the cleanest way to reliably simulate a one-shot transient.

**Evidence (celery worker logs, job 1485):**

```
[WARNING] Transient Redis error updating job 1485 state (stage=process); Celery will retry: injected fault for #1231 e2e retry test
[INFO]    Task ami.jobs.tasks.process_nats_pipeline_result[f3fa2b53-...] retry: Retry in 1s: RedisError('injected fault...')
```

**Result.** Job 1485 reached `SUCCESS` — 20 captures, 255 detections, 432 classifications, ~23 s total. `_fail_job` not invoked; `autoretry_for` caught the error, applied the first-retry backoff (1 s with jitter), and the retried task ran to completion.

### Test 2 — genuine state loss via `chaos_monkey flush redis` → `FAILURE` with accurate message

**Method.** Started a 30-image async_api job, waited for `process` stage ≥10%, then ran `docker compose exec django python manage.py chaos_monkey flush redis` to `FLUSHDB` mid-job.

**Evidence (celery worker logs, job 1488):**

```
[ERROR] Job 1488 marked as FAILURE: Job state keys not found in Redis (likely cleaned up concurrently)
```

**Result.** Job 1488 reached `FAILURE` with the new message. Pre-PR this path and the transient-error path both emitted the misleading `"Redis state missing for job"` message.

### Repro

The procedure is documented in `CLAUDE.md` under "Chaos testing async_api jobs" and re-usable for future changes to the async result handler.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Jobs now automatically retry on transient service failures up to 5 times with exponential backoff, increasing reliability during temporary disruptions
  * Error messages now distinguish between temporary connection issues and permanent job state problems

* **Tests**
  * Added test coverage for transient failure retry behavior and missing state scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
