### PR TITLE
Make missing-Redis-state job failures loud and self-diagnosing

### DIFF
--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -355,6 +355,7 @@ def _fail_job(job_id: int, reason: str) -> None:
             try:
                 job.progress.errors.append(reason)
             except Exception:
+                # Don't let diagnostic-write failures mask the original FAILURE.
                 pass
             job.update_status(JobState.FAILURE, save=False)
             job.finished_at = datetime.datetime.now()

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -45,7 +45,13 @@ def run_job(self, job_id: int) -> None:
         raise e
         # self.retry(exc=e, countdown=1, max_retries=1)
     else:
-        job.logger.info(f"Running job {job}")
+        # Log the Redis target at task start so cross-host DB-index drift surfaces
+        # in every job's log without needing to know where to look. The cluster
+        # convention is DB 0 = cache, DB 1 = Celery results (see
+        # config/settings/base.py); the Job state manager also uses the "default"
+        # connection, so every worker in the pool must agree on the DB number or
+        # initialize_job writes to one DB while update_state reads from another.
+        job.logger.info(f"Running job {job} on {_describe_redis_target()}")
         try:
             job.run()
         except Exception as e:
@@ -171,9 +177,17 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
     if not progress_info:
         # State keys genuinely missing (the total-images key returned None).
         # Ack so NATS stops redelivering and fail the job — there's no state
-        # left to reconcile against.
+        # left to reconcile against. The reason string is built from a live
+        # Redis snapshot (DB index, keys present under job:{id}:*) so the
+        # FAILURE log and the UI progress.errors entry name the actual cause
+        # instead of the previous hardcoded "likely cleaned up concurrently"
+        # guess — which conflated DB-index misconfig, eviction, and genuine
+        # concurrent cleanup into a single misleading string.
         _ack_task_via_nats(reply_subject, logger)
-        _fail_job(job_id, "Job state keys not found in Redis (likely cleaned up concurrently)")
+        _fail_job(
+            job_id,
+            f"Job state missing from Redis (stage=process): {state_manager.diagnose_missing_state()}",
+        )
         return
 
     try:
@@ -255,7 +269,10 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
             # first so NATS stops redelivering a message whose state is gone,
             # then fail the job. Mirrors the stage=process missing-state path.
             _ack_task_via_nats(reply_subject, job.logger)
-            _fail_job(job_id, "Job state keys not found in Redis (likely cleaned up concurrently)")
+            _fail_job(
+                job_id,
+                f"Job state missing from Redis (stage=results): {state_manager.diagnose_missing_state()}",
+            )
             return
 
         # update complete state based on latest progress info after saving results
@@ -304,6 +321,24 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
         job.logger.error(error)
 
 
+def _describe_redis_target() -> str:
+    """Return a ``host:port/dbN`` string for the "default" Redis connection.
+
+    Logged at the start of every ``run_job`` so DB-index drift across hosts
+    (the class of misconfig that manifests as silent ``process_nats_pipeline_result``
+    FAILUREs on whichever worker happens to read state from the wrong DB) is
+    visible in each job's log without requiring a separate diagnostic.
+    """
+    try:
+        from django_redis import get_redis_connection
+
+        redis = get_redis_connection("default")
+        kwargs = getattr(redis.connection_pool, "connection_kwargs", {}) or {}
+        return f"redis={kwargs.get('host', '?')}:{kwargs.get('port', '?')}/db{kwargs.get('db', '?')}"
+    except Exception as e:
+        return f"redis=(unavailable: {e})"
+
+
 def _fail_job(job_id: int, reason: str) -> None:
     from ami.jobs.models import Job, JobState
     from ami.ml.orchestration.jobs import cleanup_async_job_resources
@@ -313,6 +348,14 @@ def _fail_job(job_id: int, reason: str) -> None:
             job = Job.objects.select_for_update().get(pk=job_id)
             if job.status in (JobState.CANCELING, *JobState.final_states()):
                 return
+            # Mirror the reason into progress.errors so the UI surfaces it
+            # alongside the FAILURE state. Previously the reason lived only in
+            # job.logger, which meant the UI showed errors=[] and operators had
+            # to dig into Celery worker logs to find out why a job died.
+            try:
+                job.progress.errors.append(reason)
+            except Exception:
+                pass
             job.update_status(JobState.FAILURE, save=False)
             job.finished_at = datetime.datetime.now()
             job.save(update_fields=["status", "progress", "finished_at"])

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -434,7 +434,7 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
 
 
 def _describe_redis_target() -> str:
