### PR TITLE
feat(jobs): show who requests which tasks in ML processing job logs

### DIFF
--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -338,6 +338,65 @@ def _get_current_counts_from_job_progress(job, stage: str) -> tuple[int, int, in
         return 0, 0, 0
 
 
+def _format_elapsed(seconds: float) -> str:
+    """Render a duration as `Hh Mm Ss` (hours omitted when zero)."""
+    total = max(0, int(seconds))
+    h, rem = divmod(total, 3600)
+    m, s = divmod(rem, 60)
+    if h > 0:
+        return f"{h}h {m:02d}m {s:02d}s"
+    return f"{m}m {s:02d}s"
+
+
+def _log_job_throughput(job, stage: str) -> None:
+    """
+    Emit a per-job throughput/ETA line so operators can distinguish stalled-vs-slow
+    vs healthy-but-throttled jobs at a glance in the per-job log view.
+
+    Intentionally a plain division over total elapsed time, not a rolling-window
+    estimate or forecast — accurate enough to spot a stall, cheap to compute, and
+    easy to interpret from a single log line.
+    """
+    if stage not in ("process", "results"):
+        return
+    if not job.started_at:
+        return
+    elapsed_seconds = (datetime.datetime.now() - job.started_at).total_seconds()
+    elapsed_minutes = elapsed_seconds / 60.0
+    if elapsed_minutes < 0.05:
+        # Ratio over <3s of elapsed time is noise, not signal.
+        return
+
+    # The process stage holds the authoritative processed/remaining counts
+    # (results stage only tracks detection/classification/capture counts).
+    try:
+        process_stage = job.progress.get_stage("process")
+    except (ValueError, AttributeError):
+        return
+
+    processed = 0
+    remaining = 0
+    for param in getattr(process_stage, "params", []) or []:
+        if param.key == "processed":
+            processed = param.value or 0
+        elif param.key == "remaining":
+            remaining = param.value or 0
+    total = processed + remaining
+
+    if processed == 0:
+        rate_str = "rate=0.0 imgs/min, ETA=unknown"
+    else:
+        rate = processed / elapsed_minutes
+        remaining_imgs = max(0, total - processed)
+        eta_seconds = (remaining_imgs / rate) * 60.0 if rate > 0 else 0.0
+        rate_str = f"rate={rate:.1f} imgs/min, ETA={_format_elapsed(eta_seconds)}"
+
+    job.logger.info(
+        f"Job {job.pk} throughput: elapsed={_format_elapsed(elapsed_seconds)}, "
+        f"processed={processed}/{total}, {rate_str}"
+    )
+
+
 def _update_job_progress(
     job_id: int, stage: str, progress_percentage: float, complete_state: "JobState", **state_params
 ) -> None:
@@ -412,6 +471,7 @@ def _update_job_progress(
             job.finished_at = datetime.datetime.now()  # Use naive datetime in local time
         job.logger.info(f"Updated job {job_id} progress in stage '{stage}' to {progress_percentage*100}%")
         job.save()
+        _log_job_throughput(job, stage)
 
     # Clean up async resources for completed jobs that use NATS/Redis
     if job.progress.is_complete():

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -471,7 +471,10 @@ def _update_job_progress(
             job.finished_at = datetime.datetime.now()  # Use naive datetime in local time
         job.logger.info(f"Updated job {job_id} progress in stage '{stage}' to {progress_percentage*100}%")
         job.save()
-        _log_job_throughput(job, stage)
+        try:
+            _log_job_throughput(job, stage)
+        except Exception as e:
+            logger.warning("Throughput log failed for job %s: %s", job_id, e)
 
     # Clean up async resources for completed jobs that use NATS/Redis
     if job.progress.is_complete():

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -777,7 +777,10 @@ def update_job_status(sender, task_id, task, state: str, retval=None, **kwargs):
     # SUCCESS should only be set when all stages are actually complete
     # This prevents premature SUCCESS when async workers are still processing
     if state == JobState.SUCCESS and not job.progress.is_complete():
-        job.logger.info(
+        # DEBUG — fires on every async_api task_postrun (Celery task ends when
+        # images are queued; async workers drive the actual stages afterward).
+        # Always true under normal operation, so not informative at INFO.
+        job.logger.debug(
             f"Job {job.pk} task completed but stages not finished - " "deferring SUCCESS status to progress handler"
         )
         return

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -692,6 +692,96 @@ class TestJobView(APITestCase):
         self.assertIn(self.user.email, joined)
 
 
+class TestJobThroughputLogging(TestCase):
+    """Unit tests for _log_job_throughput (Task 3)."""
+
+    def setUp(self):
+        self.project = Project.objects.create(name="Throughput Test Project")
+        self.pipeline = Pipeline.objects.create(name="Throughput Pipeline", slug="throughput-pipeline")
+        self.pipeline.projects.add(self.project)
+        self.job = Job.objects.create(
+            job_type_key=MLJob.key,
+            project=self.project,
+            name="Throughput job",
+            pipeline=self.pipeline,
+        )
+
+    def _seed_process_stage(self, processed: int, remaining: int) -> None:
+        self.job.progress.add_stage("process")
+        self.job.progress.update_stage(
+            "process",
+            progress=processed / max(1, processed + remaining),
+            status=JobState.STARTED,
+            processed=processed,
+            remaining=remaining,
+            failed=0,
+        )
+        self.job.save()
+
+    def test_throughput_line_is_well_formed(self):
+        import datetime
+
+        from ami.jobs.tasks import _log_job_throughput
+
+        self._seed_process_stage(processed=10, remaining=90)
+        self.job.started_at = datetime.datetime.now() - datetime.timedelta(minutes=5)
+        self.job.save(update_fields=["started_at"])
+
+        _log_job_throughput(self.job, "process")
+
+        self.job.refresh_from_db()
+        joined = "\n".join(self.job.logs.stdout)
+        self.assertIn("throughput", joined)
+        self.assertIn("processed=10/100", joined)
+        self.assertIn("rate=2.0 imgs/min", joined)
+        # ETA for 90 remaining at 2.0 imgs/min = 45 minutes
+        self.assertIn("ETA=45m", joined)
+
+    def test_throughput_skipped_when_started_at_is_none(self):
+        from ami.jobs.tasks import _log_job_throughput
+
+        self._seed_process_stage(processed=5, remaining=5)
+        self.assertIsNone(self.job.started_at)
+
+        _log_job_throughput(self.job, "process")
+
+        self.job.refresh_from_db()
+        joined = "\n".join(self.job.logs.stdout)
+        self.assertNotIn("throughput", joined)
+
+    def test_throughput_skipped_for_non_processing_stage(self):
+        import datetime
+
+        from ami.jobs.tasks import _log_job_throughput
+
+        self._seed_process_stage(processed=10, remaining=90)
+        self.job.started_at = datetime.datetime.now() - datetime.timedelta(minutes=5)
+        self.job.save(update_fields=["started_at"])
+
+        _log_job_throughput(self.job, "delay")
+
+        self.job.refresh_from_db()
+        joined = "\n".join(self.job.logs.stdout)
+        self.assertNotIn("throughput", joined)
+
+    def test_throughput_with_zero_processed_reports_unknown_eta(self):
+        import datetime
+
+        from ami.jobs.tasks import _log_job_throughput
+
+        self._seed_process_stage(processed=0, remaining=50)
+        self.job.started_at = datetime.datetime.now() - datetime.timedelta(minutes=5)
+        self.job.save(update_fields=["started_at"])
+
+        _log_job_throughput(self.job, "process")
+
+        self.job.refresh_from_db()
+        joined = "\n".join(self.job.logs.stdout)
+        self.assertIn("processed=0/50", joined)
+        self.assertIn("rate=0.0", joined)
+        self.assertIn("ETA=unknown", joined)
+
+
 class TestJobDispatchModeFiltering(APITestCase):
     """Test job filtering by dispatch_mode."""
 

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -691,6 +691,98 @@ class TestJobView(APITestCase):
         self.assertIn("test.reply.logged", joined)
         self.assertIn(self.user.email, joined)
 
+    def test_tasks_fetch_log_uses_token_fingerprint_not_full_token(self):
+        """
+        Fix 1: token written to per-job logs is truncated to 8 chars + ellipsis,
+        never the full 40-char DRF bearer secret.
+        """
+        from rest_framework.authtoken.models import Token
+
+        pipeline = self._create_pipeline()
+        job = self._create_ml_job("Job for token-fingerprint test", pipeline)
+        job.dispatch_mode = JobDispatchMode.ASYNC_API
+        job.status = JobState.STARTED
+        job.save(update_fields=["dispatch_mode", "status"])
+        images = [
+            SourceImage.objects.create(
+                path=f"tokentest_{i}.jpg",
+                public_base_url="http://example.com",
+                project=self.project,
+            )
+            for i in range(2)
+        ]
+        queue_images_to_nats(job, images)
+
+        token, _ = Token.objects.get_or_create(user=self.user)
+        # Authenticate with the actual token object so request.auth.pk is set
+        self.client.force_authenticate(user=self.user, token=token)
+
+        tasks_url = reverse_with_params("api:job-tasks", args=[job.pk], params={"project_id": self.project.pk})
+        resp = self.client.post(tasks_url, {"batch_size": 2}, format="json")
+        self.assertEqual(resp.status_code, 200)
+
+        job.refresh_from_db()
+        joined = "\n".join(job.logs.stdout)
+        # Full token key must NOT appear anywhere in logs
+        self.assertNotIn(token.key, joined)
+        # Fingerprint (first 8 chars + ellipsis) MUST appear
+        expected_fingerprint = f"{token.key[:8]}…"
+        self.assertIn(expected_fingerprint, joined)
+
+    def test_tasks_fetch_zero_delivered_does_not_log_to_stdout(self):
+        """
+        Fix 2: when delivered==0, the log line is emitted at DEBUG and must not
+        land in job.logs.stdout (JobLogHandler only captures INFO and above).
+        """
+        pipeline = self._create_pipeline()
+        job = self._create_ml_job("Job for zero-delivered test", pipeline)
+        job.dispatch_mode = JobDispatchMode.ASYNC_API
+        job.status = JobState.STARTED
+        job.save(update_fields=["dispatch_mode", "status"])
+        # Do NOT queue any images — NATS will return 0 tasks.
+
+        self.client.force_authenticate(user=self.user)
+        tasks_url = reverse_with_params("api:job-tasks", args=[job.pk], params={"project_id": self.project.pk})
+        resp = self.client.post(tasks_url, {"batch_size": 5}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.json()["tasks"]), 0)
+
+        job.refresh_from_db()
+        # No Tasks fetched line should appear in stdout for a zero-delivery poll
+        joined = "\n".join(job.logs.stdout)
+        self.assertNotIn("Tasks fetched", joined)
+
+    def test_tasks_fetch_nonzero_delivered_logs_to_stdout(self):
+        """
+        Fix 2: when delivered>0, the log line is emitted at INFO and lands in
+        job.logs.stdout with the correct delivered count.
+        """
+        pipeline = self._create_pipeline()
+        job = self._create_ml_job("Job for nonzero-delivered test", pipeline)
+        job.dispatch_mode = JobDispatchMode.ASYNC_API
+        job.status = JobState.STARTED
+        job.save(update_fields=["dispatch_mode", "status"])
+        images = [
+            SourceImage.objects.create(
+                path=f"nonzero_{i}.jpg",
+                public_base_url="http://example.com",
+                project=self.project,
+            )
+            for i in range(3)
+        ]
+        queue_images_to_nats(job, images)
+
+        self.client.force_authenticate(user=self.user)
+        tasks_url = reverse_with_params("api:job-tasks", args=[job.pk], params={"project_id": self.project.pk})
+        resp = self.client.post(tasks_url, {"batch_size": 3}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.json()["tasks"]), 3)
+
+        job.refresh_from_db()
+        joined = "\n".join(job.logs.stdout)
+        self.assertIn("Tasks fetched", joined)
+        self.assertIn("delivered=3", joined)
+
 
 class TestJobThroughputLogging(TestCase):
     """Unit tests for _log_job_throughput (Task 3)."""

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -602,6 +602,95 @@ class TestJobView(APITestCase):
         resp = self.client.post(result_url, bare_list, format="json")
         self.assertEqual(resp.status_code, 400)
 
+    def test_tasks_endpoint_logs_fetch_to_job_logger(self):
+        """Successful task-fetch lands a 'Tasks fetched' line on the per-job logger."""
+        pipeline = self._create_pipeline()
+        job = self._create_ml_job("Job for fetch-logging test", pipeline)
+        job.dispatch_mode = JobDispatchMode.ASYNC_API
+        job.status = JobState.STARTED
+        job.save(update_fields=["dispatch_mode", "status"])
+        images = [
+            SourceImage.objects.create(
+                path=f"fetchlog_{i}.jpg",
+                public_base_url="http://example.com",
+                project=self.project,
+            )
+            for i in range(3)
+        ]
+        queue_images_to_nats(job, images)
+
+        self.client.force_authenticate(user=self.user)
+        tasks_url = reverse_with_params("api:job-tasks", args=[job.pk], params={"project_id": self.project.pk})
+        resp = self.client.post(tasks_url, {"batch_size": 2}, format="json")
+        self.assertEqual(resp.status_code, 200)
+
+        job.refresh_from_db()
+        joined = "\n".join(job.logs.stdout)
+        self.assertIn("Tasks fetched", joined)
+        self.assertIn("requested=2", joined)
+        self.assertIn("delivered=", joined)
+        self.assertIn(self.user.email, joined)
+
+    def test_tasks_endpoint_logs_early_exit_for_terminal_job(self):
+        """Polling a terminal-status job produces an empty response and a 'non-active job' log line."""
+        pipeline = self._create_pipeline()
+        job = self._create_ml_job("Job for early-exit log test", pipeline)
+        job.dispatch_mode = JobDispatchMode.ASYNC_API
+        job.status = JobState.SUCCESS
+        job.save(update_fields=["dispatch_mode", "status"])
+
+        self.client.force_authenticate(user=self.user)
+        tasks_url = reverse_with_params("api:job-tasks", args=[job.pk], params={"project_id": self.project.pk})
+        resp = self.client.post(tasks_url, {"batch_size": 5}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"tasks": []})
+
+        job.refresh_from_db()
+        joined = "\n".join(job.logs.stdout)
+        self.assertIn("non-active job", joined)
+        self.assertIn(f"status={JobState.SUCCESS}", joined)
+
+    def test_result_endpoint_mirrors_queued_log_to_job_logger(self):
+        """The result endpoint mirrors its 'Queued pipeline result' line to the per-job logger."""
+        from unittest.mock import MagicMock, patch
+
+        pipeline = self._create_pipeline()
+        job = self._create_ml_job("Job for result-logging test", pipeline)
+
+        self.client.force_authenticate(user=self.user)
+        result_url = reverse_with_params("api:job-result", args=[job.pk], params={"project_id": self.project.pk})
+
+        result_data = {
+            "results": [
+                {
+                    "reply_subject": "test.reply.logged",
+                    "result": {
+                        "pipeline": "test-pipeline",
+                        "algorithms": {},
+                        "total_time": 0.1,
+                        "source_images": [],
+                        "detections": [],
+                        "errors": None,
+                    },
+                }
+            ]
+        }
+
+        # Keep the Celery task from actually running; the log line is emitted
+        # by the view before delegating to Celery.
+        mock_async_result = MagicMock()
+        mock_async_result.id = "mirrored-task-id"
+        with patch("ami.jobs.views.process_nats_pipeline_result.delay", return_value=mock_async_result):
+            resp = self.client.post(result_url, result_data, format="json")
+        self.assertEqual(resp.status_code, 200)
+
+        job.refresh_from_db()
+        joined = "\n".join(job.logs.stdout)
+        self.assertIn("Queued pipeline result", joined)
+        self.assertIn("mirrored-task-id", joined)
+        self.assertIn("test.reply.logged", joined)
+        self.assertIn(self.user.email, joined)
+
 
 class TestJobDispatchModeFiltering(APITestCase):
     """Test job filtering by dispatch_mode."""

--- a/ami/jobs/views.py
+++ b/ami/jobs/views.py
@@ -35,6 +35,21 @@ from .serializers import JobListSerializer, JobSerializer, MinimalJobSerializer
 logger = logging.getLogger(__name__)
 
 
+def _actor_log_context(request) -> tuple[str, str | None]:
+    """
+    Return (user_desc, token_fingerprint) for use in per-job log lines.
+
+    token_fingerprint is the first 8 chars of Token.pk followed by an ellipsis.
+    Under DRF TokenAuthentication, Token.pk IS the 40-char bearer secret, so we
+    must never write the full value to job logs (readable by all project members).
+    Returns None for token_fingerprint when no auth token is present.
+    """
+    user_desc = getattr(request.user, "email", None) or str(request.user)
+    token_id = getattr(request.auth, "pk", None)
+    token_fingerprint = f"{str(token_id)[:8]}…" if token_id is not None else None
+    return user_desc, token_fingerprint
+
+
 def _mark_pipeline_pull_services_seen(job: "Job") -> None:
     """
     Record a heartbeat for async (pull-mode) processing services linked to the job's pipeline.
@@ -267,16 +282,16 @@ class JobViewSet(DefaultViewSet, ProjectMixin):
         if job.dispatch_mode != JobDispatchMode.ASYNC_API:
             raise ValidationError("Only async_api jobs have fetchable tasks")
 
-        user_desc = getattr(request.user, "email", None) or str(request.user)
-        token_id = getattr(request.auth, "pk", None)
+        user_desc, token_fingerprint = _actor_log_context(request)
 
         # Only serve tasks for actively processing jobs. Logging the early-exit
         # makes "phantom-pull" workers (polling against terminal jobs whose NATS
         # stream still exists) visible from the per-job log view.
         if job.status not in JobState.active_states():
+            token_suffix = f", token_id={token_fingerprint}" if token_fingerprint is not None else ""
             job.logger.info(
                 f"Tasks requested for non-active job (status={job.status}); returning empty. "
-                f"user={user_desc}, token_id={token_id}"
+                f"user={user_desc}{token_suffix}"
             )
             return Response({"tasks": []})
 
@@ -299,12 +314,16 @@ class JobViewSet(DefaultViewSet, ProjectMixin):
         except (asyncio.TimeoutError, OSError, nats.errors.Error) as e:
             msg = f"NATS unavailable while fetching tasks for job {job.pk}: {e}"
             logger.warning(msg)
-            job.logger.warning(f"{msg} user={user_desc}, token_id={token_id}")
+            token_suffix = f", token_id={token_fingerprint}" if token_fingerprint is not None else ""
+            job.logger.warning(f"{msg} user={user_desc}{token_suffix}")
             return Response({"error": "Task queue temporarily unavailable"}, status=503)
 
-        job.logger.info(
-            f"Tasks fetched: requested={batch_size}, delivered={len(tasks)}, " f"user={user_desc}, token_id={token_id}"
-        )
+        token_suffix = f", token_id={token_fingerprint}" if token_fingerprint is not None else ""
+        fetch_msg = f"Tasks fetched: requested={batch_size}, delivered={len(tasks)}, user={user_desc}{token_suffix}"
+        if len(tasks) > 0:
+            job.logger.info(fetch_msg)
+        else:
+            job.logger.debug(fetch_msg)
         return Response({"tasks": tasks})
 
     @extend_schema(
@@ -327,8 +346,7 @@ class JobViewSet(DefaultViewSet, ProjectMixin):
         # Record heartbeat for async processing services on this pipeline
         _mark_pipeline_pull_services_seen(job)
 
-        user_desc = getattr(request.user, "email", None) or str(request.user)
-        token_id = getattr(request.auth, "pk", None)
+        user_desc, token_fingerprint = _actor_log_context(request)
 
         serializer = MLJobResultsRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -364,9 +382,10 @@ class JobViewSet(DefaultViewSet, ProjectMixin):
                 # Mirror to per-job logger so the job log view shows result-POST
                 # activity alongside task-fetch activity. Module-logger line above
                 # stays for ops-level monitoring outside the per-job context.
+                token_suffix = f", token_id={token_fingerprint}" if token_fingerprint is not None else ""
                 job.logger.info(
                     f"Queued pipeline result: task_id={task.id}, reply_subject={reply_subject}, "
-                    f"user={user_desc}, token_id={token_id}"
+                    f"user={user_desc}{token_suffix}"
                 )
 
             return Response(

--- a/ami/jobs/views.py
+++ b/ami/jobs/views.py
@@ -267,8 +267,17 @@ class JobViewSet(DefaultViewSet, ProjectMixin):
         if job.dispatch_mode != JobDispatchMode.ASYNC_API:
             raise ValidationError("Only async_api jobs have fetchable tasks")
 
-        # Only serve tasks for actively processing jobs
+        user_desc = getattr(request.user, "email", None) or str(request.user)
+        token_id = getattr(request.auth, "pk", None)
+
+        # Only serve tasks for actively processing jobs. Logging the early-exit
+        # makes "phantom-pull" workers (polling against terminal jobs whose NATS
+        # stream still exists) visible from the per-job log view.
         if job.status not in JobState.active_states():
+            job.logger.info(
+                f"Tasks requested for non-active job (status={job.status}); returning empty. "
+                f"user={user_desc}, token_id={token_id}"
+            )
             return Response({"tasks": []})
 
         # Validate that the job has a pipeline
@@ -288,9 +297,14 @@ class JobViewSet(DefaultViewSet, ProjectMixin):
         try:
             tasks = async_to_sync(get_tasks)()
         except (asyncio.TimeoutError, OSError, nats.errors.Error) as e:
-            logger.warning("NATS unavailable while fetching tasks for job %s: %s", job.pk, e)
+            msg = f"NATS unavailable while fetching tasks for job {job.pk}: {e}"
+            logger.warning(msg)
+            job.logger.warning(f"{msg} user={user_desc}, token_id={token_id}")
             return Response({"error": "Task queue temporarily unavailable"}, status=503)
 
+        job.logger.info(
+            f"Tasks fetched: requested={batch_size}, delivered={len(tasks)}, " f"user={user_desc}, token_id={token_id}"
+        )
         return Response({"tasks": tasks})
 
     @extend_schema(
@@ -312,6 +326,9 @@ class JobViewSet(DefaultViewSet, ProjectMixin):
 
         # Record heartbeat for async processing services on this pipeline
         _mark_pipeline_pull_services_seen(job)
+
+        user_desc = getattr(request.user, "email", None) or str(request.user)
+        token_id = getattr(request.auth, "pk", None)
 
         serializer = MLJobResultsRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -343,6 +360,13 @@ class JobViewSet(DefaultViewSet, ProjectMixin):
                     job.pk,
                     task.id,
                     reply_subject,
+                )
+                # Mirror to per-job logger so the job log view shows result-POST
+                # activity alongside task-fetch activity. Module-logger line above
+                # stays for ops-level monitoring outside the per-job context.
+                job.logger.info(
+                    f"Queued pipeline result: task_id={task.id}, reply_subject={reply_subject}, "
+                    f"user={user_desc}, token_id={token_id}"
                 )
 
             return Response(


### PR DESCRIPTION
## What this does (plain English)

While an ML job is running, the job's log view was mostly empty during the long stretches where workers were actually doing the work. This PR fills that in: every worker poll, every result POST back from a worker, and a progress-rate line all show up in the job log now — along with which user and API token drove each request. Makes it much easier to tell at a glance whether a job is healthy, slow, or stuck, and who's doing what.

---

## Summary

Adds structured observability log lines to the per-job logger for `async_api` ML jobs, so worker activity is visible from the job log view (`GET /api/v2/jobs/{id}/` → `logs.stdout`).

Three additions in `ami/jobs/views.py` and `ami/jobs/tasks.py`:

- **Task-fetch lines** (`JobViewSet.tasks()`): `Tasks fetched: requested=..., delivered=..., user=..., token_id=...` on every worker poll. Fills in the silence window between `Created NATS stream` and the first `Updated job progress` line — previously the job log showed nothing during this stretch even though workers were actively polling.
- **Result-POST mirror lines** (`JobViewSet.result()`): `Queued pipeline result: task_id=..., reply_subject=..., user=...` mirrors the existing module-logger emission to the per-job log. Module-logger copy is retained for ops-level monitoring.
- **Throughput / ETA lines** (`_log_job_throughput` in `ami/jobs/tasks.py`): `Job {id} throughput: elapsed=..., processed=P/T, rate=R imgs/min, ETA=...` on `process`/`results` stage progress updates. Intentionally a plain `processed/elapsed` division rather than a rolling-window estimator — accurate enough to distinguish stalled-vs-slow from healthy-but-throttled, cheap, easy to eyeball. Guarded by `started_at != None` and skipped on non-process/results stages.
- **Phantom-pull early-exit line**: `POST /tasks/` against a terminal job now logs `Tasks requested for non-active job (status=...); returning empty.` to the per-job log instead of silently returning `{"tasks": []}`. Restores the signal used to detect workers still polling terminal jobs.

## Test plan

- [x] `ami.jobs.tests.test_jobs` — unit tests cover all four log lines (65/65 pass)
- [x] E2E on local compose stack (50-image `async_api` job) — all four signals observed in the live `logs.stdout` view; throughput line ETAs monotonically decrease and match DB counts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job progress logging now includes throughput metrics (images per minute) and estimated time to completion for processing stages.
  * Enhanced job event logging with detailed context including user information and task counts.

* **Tests**
  * Added comprehensive test coverage for job throughput logging and per-job logging behavior across job endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## E2E validation

Ran against a local compose stack with one `async_api` ML job: 50-image random collection, pipeline `quebec_vermont_moths_2023`, ADC worker. Job completed successfully in ~4 minutes (50 images / 483 detections). Pulled the resulting `job.logs.stdout` via `GET /api/v2/jobs/{id}/` and grep-counted each of the four new log lines. User/token identifiers redacted below.

**Tasks fetched** — 68 lines. `delivered` value correctly tracks the silence window (8× `delivered=8` during initial pulls, 2× `delivered=2` partial, 58× `delivered=0` during the batch-processing stretch when no work is outstanding):

```
[… 18:56:28] INFO Tasks fetched: requested=8, delivered=8, user=<user>, token_id=<…>
[… 19:00:25] INFO Tasks fetched: requested=8, delivered=0, user=<user>, token_id=<…>
```

**Queued pipeline result** — 84 per-job lines observed; module-logger copy landed 100× in `django` container logs (both emissions sit in the same `for` loop). The per-job log is ~16/100 below the module log — likely a Job-row save race when multiple `/result/` POSTs land concurrently (`job.logger.info` appends to a JSONB list on the Job row, and overlapping writes can lose entries). Not a correctness issue for the feature, but worth filing as a follow-up; the module-logger copy was retained exactly so ops doesn't rely solely on the per-job view.

**Throughput / ETA** — 64 lines, all on `process`/`results` stages (none on `collect`, confirming the stage filter). First line at elapsed=2m 11s (confirming the `started_at` guard). `processed` matches `SourceImageCollection.source_images_count` (50). ETA shrinks monotonically once processing ramps up:

```
[… 18:58:39] INFO Job N throughput: elapsed=2m 11s, processed=1/50, rate=0.5 imgs/min, ETA=1h 47m 16s
[… 19:00:25] INFO Job N throughput: elapsed=3m 57s, processed=46/50, rate=11.6 imgs/min, ETA=0m 20s
[… 19:00:27] INFO Job N throughput: elapsed=3m 59s, processed=50/50, rate=12.5 imgs/min, ETA=0m 00s
```

**Phantom-pull early-exit** — after the job hit `SUCCESS`, posting an extra `/tasks/` call returned `{"tasks":[]}` and wrote the expected line to `logs.stdout`:

```
[… 19:02:41] INFO Tasks requested for non-active job (status=SUCCESS); returning empty. user=<user>, token_id=<…>
```