### PR TITLE
fix(jobs): don't fail jobs prematurely, but fail stalled jobs sooner (3 days -> 10 min)

### DIFF
--- a/ami/jobs/management/commands/update_stale_jobs.py
+++ b/ami/jobs/management/commands/update_stale_jobs.py
@@ -9,10 +9,10 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--hours",
+            "--minutes",
             type=int,
-            default=Job.FAILED_CUTOFF_HOURS,
-            help="Number of hours to consider a job stale (default: %(default)s)",
+            default=Job.STALLED_JOBS_MAX_MINUTES,
+            help="Minutes since last update to consider a job stale (default: %(default)s)",
         )
         parser.add_argument(
             "--dry-run",
@@ -21,7 +21,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        results = check_stale_jobs(hours=options["hours"], dry_run=options["dry_run"])
+        results = check_stale_jobs(minutes=options["minutes"], dry_run=options["dry_run"])
 
         if not results:
             self.stdout.write("No stale jobs found.")

--- a/ami/jobs/models.py
+++ b/ami/jobs/models.py
@@ -816,8 +816,14 @@ def get_job_type_by_inferred_key(job: "Job") -> type[JobType] | None:
 class Job(BaseModel):
     """A job to be run by the scheduler"""
 
-    # Hide old failed jobs after 3 days
-    FAILED_CUTOFF_HOURS = 24 * 3
+    # UI/API: hide failed jobs older than this from listings (display filter only).
+    FAILED_JOBS_DISPLAY_MAX_HOURS = 24 * 3
+    # Reaper: revoke jobs in :meth:`JobState.running_states` whose ``updated_at``
+    # is older than this. A healthy async_api job bumps ``updated_at`` on every
+    # Redis SREM-driven progress save, so this is effectively "no progress for
+    # N minutes". 10 is conservative; raise if legitimate long-running jobs get
+    # reaped.
+    STALLED_JOBS_MAX_MINUTES = 10
 
     name = models.CharField(max_length=255)
     queue = models.CharField(max_length=255, default="default")
@@ -1037,14 +1043,21 @@ class Job(BaseModel):
         else:
             for stage in self.progress.stages:
                 if stage.progress > 0 and stage.status == JobState.CREATED:
-                    # Update any stages that have started but are still in the CREATED state
+                    # Promote stages that have started but are still in the CREATED state.
                     stage.status = JobState.STARTED
-                elif stage.status in JobState.final_states() and stage.progress < 1:
-                    # Update any stages that are complete but have a progress less than 1
-                    stage.progress = 1
                 elif stage.progress == 1 and stage.status not in JobState.final_states():
-                    # Update any stages that are complete but are still in the STARTED state
+                    # Promote stages that have measured-100% progress but are still STARTED.
                     stage.status = JobState.SUCCESS
+                # Note: do NOT coerce ``stage.progress = 1`` when status is in a
+                # final state but progress < 1. That branch used to fire when
+                # ``_update_job_progress`` wrote ``status=FAILURE`` at partial
+                # progress (e.g. failed/total temporarily crossed FAILURE_THRESHOLD
+                # early in an async_api job). The save-time coercion silently
+                # bumped progress to 100%, which made ``is_complete()`` return True
+                # and triggered premature ``cleanup_async_job_resources`` while
+                # NATS was still delivering results. Progress is a measurement;
+                # leave it alone. Stuck jobs are reaped by ``check_stale_jobs``
+                # via ``Job.STALLED_JOBS_MAX_MINUTES``.
             total_progress = sum([stage.progress for stage in self.progress.stages]) / len(self.progress.stages)
 
         self.progress.summary.progress = total_progress

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -454,6 +454,23 @@ def check_stale_jobs(minutes: int | None = None, dry_run: bool = False) -> list[
                     job.finished_at = datetime.datetime.now()
                     job.save()
             else:
+                # Per-job diagnostic: surface enough state at revoke time that an
+                # operator can answer "why was this stalled?" without grepping
+                # back through tick logs. Pairs with the per-tick NATS consumer
+                # snapshots logged by ``_run_running_job_snapshot_check``.
+                stalled_minutes = (datetime.datetime.now() - job.updated_at).total_seconds() / 60
+                stages_summary = (
+                    ", ".join(f"{s.key}={s.progress*100:.1f}% {s.status}" for s in job.progress.stages)
+                    or "(no stages)"
+                )
+                job.logger.warning(
+                    f"Reaping stalled job: no progress for {stalled_minutes:.1f} min "
+                    f"(threshold {minutes} min). previous_status={previous_status}, "
+                    f"celery_state={celery_state}, dispatch_mode={job.dispatch_mode}, "
+                    f"stages: {stages_summary}. "
+                    f"For NATS consumer state at the last tick, see prior "
+                    f"running_job_snapshots logs for this job."
+                )
                 if not dry_run:
                     job.update_status(JobState.REVOKED, save=False)
                     job.finished_at = datetime.datetime.now()

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -377,9 +377,14 @@ def _update_job_progress(
         cleanup_async_job_if_needed(job)
 
 
-def check_stale_jobs(hours: int | None = None, dry_run: bool = False) -> list[dict]:
+def check_stale_jobs(minutes: int | None = None, dry_run: bool = False) -> list[dict]:
     """
     Find jobs stuck in a running state past the cutoff and revoke them.
+
+    Cutoff is measured against ``Job.updated_at`` (auto-bumped on every save),
+    so a job that's actively making progress — including async_api jobs that
+    bump on each Redis SREM-driven progress save — is never reaped while
+    healthy. Default cutoff is :attr:`Job.STALLED_JOBS_MAX_MINUTES`.
 
     For each stale job, checks Celery for a terminal task status. REVOKED is
     always trusted. For async_api jobs, SUCCESS and FAILURE are only accepted
@@ -397,10 +402,10 @@ def check_stale_jobs(hours: int | None = None, dry_run: bool = False) -> list[di
 
     from ami.jobs.models import Job, JobDispatchMode, JobState
 
-    if hours is None:
-        hours = Job.FAILED_CUTOFF_HOURS
+    if minutes is None:
+        minutes = Job.STALLED_JOBS_MAX_MINUTES
 
-    cutoff = datetime.datetime.now() - datetime.timedelta(hours=hours)
+    cutoff = datetime.datetime.now() - datetime.timedelta(minutes=minutes)
     stale_pks = list(
         Job.objects.filter(
             status__in=JobState.running_states(),
@@ -492,7 +497,7 @@ class JobsHealthCheckResult:
 
 
 def _run_stale_jobs_check() -> IntegrityCheckResult:
-    """Reconcile jobs stuck in running states past FAILED_CUTOFF_HOURS."""
+    """Reconcile jobs stuck in running states past Job.STALLED_JOBS_MAX_MINUTES."""
     results = check_stale_jobs()
     updated = sum(1 for r in results if r["action"] == "updated")
     revoked = sum(1 for r in results if r["action"] == "revoked")

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -36,6 +36,26 @@ class TestJobProgress(TestCase):
         self.assertEqual(job.progress.summary.progress, 0)
         self.assertEqual(job.progress.stages, [])
 
+    def test_save_does_not_inflate_failed_stage_progress(self):
+        """A stage marked FAILURE at partial progress must keep its measured value.
+
+        Regression for the premature ``cleanup_async_job_resources`` path: when a
+        worker writes ``status=FAILURE`` at partial progress (e.g. failed/total
+        crossed FAILURE_THRESHOLD on an early result), ``Job.update_progress``
+        used to coerce ``stage.progress = 1`` on the next save. That made
+        ``is_complete()`` return True and triggered cleanup while async results
+        were still in flight. Progress is a measurement; leave it alone.
+        """
+        job = Job.objects.create(project=self.project, name="Test job - partial failure")
+        job.progress.add_stage("results")
+        job.progress.update_stage("results", progress=0.3, status=JobState.FAILURE)
+        job.save()
+
+        results_stage = job.progress.get_stage("results")
+        self.assertEqual(results_stage.progress, 0.3)
+        self.assertEqual(results_stage.status, JobState.FAILURE)
+        self.assertFalse(job.progress.is_complete())
+
     def test_create_job_with_delay(self):
         job = Job.objects.create(
             job_type_key=MLJob.key,

--- a/ami/jobs/tests/test_periodic_beat_tasks.py
+++ b/ami/jobs/tests/test_periodic_beat_tasks.py
@@ -19,9 +19,9 @@ class JobsHealthCheckTest(TestCase):
     def setUp(self):
         self.project = Project.objects.create(name="Beat schedule test project")
 
-    def _create_stale_job(self, status=JobState.STARTED, hours_ago=100):
+    def _create_stale_job(self, status=JobState.STARTED, minutes_ago=120):
         job = Job.objects.create(project=self.project, name="stale", status=status)
-        Job.objects.filter(pk=job.pk).update(updated_at=timezone.now() - timedelta(hours=hours_ago))
+        Job.objects.filter(pk=job.pk).update(updated_at=timezone.now() - timedelta(minutes=minutes_ago))
         job.refresh_from_db()
         return job
 
@@ -55,7 +55,7 @@ class JobsHealthCheckTest(TestCase):
 
     def test_idle_deployment_returns_all_zeros(self, mock_manager_cls, _mock_cleanup):
         # No stale jobs, no running async jobs.
-        self._create_stale_job(hours_ago=1)  # recent — not stale
+        self._create_stale_job(minutes_ago=5)  # recent — not stale
         self._stub_manager(mock_manager_cls)
 
         self.assertEqual(

--- a/ami/jobs/tests/test_update_stale_jobs.py
+++ b/ami/jobs/tests/test_update_stale_jobs.py
@@ -13,14 +13,14 @@ class CheckStaleJobsTest(TestCase):
     def setUp(self):
         self.project = Project.objects.create(name="Stale jobs test project")
 
-    def _create_job(self, status=JobState.STARTED, hours_ago=100, task_id=None):
+    def _create_job(self, status=JobState.STARTED, minutes_ago=120, task_id=None):
         job = Job.objects.create(
             project=self.project,
             name=f"Test job {status}",
             status=status,
         )
         Job.objects.filter(pk=job.pk).update(
-            updated_at=timezone.now() - timedelta(hours=hours_ago),
+            updated_at=timezone.now() - timedelta(minutes=minutes_ago),
         )
         if task_id is not None:
             Job.objects.filter(pk=job.pk).update(task_id=task_id)
@@ -114,8 +114,8 @@ class CheckStaleJobsTest(TestCase):
     @patch("ami.jobs.tasks.cleanup_async_job_if_needed")
     def test_skips_recent_and_final_state_jobs(self, mock_cleanup):
         """Recent jobs and jobs in final states are not touched."""
-        self._create_job(status=JobState.STARTED, hours_ago=1)  # recent
-        self._create_job(status=JobState.SUCCESS, hours_ago=200)  # final state
+        self._create_job(status=JobState.STARTED, minutes_ago=5)  # recent
+        self._create_job(status=JobState.SUCCESS, minutes_ago=300)  # final state
 
         results = check_stale_jobs()
 

--- a/ami/jobs/views.py
+++ b/ami/jobs/views.py
@@ -223,7 +223,7 @@ class JobViewSet(DefaultViewSet, ProjectMixin):
         if project:
             jobs = jobs.filter(project=project)
         cutoff_hours = IntegerField(required=False, min_value=0).clean(
-            self.request.query_params.get("cutoff_hours", Job.FAILED_CUTOFF_HOURS)
+            self.request.query_params.get("cutoff_hours", Job.FAILED_JOBS_DISPLAY_MAX_HOURS)
         )
         # Filter out completed jobs that have not been updated in the last X hours
         cutoff_datetime = timezone.now() - timezone.timedelta(hours=cutoff_hours)


### PR DESCRIPTION
## Plain language

Two related fixes for the bug where async ML jobs sometimes flip to FAILURE in the first ~30-55 seconds and disappear from the UI while the processing service is still actively returning results.

**What was happening:**

1. When a worker reports a result, we record progress in two places — Redis (a remaining-images counter) and the database (a stage's percentage and status). If 1-2 of the first few results error, the overall failed/total ratio temporarily exceeds 50%, and the code immediately stamps the stage's status as FAILURE — even though the stage is only ~5% done.
2. Then any time the Job is saved, `Job.update_progress` notices "this stage has a final status but only 5% progress — that doesn't make sense, let me bump it to 100%."
3. Now the stage looks 100% complete with FAILURE status. `is_complete()` returns True. Cleanup fires. NATS connection torn down. Job marked FAILURE. The remaining 95% of results that arrive over the next minute have nowhere to go.

The "is the stage at 100%?" check was honest. The code that wrote 100% was lying — it was a save-time janitor that "fixed" a perceived inconsistency by silently rewriting measured data.

**Fix 1 — stop lying about progress.** Remove the line that bumps `stage.progress = 1` when status is final. Progress is a measurement; if it's 30%, it's 30%, even if status is FAILURE. The stage will reach 100% honestly when SREM drains the pending set, at which point the FAILURE trip works correctly.

**Fix 2 — catch genuinely stuck jobs faster.** Without the false-positive coercion, a job whose workers genuinely stop pulling messages would sit visible as STARTED for 3 days before the reaper noticed. Two pieces:

- The reaper threshold was reusing a constant called `FAILED_CUTOFF_HOURS` that was originally added to *hide* old failed jobs from UI listings (PR #368, 2022). Two unrelated concepts had collapsed into one 72-hour value. Split into `FAILED_JOBS_DISPLAY_MAX_HOURS` (UI hide, unchanged) and a new `STALLED_JOBS_MAX_MINUTES` (reaper, 10 min — conservative starting value, raise if legitimate long-running jobs get reaped).
- The reaper already filters by `Job.updated_at` (added in #1227), which Django bumps on every save. A job actively making progress bumps its timestamp on every batch, so a healthy job is never reaped — only one whose worker pool stopped touching it.

**Reap-time diagnostic logging.** When the reaper revokes a job it now logs a single WARN line with: minutes since last update vs threshold, previous_status, celery_state, dispatch_mode, and a per-stage progress/status summary. Pairs with the per-tick NATS consumer snapshots from PR #1227, so an operator can answer "why was this stalled?" by reading the revoke line plus the most recent `running_job_snapshots` entry for that job, without grepping back through hours of tick logs.

Net behavior change: a stuck running job gets reaped within ~10-25 min (one Beat tick) instead of 3 days, with enough log context at the moment of revocation to start triage. UI display of old failures is unchanged.

## Files

- `ami/jobs/models.py` — drop progress coercion, split constant
- `ami/jobs/tasks.py` — `check_stale_jobs(minutes=...)` defaults to `STALLED_JOBS_MAX_MINUTES`; per-job WARN at revoke time
- `ami/jobs/views.py` — listing filter uses `FAILED_JOBS_DISPLAY_MAX_HOURS`
- `ami/jobs/management/commands/update_stale_jobs.py` — `--hours` → `--minutes`
- `ami/jobs/tests/test_jobs.py` — regression test for the coercion fix
- `ami/jobs/tests/test_update_stale_jobs.py`, `test_periodic_beat_tasks.py` — rescale fixtures to minutes

## Test plan

- [x] `python manage.py test ami.jobs --keepdb` — 49 tests pass
- [ ] Live e2e: dispatch an async_api job that produces early errors (PSv2 / cold ADC). Verify it does NOT flip to FAILURE in the first minute, runs to completion, and reports the actual failed-image count.
- [ ] Live e2e: kill the ADC worker mid-job. Verify the job stays STARTED, no progress advances, and the next `jobs_health_check` Beat tick (≤15 min after last update) revokes it AND emits the new "Reaping stalled job" WARN with the diagnostic context.
- [ ] Verify `python manage.py update_stale_jobs --minutes 5 --dry-run` still works.

## Stacked on

Independent of #1234 (Fix 1: ACK/SREM ordering) — this branch is based on `main`, no shared commits. Either can merge first.

---

## Footnote — future direction: managed retry pattern

Async ML jobs are designed to be idempotent (`save_results` dedupes on `(detection, source_image)`, SREM is a no-op for already-removed ids, progress percentage is clamped by `max()`). Today, when the reaper marks a job REVOKED, recovery is manual: a user re-dispatches the same collection. Since the building blocks for safe retry already exist, a natural next step is to track retry attempts on the `Job` model and let the periodic `jobs_health_check` manage automatic re-dispatch within a budget — e.g. revoke → eligible-for-retry up to N times → terminally REVOKED with reason. Out of scope for this PR; worth a design discussion before implementing because it interacts with how user-facing retry UI and audit trails should work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where failed job stage progress was incorrectly set to 100%, preventing proper job completion cleanup.
  * Stale job detection now uses minute-based timeout (10-minute default) instead of hour-based.

* **New Features**
  * Enhanced logging for revoked stale jobs includes detailed diagnostics: previous status, execution state, stage progress, and timing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->