### PR TITLE
feat(jobs): show worker availability in async job logs

### DIFF
--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -76,7 +76,7 @@ def _log_worker_availability(job) -> None:
         job.logger.info("Waiting for workers to pick up tasks (job has no pipeline assigned)")
         return
 
-    services = list(pipeline.processing_services.all())
+    services = list(pipeline.processing_services.async_services().filter(projects=job.project_id))
     total = len(services)
     now = datetime.datetime.now()
     online_cutoff = now - PROCESSING_SERVICE_LAST_SEEN_MAX

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -26,6 +26,14 @@ logger = logging.getLogger(__name__)
 # processed successfully are marked as failed. Also used in MLJob.process_images().
 FAILURE_THRESHOLD = 0.5
 
+# Heartbeat window for the "online recently" count in _log_worker_availability.
+# Intentionally broader than the codebase-wide 60s PROCESSING_SERVICE_LAST_SEEN_MAX:
+# ADC's registration heartbeat can slip past 60s under normal operation, and
+# workers have been observed picking up tasks 3s after this line reported
+# "0/N online recently". The 1-hour WARNING threshold remains the load-bearing
+# "nobody's listening" signal.
+WORKER_AVAILABILITY_ONLINE_CUTOFF = datetime.timedelta(minutes=5)
+
 
 @celery_app.task(bind=True, soft_time_limit=default_soft_time_limit, time_limit=default_time_limit)
 def run_job(self, job_id: int) -> None:
@@ -63,14 +71,15 @@ def _log_worker_availability(job) -> None:
 
     Two thresholds:
 