-    """Return a ``host:port/dbN`` string for the "default" Redis connection.
+    """Return a ``redis=host:port/dbN`` string for the "default" Redis connection.
 
     Logged at the start of every ``run_job`` so DB-index drift across hosts
     (the class of misconfig that manifests as silent ``process_nats_pipeline_result``

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -146,13 +146,15 @@ def run_job(self, job_id: int) -> None:
         raise e
         # self.retry(exc=e, countdown=1, max_retries=1)
     else:
-        # Log the Redis target at task start so cross-host DB-index drift surfaces
-        # in every job's log without needing to know where to look. The cluster
-        # convention is DB 0 = cache, DB 1 = Celery results (see
-        # config/settings/base.py); the Job state manager also uses the "default"
-        # connection, so every worker in the pool must agree on the DB number or
-        # initialize_job writes to one DB while update_state reads from another.
-        job.logger.info(f"Running job {job} on {_describe_redis_target()}")
+        # Log the Redis DB index at task start so cross-host DB-index drift — the misconfig
+        # that surfaces as silent process_nats_pipeline_result FAILUREs on whichever worker
+        # reads state from the wrong DB — is visible per job. Every host's "default" Redis
+        # connection (the one the job state manager uses) must select the same DB number, or
+        # initialize_job and update_state operate on different DBs. The public job log carries
+        # only the DB index; the full host:port goes to the server log, since the host names
+        # internal infrastructure.
+        job.logger.info(f"Running job {job} on Redis db {_redis_db_index()}")
+        logger.info("Job %s Redis target: %s", job.pk, _describe_redis_target())
         try:
             job.run()
         except Exception as e:
@@ -433,13 +435,29 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
         job.logger.error(error)
 
 
+def _redis_db_index() -> str:
+    """Return just the DB index of the "default" Redis connection (e.g. ``"1"``).
+
+    Safe for the public job log: the DB index is the load-bearing signal for diagnosing
+    cross-host DB drift, without exposing the internal Redis host. Pair with
+    :func:`_describe_redis_target` (host:port, server logs only) when an operator needs the host.
+    """
+    try:
+        from django_redis import get_redis_connection
+
+        redis = get_redis_connection("default")
+        kwargs = getattr(redis.connection_pool, "connection_kwargs", {}) or {}
+        return str(kwargs.get("db", "?"))
+    except Exception as e:
+        return f"(unavailable: {e})"
+
+
 def _describe_redis_target() -> str:
     """Return a ``redis=host:port/dbN`` string for the "default" Redis connection.
 
-    Logged at the start of every ``run_job`` so DB-index drift across hosts
-    (the class of misconfig that manifests as silent ``process_nats_pipeline_result``
-    FAILUREs on whichever worker happens to read state from the wrong DB) is
-    visible in each job's log without requiring a separate diagnostic.
+    For server-side logs only — it names the internal Redis host, so it must not reach the
+    public job log (use :func:`_redis_db_index` there). Logged server-side at ``run_job`` start
+    so an operator can resolve a DB-index drift to a specific host.
     """
     try:
         from django_redis import get_redis_connection
@@ -465,9 +483,11 @@ def _fail_job(job_id: int, reason: str) -> None:
             # job detail view without digging through Celery worker logs.
             try:
                 job.progress.errors.append(reason)
-            except Exception:
-                # Don't let diagnostic-write failures mask the original FAILURE.
-                pass
+            except Exception as e:
+                # Don't let a diagnostic-write failure mask the original FAILURE, but record
+                # that the reason could not be attached so the swallow is observable — otherwise
+                # the UI silently loses the cause this PR exists to surface.
+                logger.warning("Job %s: could not append failure reason to progress.errors: %s", job_id, e)
             job.update_status(JobState.FAILURE, save=False)
             job.finished_at = datetime.datetime.now()
             job.save(update_fields=["status", "progress", "finished_at"])

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -467,6 +467,7 @@ def _fail_job(job_id: int, reason: str) -> None:
             try:
                 job.progress.errors.append(reason)
             except Exception:
+                # Don't let diagnostic-write failures mask the original FAILURE.
                 pass
             job.update_status(JobState.FAILURE, save=False)
             job.finished_at = datetime.datetime.now()

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -461,9 +461,8 @@ def _fail_job(job_id: int, reason: str) -> None:
             if job.status in (JobState.CANCELING, *JobState.final_states()):
                 return
             # Mirror the reason into progress.errors so the UI surfaces it
-            # alongside the FAILURE state. Previously the reason lived only in
-            # job.logger, which meant the UI showed errors=[] and operators had
-            # to dig into Celery worker logs to find out why a job died.
+            # alongside the FAILURE status. Operators can see the cause in the
+            # job detail view without digging through Celery worker logs.
             try:
                 job.progress.errors.append(reason)
             except Exception:

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -146,7 +146,13 @@ def run_job(self, job_id: int) -> None:
         raise e
         # self.retry(exc=e, countdown=1, max_retries=1)
     else:
-        job.logger.info(f"Running job {job}")
+        # Log the Redis target at task start so cross-host DB-index drift surfaces
+        # in every job's log without needing to know where to look. The cluster
+        # convention is DB 0 = cache, DB 1 = Celery results (see
+        # config/settings/base.py); the Job state manager also uses the "default"
+        # connection, so every worker in the pool must agree on the DB number or
+        # initialize_job writes to one DB while update_state reads from another.
+        job.logger.info(f"Running job {job} on {_describe_redis_target()}")
         try:
             job.run()
         except Exception as e:
@@ -281,10 +287,18 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
     if not progress_info:
         # State keys genuinely missing (the total-images key returned None).
         # Ack so NATS stops redelivering and fail the job — there's no state
-        # left to reconcile against.
+        # left to reconcile against. The reason string is built from a live
+        # Redis snapshot (DB index, keys present under job:{id}:*) so the
+        # FAILURE log and the UI progress.errors entry name the actual cause
+        # instead of the previous hardcoded "likely cleaned up concurrently"
+        # guess — which conflated DB-index misconfig, eviction, and genuine
+        # concurrent cleanup into a single misleading string.
         _log_missing_state_context(job_id, "process")
         _ack_task_via_nats(reply_subject, logger)
-        _fail_job(job_id, "Job state keys not found in Redis (likely cleaned up concurrently)")
+        _fail_job(
+            job_id,
+            f"Job state missing from Redis (stage=process): {state_manager.diagnose_missing_state()}",
+        )
         return
 
     try:
@@ -367,7 +381,10 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
             # then fail the job. Mirrors the stage=process missing-state path.
             _log_missing_state_context(job_id, "results")
             _ack_task_via_nats(reply_subject, job.logger)
-            _fail_job(job_id, "Job state keys not found in Redis (likely cleaned up concurrently)")
+            _fail_job(
+                job_id,
+                f"Job state missing from Redis (stage=results): {state_manager.diagnose_missing_state()}",
+            )
             return
 
         # update complete state based on latest progress info after saving results
@@ -416,6 +433,24 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
         job.logger.error(error)
 
 
+def _describe_redis_target() -> str:
+    """Return a ``host:port/dbN`` string for the "default" Redis connection.
+
+    Logged at the start of every ``run_job`` so DB-index drift across hosts
+    (the class of misconfig that manifests as silent ``process_nats_pipeline_result``
+    FAILUREs on whichever worker happens to read state from the wrong DB) is
+    visible in each job's log without requiring a separate diagnostic.
+    """
+    try:
+        from django_redis import get_redis_connection
+
+        redis = get_redis_connection("default")
+        kwargs = getattr(redis.connection_pool, "connection_kwargs", {}) or {}
+        return f"redis={kwargs.get('host', '?')}:{kwargs.get('port', '?')}/db{kwargs.get('db', '?')}"
+    except Exception as e:
+        return f"redis=(unavailable: {e})"
+
+
 def _fail_job(job_id: int, reason: str) -> None:
     from ami.jobs.models import Job, JobState
     from ami.ml.orchestration.jobs import cleanup_async_job_resources
@@ -425,6 +460,14 @@ def _fail_job(job_id: int, reason: str) -> None:
             job = Job.objects.select_for_update().get(pk=job_id)
             if job.status in (JobState.CANCELING, *JobState.final_states()):
                 return
+            # Mirror the reason into progress.errors so the UI surfaces it
+            # alongside the FAILURE state. Previously the reason lived only in
+            # job.logger, which meant the UI showed errors=[] and operators had
+            # to dig into Celery worker logs to find out why a job died.
+            try:
+                job.progress.errors.append(reason)
+            except Exception:
+                pass
             job.update_status(JobState.FAILURE, save=False)
             job.finished_at = datetime.datetime.now()
             job.save(update_fields=["status", "progress", "finished_at"])

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -146,13 +146,10 @@ def run_job(self, job_id: int) -> None:
         raise e
         # self.retry(exc=e, countdown=1, max_retries=1)
     else:
-        # Log the Redis DB index at task start so cross-host DB-index drift — the misconfig
-        # that surfaces as silent process_nats_pipeline_result FAILUREs on whichever worker
-        # reads state from the wrong DB — is visible per job. Every host's "default" Redis
-        # connection (the one the job state manager uses) must select the same DB number, or
-        # initialize_job and update_state operate on different DBs. The public job log carries
-        # only the DB index; the full host:port goes to the server log, since the host names
-        # internal infrastructure.
+        # Log the Redis DB index at task start so cross-host DB-index drift is visible per job
+        # (workers reading state from a different DB than run_job wrote it to fail silently in
+        # process_nats_pipeline_result). Public log carries only the DB index; host:port goes
+        # to the server log, since the host names internal infrastructure.
         job.logger.info(f"Running job {job} on Redis db {_redis_db_index()}")
         logger.info("Job %s Redis target: %s", job.pk, _describe_redis_target())
         try:
@@ -289,12 +286,10 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
     if not progress_info:
         # State keys genuinely missing (the total-images key returned None).
         # Ack so NATS stops redelivering and fail the job — there's no state
-        # left to reconcile against. The reason string is built from a live
-        # Redis snapshot (DB index, keys present under job:{id}:*) so the
-        # FAILURE log and the UI progress.errors entry name the actual cause
-        # instead of the previous hardcoded "likely cleaned up concurrently"
-        # guess — which conflated DB-index misconfig, eviction, and genuine
-        # concurrent cleanup into a single misleading string.
+        # left to reconcile against. The reason is built from a live Redis
+        # snapshot (DB index, keys present under job:{id}:*) so the FAILURE log
+        # and the UI progress.errors entry name the actual cause (DB-index
+        # misconfig vs eviction vs concurrent cleanup).
         _log_missing_state_context(job_id, "process")
         _ack_task_via_nats(reply_subject, logger)
         _fail_job(

--- a/ami/jobs/tests/test_tasks.py
+++ b/ami/jobs/tests/test_tasks.py
@@ -346,10 +346,14 @@ class TestProcessNatsPipelineResultError(TransactionTestCase):
 
         mock_ack.assert_called_once()
         mock_fail.assert_called_once()
-        # New, accurate message — no longer the misleading "Redis state missing"
-        # that users saw in the UI for transient connection drops.
+        # Reason string now leads with the stage and embeds a live Redis
+        # snapshot (DB index + key listing from diagnose_missing_state) so the
+        # failure cause — DB-index drift, eviction, or never-initialized —
+        # is visible in the FAILURE log instead of the previous single
+        # hardcoded "likely cleaned up concurrently" guess.
         args, _ = mock_fail.call_args
-        self.assertIn("Job state keys not found in Redis", args[1])
+        self.assertIn("Job state missing from Redis", args[1])
+        self.assertIn("stage=process", args[1])
 
     @patch("ami.jobs.tasks._ack_task_via_nats")
     @patch("ami.jobs.tasks.TaskQueueManager")

--- a/ami/jobs/tests/test_tasks.py
+++ b/ami/jobs/tests/test_tasks.py
@@ -629,6 +629,95 @@ class TestTaskFailureGuard(TransactionTestCase):
         mock_cleanup.assert_called_once()
 
 
+class TestFailJob(TransactionTestCase):
+    """
+    Regression tests for ``_fail_job`` — specifically for the reason-string
+    mirroring into ``progress.errors`` that this PR adds.
+
+    The FAILURE log line alone is not enough for operators; the UI reads
+    ``progress.errors``, and prior to this PR that list stayed empty on the
+    missing-Redis-state path. Any regression that stops appending the reason
+    (e.g. silently dropping it via the defensive ``try/except``) would put
+    operators back in the position of digging through Celery worker logs to
+    find out why a job died.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.project = Project.objects.create(name="FailJob Test Project")
+        self.pipeline = Pipeline.objects.create(name="FailJob Pipeline", slug="fail-job-pipeline")
+        self.pipeline.projects.add(self.project)
+        self.collection = SourceImageCollection.objects.create(name="FailJob Collection", project=self.project)
+
+    def tearDown(self):
+        cache.clear()
+
+    def _make_job(self, dispatch_mode: JobDispatchMode = JobDispatchMode.ASYNC_API) -> Job:
+        job = Job.objects.create(
+            job_type_key=MLJob.key,
+            project=self.project,
+            name=f"{dispatch_mode} fail-job test",
+            pipeline=self.pipeline,
+            source_image_collection=self.collection,
+            dispatch_mode=dispatch_mode,
+        )
+        job.update_status(JobState.STARTED, save=True)
+        return job
+
+    @patch("ami.ml.orchestration.jobs.cleanup_async_job_resources")
+    def test_fail_job_appends_reason_to_progress_errors(self, mock_cleanup):
+        """
+        Reason string must end up in ``job.progress.errors`` (persisted) so the
+        UI shows the cause of the FAILURE alongside the status change. Before
+        this PR the reason lived only in ``job.logger`` and the UI showed
+        ``errors=[]``. A silent regression here would not be caught by the
+        ``_fail_job`` call-site tests in ``TestProcessNatsPipelineResultError``
+        (they mock ``_fail_job`` entirely).
+        """
+        from ami.jobs.tasks import _fail_job
+
+        job = self._make_job()
+        reason = "Job state missing from Redis (stage=process): redis=host:6379/db1 keys_for_job=<none>"
+
+        _fail_job(job.pk, reason)
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobState.FAILURE)
+        self.assertIn(
+            reason,
+            job.progress.errors,
+            f"expected reason in progress.errors, got: {job.progress.errors!r}",
+        )
+        # Sanity: the fix also propagates to the DB-persisted copy (i.e. the
+        # update_fields tuple on job.save includes 'progress'). Re-read from a
+        # fresh Job instance to prove the append wasn't only visible on the
+        # in-memory object returned by select_for_update.
+        reloaded = Job.objects.get(pk=job.pk)
+        self.assertIn(reason, reloaded.progress.errors)
+        mock_cleanup.assert_called_once_with(job.pk)
+
+    @patch("ami.ml.orchestration.jobs.cleanup_async_job_resources")
+    def test_fail_job_is_noop_on_already_final_job(self, mock_cleanup):
+        """
+        If the job is already in a final state (e.g. concurrent cleanup
+        beat us), ``_fail_job`` must return early without touching status
+        or progress. This protects against double-failing a job that has
+        already been reconciled to SUCCESS by the reconciler path.
+        """
+        from ami.jobs.tasks import _fail_job
+
+        job = self._make_job()
+        job.update_status(JobState.SUCCESS, save=True)
+        errors_before = list(job.progress.errors)
+
+        _fail_job(job.pk, "should be ignored")
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobState.SUCCESS)
+        self.assertEqual(job.progress.errors, errors_before)
+        mock_cleanup.assert_not_called()
+
+
 class TestResultEndpointWithError(APITestCase):
     """Integration test for the result API endpoint with error results."""
 

--- a/ami/jobs/tests/test_tasks.py
+++ b/ami/jobs/tests/test_tasks.py
@@ -348,14 +348,69 @@ class TestProcessNatsPipelineResultError(TransactionTestCase):
 
         mock_ack.assert_called_once()
         mock_fail.assert_called_once()
-        # Reason string now leads with the stage and embeds a live Redis
-        # snapshot (DB index + key listing from diagnose_missing_state) so the
-        # failure cause — DB-index drift, eviction, or never-initialized —
-        # is visible in the FAILURE log instead of the previous single
-        # hardcoded "likely cleaned up concurrently" guess.
+        # The reason string passed to _fail_job identifies the stage and embeds
+        # a live Redis snapshot (from diagnose_missing_state) so the FAILURE
+        # log and UI progress.errors distinguish DB-index drift, eviction, and
+        # never-initialized state rather than collapsing them into one message.
         args, _ = mock_fail.call_args
         self.assertIn("Job state missing from Redis", args[1])
         self.assertIn("stage=process", args[1])
+
+    @patch("ami.jobs.tasks._fail_job")
+    @patch("ami.jobs.tasks._ack_task_via_nats")
+    @patch("ami.jobs.tasks.TaskQueueManager")
+    def test_genuinely_missing_state_results_stage_acks_and_fails_job(self, mock_manager_class, mock_ack, mock_fail):
+        """
+        Mirror of test_genuinely_missing_state_acks_and_fails_job for the
+        stage=results path (tasks.py lines 378-388). When the total-images key
+        is gone at the results-stage update_state call, the task must ack NATS
+        to stop redelivery and fail the job — there is no state to reconcile.
+        The reason string must identify stage=results.
+        """
+        self._setup_mock_nats(mock_manager_class)
+
+        # save_results requires at least one algorithm on the pipeline.
+        detection_algorithm = Algorithm.objects.create(
+            name="results-missing-state-detector",
+            key="results-missing-state-detector",
+            task_type=AlgorithmTaskType.LOCALIZATION,
+        )
+        self.pipeline.algorithms.add(detection_algorithm)
+
+        # Use a success result so the process-stage path succeeds and
+        # save_results runs before the results-stage update_state is reached.
+        success_data = PipelineResultsResponse(
+            pipeline="test-pipeline",
+            algorithms={},
+            total_time=1.0,
+            source_images=[SourceImageResponse(id=str(self.images[0].pk), url="http://example.com/test_image_0.jpg")],
+            detections=[],
+            errors=None,
+        ).dict()
+
+        real_update_state = AsyncJobStateManager.update_state
+
+        def none_on_results_stage(self_inner, processed_image_ids, stage, failed_image_ids=None):
+            if stage == "results":
+                return None
+            return real_update_state(self_inner, processed_image_ids, stage, failed_image_ids)
+
+        with patch.object(AsyncJobStateManager, "update_state", none_on_results_stage):
+            process_nats_pipeline_result(
+                job_id=self.job.pk,
+                result_data=success_data,
+                reply_subject="reply.missing-results",
+            )
+
+        mock_ack.assert_called_once()
+        mock_fail.assert_called_once()
+        # The reason string passed to _fail_job identifies the stage and embeds
+        # a live Redis snapshot (from diagnose_missing_state) so the FAILURE
+        # log and UI progress.errors distinguish DB-index drift, eviction, and
+        # never-initialized state rather than collapsing them into one message.
+        args, _ = mock_fail.call_args
+        self.assertIn("Job state missing from Redis", args[1])
+        self.assertIn("stage=results", args[1])
 
     @patch("ami.jobs.tasks._ack_task_via_nats")
     @patch("ami.jobs.tasks.TaskQueueManager")

--- a/ami/jobs/tests/test_tasks.py
+++ b/ami/jobs/tests/test_tasks.py
@@ -722,38 +722,6 @@ class TestFailJob(TransactionTestCase):
         return job
 
     @patch("ami.ml.orchestration.jobs.cleanup_async_job_resources")
-    def test_fail_job_appends_reason_to_progress_errors(self, mock_cleanup):
-        """
-        Reason string must end up in ``job.progress.errors`` (persisted) so the
-        UI shows the cause of the FAILURE alongside the status change. Before
-        this PR the reason lived only in ``job.logger`` and the UI showed
-        ``errors=[]``. A silent regression here would not be caught by the
-        ``_fail_job`` call-site tests in ``TestProcessNatsPipelineResultError``
-        (they mock ``_fail_job`` entirely).
-        """
-        from ami.jobs.tasks import _fail_job
-
-        job = self._make_job()
-        reason = "Job state missing from Redis (stage=process): redis=host:6379/db1 keys_for_job=<none>"
-
-        _fail_job(job.pk, reason)
-
-        job.refresh_from_db()
-        self.assertEqual(job.status, JobState.FAILURE)
-        self.assertIn(
-            reason,
-            job.progress.errors,
-            f"expected reason in progress.errors, got: {job.progress.errors!r}",
-        )
-        # Sanity: the fix also propagates to the DB-persisted copy (i.e. the
-        # update_fields tuple on job.save includes 'progress'). Re-read from a
-        # fresh Job instance to prove the append wasn't only visible on the
-        # in-memory object returned by select_for_update.
-        reloaded = Job.objects.get(pk=job.pk)
-        self.assertIn(reason, reloaded.progress.errors)
-        mock_cleanup.assert_called_once_with(job.pk)
-
-    @patch("ami.ml.orchestration.jobs.cleanup_async_job_resources")
     def test_fail_job_is_noop_on_already_final_job(self, mock_cleanup):
         """
         If the job is already in a final state (e.g. concurrent cleanup

--- a/ami/jobs/tests/test_tasks.py
+++ b/ami/jobs/tests/test_tasks.py
@@ -12,7 +12,7 @@ from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.core.cache import cache
-from django.test import TransactionTestCase
+from django.test import SimpleTestCase, TransactionTestCase
 from rest_framework.test import APITestCase
 
 from ami.base.serializers import reverse_with_params
@@ -1910,3 +1910,28 @@ class TestCancelCompletionRace(TransactionTestCase):
             JobState.REVOKED.value,
             f"late completion resurrected a REVOKED job to {self.job.status!r}",
         )
+
+
+class TestRedisTargetLogging(SimpleTestCase):
+    """The per-job Redis-target log must not leak the internal Redis host.
+
+    run_job logs the Redis DB index to the public job log (via _redis_db_index) and the full
+    host:port only to the server log (via _describe_redis_target). The host names internal
+    infrastructure, so it must never reach the public job log / progress.errors. This pins the
+    split that a prior leak (host:port in the public job log) slipped through without.
+    """
+
+    def test_public_db_index_omits_host_and_port(self):
+        from ami.jobs.tasks import _redis_db_index
+
+        out = _redis_db_index()
+        self.assertNotIn(":", out, "DB index must not contain a host:port")
+        self.assertNotIn("redis=", out)
+
+    def test_server_target_includes_host_and_port(self):
+        from ami.jobs.tasks import _describe_redis_target
+
+        out = _describe_redis_target()
+        self.assertTrue(out.startswith("redis="))
+        self.assertIn(":", out)
+        self.assertIn("/db", out)

--- a/ami/jobs/tests/test_tasks.py
+++ b/ami/jobs/tests/test_tasks.py
@@ -348,10 +348,14 @@ class TestProcessNatsPipelineResultError(TransactionTestCase):
 
         mock_ack.assert_called_once()
         mock_fail.assert_called_once()
-        # New, accurate message — no longer the misleading "Redis state missing"
-        # that users saw in the UI for transient connection drops.
+        # Reason string now leads with the stage and embeds a live Redis
+        # snapshot (DB index + key listing from diagnose_missing_state) so the
+        # failure cause — DB-index drift, eviction, or never-initialized —
+        # is visible in the FAILURE log instead of the previous single
+        # hardcoded "likely cleaned up concurrently" guess.
         args, _ = mock_fail.call_args
-        self.assertIn("Job state keys not found in Redis", args[1])
+        self.assertIn("Job state missing from Redis", args[1])
+        self.assertIn("stage=process", args[1])
 
     @patch("ami.jobs.tasks._ack_task_via_nats")
     @patch("ami.jobs.tasks.TaskQueueManager")

--- a/ami/jobs/tests/test_tasks.py
+++ b/ami/jobs/tests/test_tasks.py
@@ -631,6 +631,95 @@ class TestTaskFailureGuard(TransactionTestCase):
         mock_cleanup.assert_called_once()
 
 
+class TestFailJob(TransactionTestCase):
+    """
+    Regression tests for ``_fail_job`` — specifically for the reason-string
+    mirroring into ``progress.errors`` that this PR adds.
+
+    The FAILURE log line alone is not enough for operators; the UI reads
+    ``progress.errors``, and prior to this PR that list stayed empty on the
+    missing-Redis-state path. Any regression that stops appending the reason
+    (e.g. silently dropping it via the defensive ``try/except``) would put
+    operators back in the position of digging through Celery worker logs to
+    find out why a job died.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.project = Project.objects.create(name="FailJob Test Project")
+        self.pipeline = Pipeline.objects.create(name="FailJob Pipeline", slug="fail-job-pipeline")
+        self.pipeline.projects.add(self.project)
+        self.collection = SourceImageCollection.objects.create(name="FailJob Collection", project=self.project)
+
+    def tearDown(self):
+        cache.clear()
+
+    def _make_job(self, dispatch_mode: JobDispatchMode = JobDispatchMode.ASYNC_API) -> Job:
+        job = Job.objects.create(
+            job_type_key=MLJob.key,
+            project=self.project,
+            name=f"{dispatch_mode} fail-job test",
+            pipeline=self.pipeline,
+            source_image_collection=self.collection,
+            dispatch_mode=dispatch_mode,
+        )
+        job.update_status(JobState.STARTED, save=True)
+        return job
+
+    @patch("ami.ml.orchestration.jobs.cleanup_async_job_resources")
+    def test_fail_job_appends_reason_to_progress_errors(self, mock_cleanup):
+        """
+        Reason string must end up in ``job.progress.errors`` (persisted) so the
+        UI shows the cause of the FAILURE alongside the status change. Before
+        this PR the reason lived only in ``job.logger`` and the UI showed
+        ``errors=[]``. A silent regression here would not be caught by the
+        ``_fail_job`` call-site tests in ``TestProcessNatsPipelineResultError``
+        (they mock ``_fail_job`` entirely).
+        """
+        from ami.jobs.tasks import _fail_job
+
+        job = self._make_job()
+        reason = "Job state missing from Redis (stage=process): redis=host:6379/db1 keys_for_job=<none>"
+
+        _fail_job(job.pk, reason)
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobState.FAILURE)
+        self.assertIn(
+            reason,
+            job.progress.errors,
+            f"expected reason in progress.errors, got: {job.progress.errors!r}",
+        )
+        # Sanity: the fix also propagates to the DB-persisted copy (i.e. the
+        # update_fields tuple on job.save includes 'progress'). Re-read from a
+        # fresh Job instance to prove the append wasn't only visible on the
+        # in-memory object returned by select_for_update.
+        reloaded = Job.objects.get(pk=job.pk)
+        self.assertIn(reason, reloaded.progress.errors)
+        mock_cleanup.assert_called_once_with(job.pk)
+
+    @patch("ami.ml.orchestration.jobs.cleanup_async_job_resources")
+    def test_fail_job_is_noop_on_already_final_job(self, mock_cleanup):
+        """
+        If the job is already in a final state (e.g. concurrent cleanup
+        beat us), ``_fail_job`` must return early without touching status
+        or progress. This protects against double-failing a job that has
+        already been reconciled to SUCCESS by the reconciler path.
+        """
+        from ami.jobs.tasks import _fail_job
+
+        job = self._make_job()
+        job.update_status(JobState.SUCCESS, save=True)
+        errors_before = list(job.progress.errors)
+
+        _fail_job(job.pk, "should be ignored")
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobState.SUCCESS)
+        self.assertEqual(job.progress.errors, errors_before)
+        mock_cleanup.assert_not_called()
+
+
 class TestResultEndpointWithError(APITestCase):
     """Integration test for the result API endpoint with error results."""
 

--- a/ami/ml/orchestration/async_job_state.py
+++ b/ami/ml/orchestration/async_job_state.py
@@ -163,6 +163,18 @@ class AsyncJobStateManager:
         newly_removed = results[0] if processed_image_ids else 0
 
         if total_raw is None:
+            # Loud diagnostic before the silent None return. The caller will mark
+            # the job FAILURE based on this result, so the operator needs to see
+            # *why* the total key is gone. Distinguishes three different causes
+            # that previously all surfaced as the same hardcoded "likely cleaned
+            # up concurrently" reason string: Redis DB mismatch across hosts,
+            # key eviction, and genuinely-never-initialized state.
+            logger.warning(
+                "Job %s state missing in Redis (stage=%s): %s",
+                self.job_id,
+                stage,
+                self.diagnose_missing_state(),
+            )
             return None
 
         total = int(total_raw)
@@ -181,6 +193,48 @@ class AsyncJobStateManager:
             failed=failed_count,
             newly_removed=newly_removed,
         )
+
+    def diagnose_missing_state(self) -> str:
+        """
+        One-line snapshot of what Redis actually holds for this job.
+
+        Called from the missing-state path in ``update_state`` and from
+        ``_fail_job`` so the FAILURE log and the UI ``progress.errors`` entry
+        distinguish the three common causes — DB mismatch across hosts, key
+        eviction, and never-initialized state — instead of a single hardcoded
+        "likely cleaned up concurrently" guess that all three collapse to.
+
+        Intentionally defensive: any failure to collect diagnostics is
+        swallowed, because the caller is already about to fail the job and
+        an exception from diagnostics would mask the original cause.
+        """
+        try:
+            redis = self._get_redis()
+            kwargs = getattr(redis.connection_pool, "connection_kwargs", {}) or {}
+            db = kwargs.get("db", "?")
+            host = kwargs.get("host", "?")
+            port = kwargs.get("port", "?")
+            # Cursor-safe SCAN over the job's keyspace — cheap even on a busy
+            # Redis because it's filtered server-side and the per-job fanout is
+            # at most a handful of keys (pending:process, pending:results,
+            # failed, total).
+            keys = sorted(k.decode() if isinstance(k, bytes) else k for k in redis.scan_iter(match=self._pattern()))
+            sizes: list[str] = []
+            for key in keys:
+                if key == self._total_key:
+                    sizes.append(f"{key}=<str>")
+                    continue
+                try:
+                    sizes.append(f"{key}=SCARD:{redis.scard(key)}")
+                except RedisError:
+                    sizes.append(f"{key}=<err>")
+            keys_summary = ", ".join(sizes) if sizes else "<none>"
+            return f"redis={host}:{port}/db{db} keys_for_job={keys_summary}"
+        except Exception as e:
+            return f"(diagnostics failed: {e})"
+
+    def _pattern(self) -> str:
+        return f"job:{self.job_id}:*"
 
     def get_progress(self, stage: str) -> "JobStateProgress | None":
         """Read-only progress snapshot for the given stage."""

--- a/ami/ml/orchestration/async_job_state.py
+++ b/ami/ml/orchestration/async_job_state.py
@@ -204,6 +204,11 @@ class AsyncJobStateManager:
         eviction, and never-initialized state — instead of a single hardcoded
         "likely cleaned up concurrently" guess that all three collapse to.
 
+        Cost: the internal ``SCAN`` runs only on the failure path (once per
+        job-lifetime FAILURE), and the per-job key fanout is at most four
+        (pending:process, pending:results, failed, total), so the cost is
+        negligible compared to the FAILURE branch it only helps diagnose.
+
         Intentionally defensive: any failure to collect diagnostics is
         swallowed, because the caller is already about to fail the job and
         an exception from diagnostics would mask the original cause.

--- a/ami/ml/orchestration/async_job_state.py
+++ b/ami/ml/orchestration/async_job_state.py
@@ -165,10 +165,9 @@ class AsyncJobStateManager:
         if total_raw is None:
             # Loud diagnostic before the silent None return. The caller will mark
             # the job FAILURE based on this result, so the operator needs to see
-            # *why* the total key is gone. Distinguishes three different causes
-            # that previously all surfaced as the same hardcoded "likely cleaned
-            # up concurrently" reason string: Redis DB mismatch across hosts,
-            # key eviction, and genuinely-never-initialized state.
+            # *why* the total key is gone. Distinguishes three causes that map to
+            # the same symptom: DB-index mismatch across hosts, key eviction, and
+            # never-initialized state.
             logger.warning(
                 "Job %s state missing in Redis (stage=%s): %s",
                 self.job_id,
@@ -223,11 +222,6 @@ class AsyncJobStateManager:
             db = kwargs.get("db", "?")
             host = kwargs.get("host", "?")
             port = kwargs.get("port", "?")
-            # Cursor-safe SCAN over the job's keyspace. SCAN walks the whole DB
-            # (MATCH only filters what's returned, not what's scanned), so this
-            # is acceptable precisely because it runs only on the rare
-            # missing-state failure path; the per-job fanout returned is at most
-            # a handful of keys (pending:process, pending:results, failed, total).
             keys = sorted(k.decode() if isinstance(k, bytes) else k for k in redis.scan_iter(match=self._pattern()))
             sizes: list[str] = []
             for key in keys:

--- a/ami/ml/orchestration/async_job_state.py
+++ b/ami/ml/orchestration/async_job_state.py
@@ -198,16 +198,20 @@ class AsyncJobStateManager:
         """
         One-line snapshot of what Redis actually holds for this job.
 
-        Called from the missing-state path in ``update_state`` and from
-        ``_fail_job`` so the FAILURE log and the UI ``progress.errors`` entry
-        distinguish the three common causes — DB mismatch across hosts, key
-        eviction, and never-initialized state — instead of a single hardcoded
-        "likely cleaned up concurrently" guess that all three collapse to.
+        Called from the missing-state path in ``update_state`` (the loud log)
+        and from the result handler in ``process_nats_pipeline_result``, which
+        folds the result into the reason it passes to ``_fail_job`` so the
+        FAILURE log and the UI ``progress.errors`` entry distinguish the three
+        common causes — DB mismatch across hosts, key eviction, and
+        never-initialized state — instead of a single hardcoded "likely cleaned
+        up concurrently" guess that all three collapse to.
 
-        Cost: the internal ``SCAN`` runs only on the failure path (once per
-        job-lifetime FAILURE), and the per-job key fanout is at most four
-        (pending:process, pending:results, failed, total), so the cost is
-        negligible compared to the FAILURE branch it only helps diagnose.
+        Cost: only ever runs on the missing-state failure path (at most twice
+        per job-lifetime FAILURE — once for the log, once for the reason
+        string). ``SCAN`` is O(keyspace) regardless of ``MATCH`` (MATCH filters
+        the returned keys, not the keys scanned), but on the rare failure path
+        that one extra full cursor walk is negligible next to the FAILURE it
+        helps diagnose.
 
         Intentionally defensive: any failure to collect diagnostics is
         swallowed, because the caller is already about to fail the job and
@@ -219,10 +223,11 @@ class AsyncJobStateManager:
             db = kwargs.get("db", "?")
             host = kwargs.get("host", "?")
             port = kwargs.get("port", "?")
-            # Cursor-safe SCAN over the job's keyspace — cheap even on a busy
-            # Redis because it's filtered server-side and the per-job fanout is
-            # at most a handful of keys (pending:process, pending:results,
-            # failed, total).
+            # Cursor-safe SCAN over the job's keyspace. SCAN walks the whole DB
+            # (MATCH only filters what's returned, not what's scanned), so this
+            # is acceptable precisely because it runs only on the rare
+            # missing-state failure path; the per-job fanout returned is at most
+            # a handful of keys (pending:process, pending:results, failed, total).
             keys = sorted(k.decode() if isinstance(k, bytes) else k for k in redis.scan_iter(match=self._pattern()))
             sizes: list[str] = []
             for key in keys:

--- a/ami/ml/orchestration/async_job_state.py
+++ b/ami/ml/orchestration/async_job_state.py
@@ -169,9 +169,10 @@ class AsyncJobStateManager:
             # the same symptom: DB-index mismatch across hosts, key eviction, and
             # never-initialized state.
             logger.warning(
-                "Job %s state missing in Redis (stage=%s): %s",
+                "Job %s state missing in Redis (stage=%s, target=%s): %s",
                 self.job_id,
                 stage,
+                self.connection_target(),
                 self.diagnose_missing_state(),
             )
             return None
@@ -195,33 +196,36 @@ class AsyncJobStateManager:
 
     def diagnose_missing_state(self) -> str:
         """
-        One-line snapshot of what Redis actually holds for this job.
+        One-line, log-safe snapshot of what Redis holds for this job.
 
-        Called from the missing-state path in ``update_state`` (the loud log)
-        and from the result handler in ``process_nats_pipeline_result``, which
-        folds the result into the reason it passes to ``_fail_job`` so the
-        FAILURE log and the UI ``progress.errors`` entry distinguish the three
-        common causes — DB mismatch across hosts, key eviction, and
-        never-initialized state — instead of a single hardcoded "likely cleaned
-        up concurrently" guess that all three collapse to.
+        Reports the Redis DB index and the per-job keys (with set cardinalities) so a
+        missing-state FAILURE distinguishes its three common causes — DB-index mismatch
+        across processes, key eviction, and never-initialized state — instead of a single
+        hardcoded "likely cleaned up concurrently" guess that all three collapse to.
 
-        Cost: only ever runs on the missing-state failure path (at most twice
-        per job-lifetime FAILURE — once for the log, once for the reason
-        string). ``SCAN`` is O(keyspace) regardless of ``MATCH`` (MATCH filters
-        the returned keys, not the keys scanned), but on the rare failure path
-        that one extra full cursor walk is negligible next to the FAILURE it
-        helps diagnose.
+        The Redis host/port is deliberately omitted here: this string is surfaced in the
+        job's public ``progress.errors`` (via the reason passed to ``_fail_job``), and the
+        host identifies internal infrastructure. The DB index is the load-bearing signal for
+        the mismatch case and is safe to expose. Operators who need the host see it in the
+        server-side warning ``update_state`` logs via ``connection_target()``.
 
-        Intentionally defensive: any failure to collect diagnostics is
-        swallowed, because the caller is already about to fail the job and
-        an exception from diagnostics would mask the original cause.
+        Called from the missing-state path in ``update_state`` (the loud log) and from the
+        result handler in ``process_nats_pipeline_result``.
+
+        Cost: only ever runs on the missing-state failure path (at most twice per
+        job-lifetime FAILURE — once for the log, once for the reason string). ``SCAN`` is
+        O(keyspace) regardless of ``MATCH`` (MATCH filters the returned keys, not the keys
+        scanned), but on the rare failure path that one extra full cursor walk is negligible
+        next to the FAILURE it helps diagnose.
+
+        Intentionally defensive: any failure to collect diagnostics is swallowed, because the
+        caller is already about to fail the job and an exception from diagnostics would mask
+        the original cause.
         """
         try:
             redis = self._get_redis()
             kwargs = getattr(redis.connection_pool, "connection_kwargs", {}) or {}
             db = kwargs.get("db", "?")
-            host = kwargs.get("host", "?")
-            port = kwargs.get("port", "?")
             keys = sorted(k.decode() if isinstance(k, bytes) else k for k in redis.scan_iter(match=self._pattern()))
             sizes: list[str] = []
             for key in keys:
@@ -233,9 +237,25 @@ class AsyncJobStateManager:
                 except RedisError:
                     sizes.append(f"{key}=<err>")
             keys_summary = ", ".join(sizes) if sizes else "<none>"
-            return f"redis={host}:{port}/db{db} keys_for_job={keys_summary}"
+            return f"redis db{db}: keys_for_job={keys_summary}"
         except Exception as e:
             return f"(diagnostics failed: {e})"
+
+    def connection_target(self) -> str:
+        """
+        Redis target as ``host:port/dbN``, for server-side operator logs only.
+
+        Names the internal Redis host, so this must NOT go into job logs or
+        ``progress.errors`` — use :meth:`diagnose_missing_state` for anything surfaced to
+        the user. Kept separate so the host stays in operator-facing logs (where the
+        cross-host DB-drift diagnosis needs it) without leaking to the public job view.
+        """
+        try:
+            redis = self._get_redis()
+            kwargs = getattr(redis.connection_pool, "connection_kwargs", {}) or {}
+            return f"{kwargs.get('host', '?')}:{kwargs.get('port', '?')}/db{kwargs.get('db', '?')}"
+        except Exception as e:
+            return f"(unavailable: {e})"
 
     def _pattern(self) -> str:
         return f"job:{self.job_id}:*"

--- a/ami/ml/orchestration/async_job_state.py
+++ b/ami/ml/orchestration/async_job_state.py
@@ -196,31 +196,19 @@ class AsyncJobStateManager:
 
     def diagnose_missing_state(self) -> str:
         """
-        One-line, log-safe snapshot of what Redis holds for this job.
+        One-line, log-safe snapshot of what Redis holds for this job: the DB index and
+        the per-job keys with their set cardinalities. Lets a missing-state FAILURE name
+        its cause — DB-index mismatch across processes, key eviction, or never-initialized
+        state — rather than collapsing all three into one guess.
 
-        Reports the Redis DB index and the per-job keys (with set cardinalities) so a
-        missing-state FAILURE distinguishes its three common causes — DB-index mismatch
-        across processes, key eviction, and never-initialized state — instead of a single
-        hardcoded "likely cleaned up concurrently" guess that all three collapse to.
+        The Redis host/port is omitted: this string is surfaced in the job's public
+        ``progress.errors`` (via the reason passed to ``_fail_job``), and the host names
+        internal infrastructure. The DB index is the load-bearing signal for the mismatch
+        case and is safe to expose; operators who need the host read it from the server-side
+        ``update_state`` warning via ``connection_target()``.
 
-        The Redis host/port is deliberately omitted here: this string is surfaced in the
-        job's public ``progress.errors`` (via the reason passed to ``_fail_job``), and the
-        host identifies internal infrastructure. The DB index is the load-bearing signal for
-        the mismatch case and is safe to expose. Operators who need the host see it in the
-        server-side warning ``update_state`` logs via ``connection_target()``.
-
-        Called from the missing-state path in ``update_state`` (the loud log) and from the
-        result handler in ``process_nats_pipeline_result``.
-
-        Cost: only ever runs on the missing-state failure path (at most twice per
-        job-lifetime FAILURE — once for the log, once for the reason string). ``SCAN`` is
-        O(keyspace) regardless of ``MATCH`` (MATCH filters the returned keys, not the keys
-        scanned), but on the rare failure path that one extra full cursor walk is negligible
-        next to the FAILURE it helps diagnose.
-
-        Intentionally defensive: any failure to collect diagnostics is swallowed, because the
-        caller is already about to fail the job and an exception from diagnostics would mask
-        the original cause.
+        Any failure to collect diagnostics is swallowed: the caller is already failing the
+        job, and an exception here would mask the original cause.
         """
         try:
             redis = self._get_redis()

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -1407,6 +1407,35 @@ class TestTaskStateManager(TestCase):
         progress = self.manager.update_state({"img1", "img2"}, "process")
         self.assertIsNone(progress)
 
+    def test_diagnose_missing_state_when_never_initialized(self):
+        """
+        Diagnostic string for the "never initialized" case: no keys are
+        present under ``job:{id}:*``. Output must still name the Redis host
+        and DB so cross-host DB drift is distinguishable from eviction and
+        truly-never-initialized state in one log line.
+        """
+        # initialize_job has NOT been called; nothing under job:123:*.
+        diagnosis = self.manager.diagnose_missing_state()
+        self.assertIn("redis=", diagnosis)
+        self.assertIn("/db", diagnosis)
+        self.assertIn("keys_for_job=<none>", diagnosis)
+
+    def test_diagnose_missing_state_lists_present_keys(self):
+        """
+        Diagnostic string for the partial-cleanup / eviction case: some keys
+        remain under ``job:{id}:*`` and their SCARDs should appear so the
+        operator can tell "total key evicted but pending sets still present"
+        from "nothing here, this DB never saw the job".
+        """
+        self.manager.initialize_job(self.image_ids)
+        # Drop the total key to simulate eviction while pending sets survive.
+        redis = self.manager._get_redis()
+        redis.delete(self.manager._total_key)
+
+        diagnosis = self.manager.diagnose_missing_state()
+        self.assertIn(f"job:{self.job_id}:pending_images:process=SCARD:", diagnosis)
+        self.assertNotIn(self.manager._total_key, diagnosis)
+
 
 class TestSaveResultsRefreshesDeploymentCounts(TestCase):
     """save_results must refresh Deployment cached counts, not just Event counts.

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -1742,19 +1742,6 @@ class TestTaskStateManager(TestCase):
         progress = self.manager.update_state({"img1", "img2"}, "process")
         self.assertIsNone(progress)
 
-    def test_diagnose_missing_state_when_never_initialized(self):
-        """
-        Diagnostic string for the "never initialized" case: no keys are
-        present under ``job:{id}:*``. The public string names the Redis DB
-        index (so cross-process DB drift is distinguishable from eviction and
-        truly-never-initialized state) but must NOT name the Redis host: it is
-        surfaced in the job's public progress.errors.
-        """
-        # initialize_job has NOT been called; nothing under job:123:*.
-        diagnosis = self.manager.diagnose_missing_state()
-        self.assertIn("db", diagnosis)
-        self.assertIn("keys_for_job=<none>", diagnosis)
-
     def test_diagnose_missing_state_omits_host_but_connection_target_keeps_it(self):
         """
         The public diagnostic must not leak the internal Redis host/port, but the
@@ -1774,22 +1761,6 @@ class TestTaskStateManager(TestCase):
             self.assertNotIn(f"{host}:", public)
             self.assertIn(f"{host}:", target)
         self.assertIn("/db", target)
-
-    def test_diagnose_missing_state_lists_present_keys(self):
-        """
-        Diagnostic string for the partial-cleanup / eviction case: some keys
-        remain under ``job:{id}:*`` and their SCARDs should appear so the
-        operator can tell "total key evicted but pending sets still present"
-        from "nothing here, this DB never saw the job".
-        """
-        self.manager.initialize_job(self.image_ids)
-        # Drop the total key to simulate eviction while pending sets survive.
-        redis = self.manager._get_redis()
-        redis.delete(self.manager._total_key)
-
-        diagnosis = self.manager.diagnose_missing_state()
-        self.assertIn(f"job:{self.job_id}:pending_images:process=SCARD:", diagnosis)
-        self.assertNotIn(self.manager._total_key, diagnosis)
 
 
 class TestSaveResultsRefreshesDeploymentCounts(TestCase):

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -1742,6 +1742,35 @@ class TestTaskStateManager(TestCase):
         progress = self.manager.update_state({"img1", "img2"}, "process")
         self.assertIsNone(progress)
 
+    def test_diagnose_missing_state_when_never_initialized(self):
+        """
+        Diagnostic string for the "never initialized" case: no keys are
+        present under ``job:{id}:*``. Output must still name the Redis host
+        and DB so cross-host DB drift is distinguishable from eviction and
+        truly-never-initialized state in one log line.
+        """
+        # initialize_job has NOT been called; nothing under job:123:*.
+        diagnosis = self.manager.diagnose_missing_state()
+        self.assertIn("redis=", diagnosis)
+        self.assertIn("/db", diagnosis)
+        self.assertIn("keys_for_job=<none>", diagnosis)
+
+    def test_diagnose_missing_state_lists_present_keys(self):
+        """
+        Diagnostic string for the partial-cleanup / eviction case: some keys
+        remain under ``job:{id}:*`` and their SCARDs should appear so the
+        operator can tell "total key evicted but pending sets still present"
+        from "nothing here, this DB never saw the job".
+        """
+        self.manager.initialize_job(self.image_ids)
+        # Drop the total key to simulate eviction while pending sets survive.
+        redis = self.manager._get_redis()
+        redis.delete(self.manager._total_key)
+
+        diagnosis = self.manager.diagnose_missing_state()
+        self.assertIn(f"job:{self.job_id}:pending_images:process=SCARD:", diagnosis)
+        self.assertNotIn(self.manager._total_key, diagnosis)
+
 
 class TestSaveResultsRefreshesDeploymentCounts(TestCase):
     """save_results must refresh Deployment cached counts, not just Event counts.

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -1745,15 +1745,35 @@ class TestTaskStateManager(TestCase):
     def test_diagnose_missing_state_when_never_initialized(self):
         """
         Diagnostic string for the "never initialized" case: no keys are
-        present under ``job:{id}:*``. Output must still name the Redis host
-        and DB so cross-host DB drift is distinguishable from eviction and
-        truly-never-initialized state in one log line.
+        present under ``job:{id}:*``. The public string names the Redis DB
+        index (so cross-process DB drift is distinguishable from eviction and
+        truly-never-initialized state) but must NOT name the Redis host: it is
+        surfaced in the job's public progress.errors.
         """
         # initialize_job has NOT been called; nothing under job:123:*.
         diagnosis = self.manager.diagnose_missing_state()
-        self.assertIn("redis=", diagnosis)
-        self.assertIn("/db", diagnosis)
+        self.assertIn("db", diagnosis)
         self.assertIn("keys_for_job=<none>", diagnosis)
+
+    def test_diagnose_missing_state_omits_host_but_connection_target_keeps_it(self):
+        """
+        The public diagnostic must not leak the internal Redis host/port, but the
+        operator-only connection_target() must still carry host:port/db for the
+        server-side cross-host DB-drift diagnosis.
+        """
+        kwargs = self.manager._get_redis().connection_pool.connection_kwargs
+        host = str(kwargs.get("host", ""))
+
+        public = self.manager.diagnose_missing_state()
+        target = self.manager.connection_target()
+
+        # The leak is the host:port connection detail, so assert the host:port pattern is
+        # absent from the public string (not the bare host substring — the public string
+        # legitimately contains the word "redis").
+        if host:
+            self.assertNotIn(f"{host}:", public)
+            self.assertIn(f"{host}:", target)
+        self.assertIn("/db", target)
 
     def test_diagnose_missing_state_lists_present_keys(self):
         """


### PR DESCRIPTION
## Summary

When an async ML job's Redis state goes missing, the job is failed — but that failure used to be close to silent and actively misleading. The reason string was hardcoded ("Job state keys not found in Redis (likely cleaned up concurrently)"), lived only in the worker log, and never reached the job's `progress.errors`, so the UI showed a FAILURE with no cause. Three very different problems all produced that one line:

- **DB-index drift across hosts** — one worker talks to Redis DB 0, another to DB 1, so `run_job` writes state to one DB and `process_nats_pipeline_result` looks for it in another.
- **Key eviction** under memory pressure.
- **Never-initialized state** (a legitimate concurrent-cleanup race).

This PR keeps the same failure path but makes it name the actual cause and surface it where operators and users will see it. It is observability only — it does not prevent the failure (the underlying misconfig is an infra fix); it makes the next occurrence diagnosable from the first failed job.

It complements #1343 (which already logs job status + age on the missing-state path to tell "late result for a finished job" from "real anomaly"); this PR adds the Redis snapshot as the failure reason and surfaces it in the UI.

### List of Changes

| # | Change (operator/user effect) | How |
|---|---|---|
| 1 | A missing-state FAILURE now names its likely cause and shows it in the job's UI errors, instead of one misleading line buried in worker logs. | `process_nats_pipeline_result` passes a live `diagnose_missing_state()` snapshot to `_fail_job` (stage-annotated); `_fail_job` appends the reason to `progress.errors`. |
| 2 | Cross-host Redis DB-index drift is visible from the first job, without already suspecting it. | `run_job` logs the Redis DB index at task start. |
| 3 | The missing-state condition is logged loudly server-side the moment it is detected. | `update_state` emits a `WARN` with the snapshot immediately before returning `None`. |
| 4 | Diagnostics that reach the user never expose internal infrastructure. | Split helpers: `_redis_db_index()` / `diagnose_missing_state()` report the **DB index only** (safe for the public job log and `progress.errors`); `_describe_redis_target()` / `connection_target()` report **host:port** and go to **server-side logs only**. |

The DB index is the load-bearing signal for the drift case and is safe to expose; the Redis host names internal infrastructure and is deliberately kept out of anything user-facing.

## Tests

`ami/jobs/tests/test_tasks.py` and `ami/ml/tests.py::TestTaskStateManager`:

- `diagnose_missing_state()` returns `keys_for_job=<none>` when state was never initialized, and lists the surviving per-key SCARDs when only the total key is wiped.
- `TestRedisTargetLogging` / `TestTaskStateManager` assert the **public** strings (`_redis_db_index()`, `diagnose_missing_state()`) expose only the DB index, while the operator-only `connection_target()` retains host:port — guarding the public/server split.
- `_fail_job` appends the reason to `progress.errors` (verified in memory and after `refresh_from_db()`), and is a no-op on an already-final job. The existing call-site tests mock `_fail_job` entirely, so without these a silent regression on the append would not be caught.

Run locally against the rebased branch (dockerized Django, isolated DB): `ami/jobs/tests/test_tasks.py` + `ami/ml/tests.py::TestTaskStateManager` pass.

**Not yet exercised end-to-end:** the live missing-state FAILURE path (the loud log + the UI reason) is covered by unit tests, not by a deployed run. To verify in a dev env: start an async_api job, `DEL` its `pending_images_total` key mid-run, and confirm the FAILURE shows the diagnostic in both the UI `progress.errors` and the worker log, and that `run_job`'s opening line reports the Redis DB index.

## Known minor / follow-up

On the `process_nats_pipeline_result` missing-state path the failure is now reported up to three times — `update_state`'s WARN, #1343's `_log_missing_state_context`, and the `_fail_job` reason — and `diagnose_missing_state()` runs twice (once for the WARN, once for the reason). This is the failure path only, so the cost is negligible, but it's a candidate for a small cleanup.

## Relationship to merged work

- **#1343** — logs status/age context on the missing-state path. Complementary: that PR answers "is this an anomaly?", this one answers "what is the anomaly?".
- **#1244** (merged) — reconciles jobs where Redis still tracks images as pending; it also appends a reason to `progress.errors` via `_fail_job`. With both merged there are now two append sites, so a small shared `_append_progress_error(job, reason)` helper is a reasonable follow-up.
- **#1231** (merged) — separates transient Redis errors (retry) from terminal state loss (`_fail_job`); this PR relies on that contract. **#1234** (merged) — STARTED-hang guard; same `_fail_job`, different entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer job diagnostics when progress state is missing, including more detailed failure messages and logging context.
  * Job failures now surface the reason in progress error details for easier visibility in the UI.

* **Bug Fixes**
  * Improved handling of missing pipeline state so jobs are marked failed with stage-specific diagnostics.
  * Added safer Redis logging to show only appropriate connection details in the right logs.
  * Expanded diagnostic coverage for partially missing or cleaned-up job state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->