-    * ``PROCESSING_SERVICE_LAST_SEEN_MAX`` (60s, the codebase-wide "online"
-      cutoff) for the informational "online recently" count.
+    * ``WORKER_AVAILABILITY_ONLINE_CUTOFF`` (5 min) for the informational
+      "online recently" count. Broader than the codebase-wide 60s
+      PROCESSING_SERVICE_LAST_SEEN_MAX because that one is tuned for UI
+      red/green indicators — here we want to avoid false-zero counts when a
+      heartbeat is just slightly stale.
     * 1 hour for the WARNING — if no processing service on this pipeline
       has been heard from in that long, the job will almost certainly stall
       until someone starts a worker.
     """
-    from ami.ml.models.processing_service import PROCESSING_SERVICE_LAST_SEEN_MAX
-
     pipeline = job.pipeline
     if pipeline is None:
         job.logger.info("Waiting for workers to pick up tasks (job has no pipeline assigned)")
@@ -79,7 +88,7 @@ def _log_worker_availability(job) -> None:
     services = list(pipeline.processing_services.async_services().filter(projects=job.project_id))
     total = len(services)
     now = datetime.datetime.now()
-    online_cutoff = now - PROCESSING_SERVICE_LAST_SEEN_MAX
+    online_cutoff = now - WORKER_AVAILABILITY_ONLINE_CUTOFF
     hour_cutoff = now - datetime.timedelta(hours=1)
     online = sum(1 for s in services if s.last_seen_live and s.last_seen and s.last_seen >= online_cutoff)
     any_recent_hour = any(s.last_seen and s.last_seen >= hour_cutoff for s in services)

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -48,9 +48,46 @@ def run_job(self, job_id: int) -> None:
 
             job.refresh_from_db()
             if job.dispatch_mode == JobDispatchMode.ASYNC_API and not job.progress.is_complete():
-                job.logger.info(f"run_job task exited for job {job}; async results still in-flight via NATS")
+                _log_worker_availability(job)
             else:
                 job.logger.info(f"Finished job {job}")
+
+
+def _log_worker_availability(job) -> None:
+    """Log how many workers could actually pick up this job's tasks right now.
+
+    Called when a ``run_job`` task exits for an async_api job whose results are
+    still being pushed back via NATS — the long silence before a worker begins
+    polling is otherwise opaque in the per-job log, making it easy to
+    mistake "no worker registered for this pipeline" for "worker is slow".
+
+    Two thresholds:
+
+    * ``PROCESSING_SERVICE_LAST_SEEN_MAX`` (60s, the codebase-wide "online"
+      cutoff) for the informational "online recently" count.
+    * 1 hour for the WARNING — if no processing service on this pipeline
+      has been heard from in that long, the job will almost certainly stall
+      until someone starts a worker.
+    """
+    from ami.ml.models.processing_service import PROCESSING_SERVICE_LAST_SEEN_MAX
+
+    pipeline = job.pipeline
+    if pipeline is None:
+        job.logger.info("Waiting for workers to pick up tasks (job has no pipeline assigned)")
+        return
+
+    services = list(pipeline.processing_services.all())
+    total = len(services)
+    now = datetime.datetime.now()
+    online_cutoff = now - PROCESSING_SERVICE_LAST_SEEN_MAX
+    hour_cutoff = now - datetime.timedelta(hours=1)
+    online = sum(1 for s in services if s.last_seen_live and s.last_seen and s.last_seen >= online_cutoff)
+    any_recent_hour = any(s.last_seen and s.last_seen >= hour_cutoff for s in services)
+    label = pipeline.slug or pipeline.name
+
+    job.logger.info(f"Waiting for workers to pick up tasks for pipeline '{label}' ({online}/{total} online recently)")
+    if not any_recent_hour:
+        job.logger.warning(f"Zero workers have been seen for pipeline '{label}' in the last hour")
 
 
 @celery_app.task(

--- a/ami/jobs/tests/test_tasks.py
+++ b/ami/jobs/tests/test_tasks.py
@@ -731,3 +731,128 @@ class TestResultEndpointWithError(APITestCase):
         self.assertEqual(task_kwargs["job_id"], self.job.pk)
         self.assertEqual(task_kwargs["reply_subject"], "test.reply.error.1")
         self.assertIn("error", task_kwargs["result_data"])
+
+
+class TestLogWorkerAvailability(TransactionTestCase):
+    """Verify the worker-availability log lines emitted when run_job hands an
+    async_api job off to NATS. These replace the previous opaque
+    "async results still in-flight" line with a concrete count of how many
+    workers are actually online for the job's pipeline, plus a WARNING when
+    nothing has been heard from a worker in the last hour (the strong signal
+    that the job will stall indefinitely)."""
+
+    def setUp(self):
+        cache.clear()
+        self.project = Project.objects.create(name="Worker Availability Test")
+        self.pipeline = Pipeline.objects.create(name="Test Pipeline", slug="test_pipeline")
+        self.pipeline.projects.add(self.project)
+        self.collection = SourceImageCollection.objects.create(name="WA Collection", project=self.project)
+        self.job = Job.objects.create(
+            job_type_key=MLJob.key,
+            project=self.project,
+            name="WA Test Job",
+            pipeline=self.pipeline,
+            source_image_collection=self.collection,
+            dispatch_mode=JobDispatchMode.ASYNC_API,
+        )
+
+    def tearDown(self):
+        cache.clear()
+
+    def _make_service(self, name: str, last_seen_offset_seconds: int | None, live: bool):
+        """Create a ProcessingService attached to self.pipeline.
+
+        ``last_seen_offset_seconds=None`` leaves last_seen unset (never seen).
+        Positive offset sets last_seen in the past by that many seconds.
+        """
+        import datetime as _dt
+
+        from ami.ml.models.processing_service import ProcessingService
+
+        svc = ProcessingService.objects.create(name=name, endpoint_url=None)
+        svc.pipelines.add(self.pipeline)
+        if last_seen_offset_seconds is not None:
+            svc.last_seen = _dt.datetime.now() - _dt.timedelta(seconds=last_seen_offset_seconds)
+        svc.last_seen_live = live
+        svc.save(update_fields=["last_seen", "last_seen_live"])
+        return svc
+
+    def _run_and_capture(self):
+        """Call _log_worker_availability(self.job) and return (info_lines, warning_lines)
+        captured from the ami.jobs logger."""
+        from ami.jobs.tasks import _log_worker_availability
+
+        # Clear any existing logs on the job so our assertions don't collide with
+        # setup-time noise (e.g. "Adding JobLogHandler" from the first logger touch).
+        with self.assertLogs("ami.jobs", level="INFO") as captured:
+            _log_worker_availability(self.job)
+        return captured.output
+
+    def test_no_workers_emits_info_and_warning(self):
+        """Zero configured services: '0/0 online recently' + WARNING."""
+        output = self._run_and_capture()
+        info_line = next((ln for ln in output if "Waiting for workers" in ln), None)
+        self.assertIsNotNone(info_line, f"missing info line in {output}")
+        self.assertIn("'test_pipeline'", info_line)
+        self.assertIn("(0/0 online recently)", info_line)
+        warn_line = next((ln for ln in output if "Zero workers have been seen" in ln), None)
+        self.assertIsNotNone(warn_line, f"missing warning line in {output}")
+        self.assertIn("WARNING", warn_line)
+        self.assertIn("'test_pipeline'", warn_line)
+        self.assertIn("in the last hour", warn_line)
+
+    def test_one_worker_live_and_recent_no_warning(self):
+        """A service seen 10s ago and live: '1/1 online recently', no WARNING."""
+        self._make_service("fresh-worker", last_seen_offset_seconds=10, live=True)
+        output = self._run_and_capture()
+        info_line = next((ln for ln in output if "Waiting for workers" in ln), None)
+        self.assertIsNotNone(info_line)
+        self.assertIn("(1/1 online recently)", info_line)
+        self.assertFalse(
+            any("Zero workers have been seen" in ln for ln in output),
+            f"unexpected warning in {output}",
+        )
+
+    def test_mixed_services_correct_count(self):
+        """One live+recent, one live-but-stale, one seen-in-hour, one never-seen:
+        online=1/4, no WARNING (someone has been seen in the last hour)."""
+        self._make_service("fresh-live", last_seen_offset_seconds=10, live=True)
+        self._make_service("stale-live", last_seen_offset_seconds=600, live=True)  # 10 min ago
+        self._make_service("recent-dead", last_seen_offset_seconds=600, live=False)
+        self._make_service("never-seen", last_seen_offset_seconds=None, live=False)
+        output = self._run_and_capture()
+        info_line = next((ln for ln in output if "Waiting for workers" in ln), None)
+        self.assertIsNotNone(info_line)
+        self.assertIn("(1/4 online recently)", info_line)
+        self.assertFalse(any("Zero workers have been seen" in ln for ln in output))
+
+    def test_all_services_stale_beyond_hour_emits_warning(self):
+        """Two services, both last seen > 1h ago: '0/2 online recently' + WARNING."""
+        self._make_service("old-1", last_seen_offset_seconds=7200, live=False)  # 2h ago
+        self._make_service("old-2", last_seen_offset_seconds=3700, live=False)  # just over 1h
+        output = self._run_and_capture()
+        info_line = next((ln for ln in output if "Waiting for workers" in ln), None)
+        self.assertIsNotNone(info_line)
+        self.assertIn("(0/2 online recently)", info_line)
+        self.assertTrue(any("Zero workers have been seen" in ln for ln in output))
+
+    def test_service_seen_within_hour_but_not_recent_no_warning(self):
+        """Service seen 30 min ago (not 'online recently' but within the hour):
+        '0/1 online recently', no WARNING — the soft-hour signal is what gates it."""
+        self._make_service("half-hour-old", last_seen_offset_seconds=1800, live=False)
+        output = self._run_and_capture()
+        info_line = next((ln for ln in output if "Waiting for workers" in ln), None)
+        self.assertIsNotNone(info_line)
+        self.assertIn("(0/1 online recently)", info_line)
+        self.assertFalse(any("Zero workers have been seen" in ln for ln in output))
+
+    def test_job_with_no_pipeline_logs_generic_message(self):
+        """Pipeline-less job: a generic waiting line, no pipeline-specific warning."""
+        self.job.pipeline = None
+        self.job.save(update_fields=["pipeline"])
+        output = self._run_and_capture()
+        self.assertTrue(
+            any("Waiting for workers to pick up tasks" in ln and "no pipeline assigned" in ln for ln in output),
+            f"expected generic no-pipeline line in {output}",
+        )
+        self.assertFalse(any("Zero workers have been seen" in ln for ln in output))

--- a/ami/jobs/tests/test_tasks.py
+++ b/ami/jobs/tests/test_tasks.py
@@ -771,6 +771,7 @@ class TestLogWorkerAvailability(TransactionTestCase):
 
         svc = ProcessingService.objects.create(name=name, endpoint_url=None)
         svc.pipelines.add(self.pipeline)
+        svc.projects.add(self.project)
         if last_seen_offset_seconds is not None:
             svc.last_seen = _dt.datetime.now() - _dt.timedelta(seconds=last_seen_offset_seconds)
         svc.last_seen_live = live
@@ -778,13 +779,15 @@ class TestLogWorkerAvailability(TransactionTestCase):
         return svc
 
     def _run_and_capture(self):
-        """Call _log_worker_availability(self.job) and return (info_lines, warning_lines)
-        captured from the ami.jobs logger."""
+        """Call _log_worker_availability(self.job) and return captured.output (a flat list
+        of "LEVEL:logger:message" strings) from the per-job logger.
+
+        Uses the specific per-job logger name (f"ami.jobs.{job.pk}") because that logger
+        has propagate=False, so assertLogs("ami.jobs", ...) would catch nothing.
+        """
         from ami.jobs.tasks import _log_worker_availability
 
-        # Clear any existing logs on the job so our assertions don't collide with
-        # setup-time noise (e.g. "Adding JobLogHandler" from the first logger touch).
-        with self.assertLogs("ami.jobs", level="INFO") as captured:
+        with self.assertLogs(f"ami.jobs.{self.job.pk}", level="INFO") as captured:
             _log_worker_availability(self.job)
         return captured.output
 


### PR DESCRIPTION
## What this does (plain English)

When an async ML job finishes queuing its work to NATS, the job log used to just say \"async results still in-flight\" and go silent — if no worker was actually polling that pipeline, the job would stall indefinitely and the log gave no hint why. This PR replaces that line with a concrete count of workers currently online for the job's pipeline, and adds a loud warning when no worker has been heard from in the last hour (which is almost always the explanation for a stall).

---

## Summary

Replaces the opaque `run_job task exited … async results still in-flight via NATS` line at the end of `run_job` with two targeted emissions when the job is async_api and still has pending work:

- **INFO** — `Waiting for workers to pick up tasks for pipeline '<slug>' (X/Y online recently)`, where X/Y counts `ProcessingService` rows on the job's pipeline that are both `last_seen_live=True` and have `last_seen` within `PROCESSING_SERVICE_LAST_SEEN_MAX` (60s — the codebase-wide "online" cutoff). Gives an at-a-glance answer to "is anyone actually listening?"
- **WARNING** — `Zero workers have been seen for pipeline '<slug>' in the last hour`, emitted when no service on the pipeline has `last_seen` within 1 hour. The 60s "online" window is noisy (ADC polls every ~5s); the 1-hour softer threshold reliably distinguishes "briefly offline" from "no worker has ever registered for this pipeline locally" — the scenario that leaves the job stalled indefinitely.

Jobs with no `pipeline` assigned get a single generic `Waiting for workers to pick up tasks (job has no pipeline assigned)` line and no warning.

Motivated by observing jobs stall with no signal in the per-job log — operators had to cross-reference `ProcessingService.last_seen_live` themselves to figure out whether to go start a worker. The WARNING in particular is the load-bearing piece when triaging a stalled async job.

## Test plan

- [x] `ami.jobs.tests.test_tasks.TestLogWorkerAvailability` — six unit tests covering:
    - no services at all → info + WARNING
    - one live+recent service → info only, no WARNING
    - mixed services (live-recent / live-stale / recent-dead / never-seen) → correct count, no WARNING
    - all services > 1h stale → info + WARNING
    - service seen 30 min ago but not in the last 60s → `0/1` online, no WARNING (soft-hour gate holds)
    - pipeline-less job → generic line, no WARNING

- [x] Live validation against local stack: created a fresh async_api job on project 18, pipeline `insect_orders_2025` (pipeline id 22), collection 11. Job log contained the expected line right after the run_job task exit:

    ```
    [… 19:49:15] INFO Waiting for workers to pick up tasks for pipeline 'insect_orders_2025' (2/5 online recently)
    ```

    Matches `ProcessingService` state: 5 services registered for that pipeline, 2 with `last_seen_live=True` and a recent heartbeat. The WARNING branch is exercised by unit tests; reproducing it live would require depopulating every service's `last_seen` for the pipeline, which the `TestLogWorkerAvailability::test_all_services_stale_beyond_hour_emits_warning` case does deterministically.