### PR TITLE
fix(jobs): throttle and defer pipeline heartbeat update

### DIFF
--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from asgiref.sync import async_to_sync, sync_to_async
 from celery.signals import task_failure, task_postrun, task_prerun
 from django.db import transaction
+from django.db.models import Q
 from redis.exceptions import RedisError
 
 from ami.main.checks.schemas import IntegrityCheckResult
@@ -34,18 +35,22 @@ FAILURE_THRESHOLD = 0.5
 # "nobody's listening" signal.
 WORKER_AVAILABILITY_ONLINE_CUTOFF = datetime.timedelta(minutes=5)
 
-# Minimum interval between heartbeat DB writes for a given job.
+# Minimum interval between heartbeat DB writes for a given (pipeline, project).
 # PROCESSING_SERVICE_LAST_SEEN_MAX is 60s; writing at most once per 30s keeps
-# last_seen current without hammering the same rows on every concurrent request.
+# shared last_seen rows current without hammering them on every concurrent
+# request for the same pipeline within a project.
 HEARTBEAT_THROTTLE_SECONDS = 30
+HEARTBEAT_TASK_EXPIRES_SECONDS = HEARTBEAT_THROTTLE_SECONDS * 2
 
 
 @celery_app.task(
     soft_time_limit=10,
     time_limit=15,
+    expires=HEARTBEAT_TASK_EXPIRES_SECONDS,
+    ignore_result=True,
     # No retries — a missed heartbeat is benign; retrying adds load for no gain.
 )
-def update_pipeline_pull_services_seen(job_id: int) -> None:
+def update_pipeline_pull_services_seen(job_id: int, seen_at_iso: str | None = None) -> None:
     """
     Fire-and-forget heartbeat task: record last_seen/last_seen_live for async
     (pull-mode) processing services linked to a job's pipeline.
@@ -53,9 +58,10 @@ def update_pipeline_pull_services_seen(job_id: int) -> None:
     Called via .delay() from the tasks and result view endpoints so the HTTP
     request is never blocked on this DB write.
 
-    Throttle: skips the UPDATE if all matching services were seen within
-    HEARTBEAT_THROTTLE_SECONDS, cutting write rate under concurrent requests by
-    orders of magnitude while keeping last_seen fresh relative to the 60s
+    Throttle: skips the UPDATE if every matching service in the shared
+    (pipeline, project) scope was seen within HEARTBEAT_THROTTLE_SECONDS,
+    cutting write rate under concurrent requests by orders of magnitude while
+    keeping last_seen fresh relative to the 60s
     PROCESSING_SERVICE_LAST_SEEN_MAX threshold.
 
     Scope: marks ALL async services on the pipeline within this project as live,
@@ -73,17 +79,15 @@ def update_pipeline_pull_services_seen(job_id: int) -> None:
     if not job.pipeline_id:
         return
 
-    now = datetime.datetime.now()
-    throttle_cutoff = now - datetime.timedelta(seconds=HEARTBEAT_THROTTLE_SECONDS)
+    seen_at = datetime.datetime.fromisoformat(seen_at_iso) if seen_at_iso is not None else datetime.datetime.now()
+    throttle_cutoff = seen_at - datetime.timedelta(seconds=HEARTBEAT_THROTTLE_SECONDS)
 
     services_qs = job.pipeline.processing_services.async_services().filter(projects=job.project_id)
-
-    # Cheap read: skip the UPDATE if every matching service was seen recently.
-    recent_seen = services_qs.values_list("last_seen", flat=True)
-    if recent_seen and all(ts is not None and ts >= throttle_cutoff for ts in recent_seen):
+    stale_services_qs = services_qs.filter(Q(last_seen__isnull=True) | Q(last_seen__lt=throttle_cutoff))
+    if not stale_services_qs.exists():
         return
 
-    services_qs.update(last_seen=now, last_seen_live=True)
+    stale_services_qs.update(last_seen=seen_at, last_seen_live=True)
 
 
 @celery_app.task(bind=True, soft_time_limit=default_soft_time_limit, time_limit=default_time_limit)

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -34,6 +34,57 @@ FAILURE_THRESHOLD = 0.5
 # "nobody's listening" signal.
 WORKER_AVAILABILITY_ONLINE_CUTOFF = datetime.timedelta(minutes=5)
 
+# Minimum interval between heartbeat DB writes for a given job.
+# PROCESSING_SERVICE_LAST_SEEN_MAX is 60s; writing at most once per 30s keeps
+# last_seen current without hammering the same rows on every concurrent request.
+HEARTBEAT_THROTTLE_SECONDS = 30
+
+
+@celery_app.task(
+    soft_time_limit=10,
+    time_limit=15,
+    # No retries — a missed heartbeat is benign; retrying adds load for no gain.
+)
+def update_pipeline_pull_services_seen(job_id: int) -> None:
+    """
+    Fire-and-forget heartbeat task: record last_seen/last_seen_live for async
+    (pull-mode) processing services linked to a job's pipeline.
+
+    Called via .delay() from the tasks and result view endpoints so the HTTP
+    request is never blocked on this DB write.
+
+    Throttle: skips the UPDATE if all matching services were seen within
+    HEARTBEAT_THROTTLE_SECONDS, cutting write rate under concurrent requests by
+    orders of magnitude while keeping last_seen fresh relative to the 60s
+    PROCESSING_SERVICE_LAST_SEEN_MAX threshold.
+
+    Scope: marks ALL async services on the pipeline within this project as live,
+    not just the specific service that made the request. Once application-token
+    auth is available (PR #1117), this should be scoped to the individual
+    calling service instead.
+    """
+    from ami.jobs.models import Job  # avoid circular import
+
+    try:
+        job = Job.objects.select_related("pipeline").get(pk=job_id)
+    except Job.DoesNotExist:
+        return
+
+    if not job.pipeline_id:
+        return
+
+    now = datetime.datetime.now()
+    throttle_cutoff = now - datetime.timedelta(seconds=HEARTBEAT_THROTTLE_SECONDS)
+
+    services_qs = job.pipeline.processing_services.async_services().filter(projects=job.project_id)
+
+    # Cheap read: skip the UPDATE if every matching service was seen recently.
+    recent_seen = services_qs.values_list("last_seen", flat=True)
+    if recent_seen and all(ts is not None and ts >= throttle_cutoff for ts in recent_seen):
+        return
+
+    services_qs.update(last_seen=now, last_seen_live=True)
+
 
 @celery_app.task(bind=True, soft_time_limit=default_soft_time_limit, time_limit=default_time_limit)
 def run_job(self, job_id: int) -> None:

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 from asgiref.sync import async_to_sync, sync_to_async
 from celery.signals import task_failure, task_postrun, task_prerun
 from django.db import transaction
-from django.db.models import Q
 from redis.exceptions import RedisError
 
 from ami.main.checks.schemas import IntegrityCheckResult
@@ -35,34 +34,26 @@ FAILURE_THRESHOLD = 0.5
 # "nobody's listening" signal.
 WORKER_AVAILABILITY_ONLINE_CUTOFF = datetime.timedelta(minutes=5)
 
-# Minimum interval between heartbeat DB writes for a given (pipeline, project).
-# PROCESSING_SERVICE_LAST_SEEN_MAX is 60s; writing at most once per 30s keeps
-# shared last_seen rows current without hammering them on every concurrent
-# request for the same pipeline within a project.
+# Minimum interval between heartbeat dispatches for a given (pipeline, project).
+# The view-level Redis cache gate uses this window to skip .delay() under
+# concurrent polling; the task itself does no throttling.
 HEARTBEAT_THROTTLE_SECONDS = 30
-HEARTBEAT_TASK_EXPIRES_SECONDS = HEARTBEAT_THROTTLE_SECONDS * 2
 
 
 @celery_app.task(
     soft_time_limit=10,
     time_limit=15,
-    expires=HEARTBEAT_TASK_EXPIRES_SECONDS,
     ignore_result=True,
     # No retries — a missed heartbeat is benign; retrying adds load for no gain.
 )
-def update_pipeline_pull_services_seen(job_id: int, seen_at_iso: str | None = None) -> None:
+def update_pipeline_pull_services_seen(job_id: int) -> None:
     """
     Fire-and-forget heartbeat task: record last_seen/last_seen_live for async
     (pull-mode) processing services linked to a job's pipeline.
 
-    Called via .delay() from the tasks and result view endpoints so the HTTP
-    request is never blocked on this DB write.
-
-    Throttle: skips the UPDATE if every matching service in the shared
-    (pipeline, project) scope was seen within HEARTBEAT_THROTTLE_SECONDS,
-    cutting write rate under concurrent requests by orders of magnitude while
-    keeping last_seen fresh relative to the 60s
-    PROCESSING_SERVICE_LAST_SEEN_MAX threshold.
+    Throttling lives in the view (Redis cache gate over HEARTBEAT_THROTTLE_SECONDS),
+    so this task is dispatched at most once per (pipeline, project) per window
+    and can just write.
 
     Scope: marks ALL async services on the pipeline within this project as live,
     not just the specific service that made the request. Once application-token
@@ -79,15 +70,10 @@ def update_pipeline_pull_services_seen(job_id: int, seen_at_iso: str | None = No
     if not job.pipeline_id:
         return
 
-    seen_at = datetime.datetime.fromisoformat(seen_at_iso) if seen_at_iso is not None else datetime.datetime.now()
-    throttle_cutoff = seen_at - datetime.timedelta(seconds=HEARTBEAT_THROTTLE_SECONDS)
-
-    services_qs = job.pipeline.processing_services.async_services().filter(projects=job.project_id)
-    stale_services_qs = services_qs.filter(Q(last_seen__isnull=True) | Q(last_seen__lt=throttle_cutoff))
-    if not stale_services_qs.exists():
-        return
-
-    stale_services_qs.update(last_seen=seen_at, last_seen_live=True)
+    job.pipeline.processing_services.async_services().filter(projects=job.project_id).update(
+        last_seen=datetime.datetime.now(),
+        last_seen_live=True,
+    )
 
 
 @celery_app.task(bind=True, soft_time_limit=default_soft_time_limit, time_limit=default_time_limit)

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -11,6 +11,7 @@ from ami.base.serializers import reverse_with_params
 from ami.jobs.models import Job, JobDispatchMode, JobProgress, JobState, MLJob, SourceImageCollectionPopulateJob
 from ami.main.models import Project, SourceImage, SourceImageCollection
 from ami.ml.models import Pipeline
+from ami.ml.models.processing_service import ProcessingService
 from ami.ml.orchestration.jobs import queue_images_to_nats
 from ami.users.models import User
 
@@ -1016,3 +1017,166 @@ class TestJobDispatchModeFiltering(APITestCase):
         resp = self.client.post(tasks_url, {"batch_size": 1}, format="json")
         self.assertEqual(resp.status_code, 400)
         self.assertIn("async_api", resp.json()[0].lower())
+
+
+class TestPipelineHeartbeatTask(APITestCase):
+    """
+    Unit tests for update_pipeline_pull_services_seen and the view-level
+    _mark_pipeline_pull_services_seen fire-and-forget dispatch.
+    """
+
+    def setUp(self):
+        self.project = Project.objects.create(name="Heartbeat Test Project")
+        self.pipeline = Pipeline.objects.create(name="Heartbeat Pipeline", slug="heartbeat-pipeline")
+        self.pipeline.projects.add(self.project)
+        self.collection = SourceImageCollection.objects.create(name="HB Collection", project=self.project)
+        self.job = Job.objects.create(
+            job_type_key=MLJob.key,
+            project=self.project,
+            name="Heartbeat Test Job",
+            pipeline=self.pipeline,
+            source_image_collection=self.collection,
+            dispatch_mode=JobDispatchMode.ASYNC_API,
+        )
+        self.service = ProcessingService.objects.create(
+            name="Heartbeat Worker",
+            endpoint_url=None,  # None = pull-mode / async service
+        )
+        self.service.pipelines.add(self.pipeline)
+        self.service.projects.add(self.project)
+
+    def test_tasks_endpoint_dispatches_heartbeat_task(self):
+        """The /tasks endpoint calls update_pipeline_pull_services_seen.delay(), not the DB directly."""
+        from unittest.mock import patch
+
+        job = self.job
+        job.status = JobState.STARTED
+        job.save(update_fields=["status"])
+
+        images = [
+            SourceImage.objects.create(
+                path=f"hb_tasks_{i}.jpg",
+                public_base_url="http://example.com",
+                project=self.project,
+            )
+            for i in range(2)
+        ]
+        queue_images_to_nats(job, images)
+
+        user = User.objects.create_user(email="hbtest@example.com", is_superuser=True, is_active=True)
+        self.client.force_authenticate(user=user)
+
+        with patch("ami.jobs.views.update_pipeline_pull_services_seen.delay") as mock_delay:
+            tasks_url = reverse_with_params("api:job-tasks", args=[job.pk], params={"project_id": self.project.pk})
+            resp = self.client.post(tasks_url, {"batch_size": 1}, format="json")
+
+        self.assertEqual(resp.status_code, 200)
+        mock_delay.assert_called_once_with(job.pk)
+
+    def test_result_endpoint_dispatches_heartbeat_task(self):
+        """The /result endpoint calls update_pipeline_pull_services_seen.delay(), not the DB directly."""
+        from unittest.mock import MagicMock, patch
+
+        user = User.objects.create_user(email="hbresult@example.com", is_superuser=True, is_active=True)
+        self.client.force_authenticate(user=user)
+
+        result_data = {
+            "results": [
+                {
+                    "reply_subject": "test.reply.hb",
+                    "result": {
+                        "pipeline": "heartbeat-pipeline",
+                        "algorithms": {},
+                        "total_time": 0.1,
+                        "source_images": [],
+                        "detections": [],
+                        "errors": None,
+                    },
+                }
+            ]
+        }
+
+        mock_async_result = MagicMock()
+        mock_async_result.id = "hb-task-id"
+        with (
+            patch("ami.jobs.views.process_nats_pipeline_result.delay", return_value=mock_async_result),
+            patch("ami.jobs.views.update_pipeline_pull_services_seen.delay") as mock_delay,
+        ):
+            result_url = reverse_with_params(
+                "api:job-result", args=[self.job.pk], params={"project_id": self.project.pk}
+            )
+            resp = self.client.post(result_url, result_data, format="json")
+
+        self.assertEqual(resp.status_code, 200)
+        mock_delay.assert_called_once_with(self.job.pk)
+
+    def test_heartbeat_task_updates_last_seen_when_stale(self):
+        """update_pipeline_pull_services_seen writes last_seen when the service is stale."""
+        import datetime
+
+        from ami.jobs.tasks import update_pipeline_pull_services_seen
+
+        # Set last_seen to well past the throttle window
+        old_time = datetime.datetime.now() - datetime.timedelta(minutes=5)
+        self.service.last_seen = old_time
+        self.service.last_seen_live = False
+        self.service.save(update_fields=["last_seen", "last_seen_live"])
+
+        update_pipeline_pull_services_seen(self.job.pk)
+
+        self.service.refresh_from_db()
+        self.assertTrue(self.service.last_seen_live)
+        self.assertGreater(self.service.last_seen, old_time)
+
+    def test_heartbeat_task_skips_update_when_recent(self):
+        """update_pipeline_pull_services_seen skips the UPDATE when last_seen is within the throttle window."""
+        import datetime
+
+        from ami.jobs.tasks import update_pipeline_pull_services_seen
+
+        # Set last_seen to just now — well inside the 30s throttle window
+        recent_time = datetime.datetime.now() - datetime.timedelta(seconds=5)
+        self.service.last_seen = recent_time
+        self.service.last_seen_live = True
+        self.service.save(update_fields=["last_seen", "last_seen_live"])
+
+        update_pipeline_pull_services_seen(self.job.pk)
+
+        self.service.refresh_from_db()
+        # last_seen should not have advanced significantly (throttle skipped the UPDATE)
+        self.assertAlmostEqual(
+            self.service.last_seen.timestamp(),
+            recent_time.timestamp(),
+            delta=1.0,
+        )
+
+    def test_heartbeat_task_no_op_for_missing_job(self):
+        """update_pipeline_pull_services_seen silently returns when job_id does not exist."""
+        from ami.jobs.tasks import update_pipeline_pull_services_seen
+
+        # Should not raise
+        update_pipeline_pull_services_seen(job_id=999999)
+
+    def test_heartbeat_task_no_op_for_job_without_pipeline(self):
+        """update_pipeline_pull_services_seen returns early when job has no pipeline."""
+        import datetime
+
+        from ami.jobs.tasks import update_pipeline_pull_services_seen
+
+        job_no_pipeline = Job.objects.create(
+            job_type_key=MLJob.key,
+            project=self.project,
+            name="No-pipeline job",
+            source_image_collection=self.collection,
+            dispatch_mode=JobDispatchMode.ASYNC_API,
+        )
+
+        old_time = datetime.datetime.now() - datetime.timedelta(minutes=10)
+        self.service.last_seen = old_time
+        self.service.save(update_fields=["last_seen"])
+
+        update_pipeline_pull_services_seen(job_no_pipeline.pk)
+
+        # Service last_seen should be unchanged because the task returned early
+        self.service.refresh_from_db()
+        self.assertAlmostEqual(self.service.last_seen.timestamp(), old_time.timestamp(), delta=1.0)

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -1053,7 +1053,7 @@ class TestPipelineHeartbeatTask(APITestCase):
 
     def test_tasks_endpoint_dispatches_heartbeat_task(self):
         """The /tasks endpoint calls update_pipeline_pull_services_seen.delay(), not the DB directly."""
-        from unittest.mock import ANY, patch
+        from unittest.mock import patch
 
         job = self.job
         job.status = JobState.STARTED
@@ -1077,11 +1077,11 @@ class TestPipelineHeartbeatTask(APITestCase):
             resp = self.client.post(tasks_url, {"batch_size": 1}, format="json")
 
         self.assertEqual(resp.status_code, 200)
-        mock_delay.assert_called_once_with(job.pk, seen_at_iso=ANY)
+        mock_delay.assert_called_once_with(job.pk)
 
     def test_result_endpoint_dispatches_heartbeat_task(self):
         """The /result endpoint calls update_pipeline_pull_services_seen.delay(), not the DB directly."""
-        from unittest.mock import ANY, MagicMock, patch
+        from unittest.mock import MagicMock, patch
 
         user = User.objects.create_user(email="hbresult@example.com", is_superuser=True, is_active=True)
         self.client.force_authenticate(user=user)
@@ -1114,7 +1114,7 @@ class TestPipelineHeartbeatTask(APITestCase):
             resp = self.client.post(result_url, result_data, format="json")
 
         self.assertEqual(resp.status_code, 200)
-        mock_delay.assert_called_once_with(self.job.pk, seen_at_iso=ANY)
+        mock_delay.assert_called_once_with(self.job.pk)
 
     def test_tasks_endpoint_tolerates_heartbeat_dispatch_failure(self):
         """Heartbeat enqueue errors should not fail the /tasks response."""
@@ -1145,95 +1145,6 @@ class TestPipelineHeartbeatTask(APITestCase):
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.json()["tasks"]), 1)
-
-    def test_heartbeat_task_updates_last_seen_when_stale(self):
-        """update_pipeline_pull_services_seen writes last_seen when the service is stale."""
-        import datetime
-
-        from ami.jobs.tasks import update_pipeline_pull_services_seen
-
-        # Set last_seen to well past the throttle window
-        old_time = datetime.datetime.now() - datetime.timedelta(minutes=5)
-        self.service.last_seen = old_time
-        self.service.last_seen_live = False
-        self.service.save(update_fields=["last_seen", "last_seen_live"])
-
-        seen_at = datetime.datetime.now()
-        update_pipeline_pull_services_seen(self.job.pk, seen_at_iso=seen_at.isoformat())
-
-        self.service.refresh_from_db()
-        self.assertTrue(self.service.last_seen_live)
-        self.assertEqual(self.service.last_seen, seen_at)
-
-    def test_heartbeat_task_skips_update_when_recent(self):
-        """update_pipeline_pull_services_seen skips the UPDATE when last_seen is within the throttle window."""
-        import datetime
-
-        from ami.jobs.tasks import update_pipeline_pull_services_seen
-
-        # Set last_seen to just now — well inside the 30s throttle window
-        recent_time = datetime.datetime.now() - datetime.timedelta(seconds=5)
-        self.service.last_seen = recent_time
-        self.service.last_seen_live = True
-        self.service.save(update_fields=["last_seen", "last_seen_live"])
-
-        update_pipeline_pull_services_seen(self.job.pk, seen_at_iso=datetime.datetime.now().isoformat())
-
-        self.service.refresh_from_db()
-        # last_seen should not have advanced significantly (throttle skipped the UPDATE)
-        self.assertAlmostEqual(
-            self.service.last_seen.timestamp(),
-            recent_time.timestamp(),
-            delta=1.0,
-        )
-
-    def test_heartbeat_task_no_op_for_missing_job(self):
-        """update_pipeline_pull_services_seen silently returns when job_id does not exist."""
-        from ami.jobs.tasks import update_pipeline_pull_services_seen
-
-        # Should not raise
-        update_pipeline_pull_services_seen(job_id=999999)
-
-    def test_heartbeat_task_no_op_for_job_without_pipeline(self):
-        """update_pipeline_pull_services_seen returns early when job has no pipeline."""
-        import datetime
-
-        from ami.jobs.tasks import update_pipeline_pull_services_seen
-
-        job_no_pipeline = Job.objects.create(
-            job_type_key=MLJob.key,
-            project=self.project,
-            name="No-pipeline job",
-            source_image_collection=self.collection,
-            dispatch_mode=JobDispatchMode.ASYNC_API,
-        )
-
-        old_time = datetime.datetime.now() - datetime.timedelta(minutes=10)
-        self.service.last_seen = old_time
-        self.service.save(update_fields=["last_seen"])
-
-        update_pipeline_pull_services_seen(job_no_pipeline.pk, seen_at_iso=datetime.datetime.now().isoformat())
-
-        # Service last_seen should be unchanged because the task returned early
-        self.service.refresh_from_db()
-        self.assertAlmostEqual(self.service.last_seen.timestamp(), old_time.timestamp(), delta=1.0)
-
-    def test_heartbeat_task_does_not_regress_newer_last_seen(self):
-        """Delayed heartbeats must not overwrite a newer last_seen value."""
-        import datetime
-
-        from ami.jobs.tasks import update_pipeline_pull_services_seen
-
-        newer_time = datetime.datetime.now()
-        delayed_seen_at = newer_time - datetime.timedelta(minutes=1)
-        self.service.last_seen = newer_time
-        self.service.last_seen_live = True
-        self.service.save(update_fields=["last_seen", "last_seen_live"])
-
-        update_pipeline_pull_services_seen(self.job.pk, seen_at_iso=delayed_seen_at.isoformat())
-
-        self.service.refresh_from_db()
-        self.assertEqual(self.service.last_seen, newer_time)
 
     def test_view_gate_suppresses_redundant_dispatches(self):
         """Rapid repeated calls to _mark_pipeline_pull_services_seen should only enqueue once per window."""

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -1026,6 +1026,12 @@ class TestPipelineHeartbeatTask(APITestCase):
     """
 
     def setUp(self):
+        from django.core.cache import cache
+
+        # Cache-based gate in _mark_pipeline_pull_services_seen would otherwise
+        # carry over between tests and suppress the .delay() we want to assert.
+        cache.clear()
+
         self.project = Project.objects.create(name="Heartbeat Test Project")
         self.pipeline = Pipeline.objects.create(name="Heartbeat Pipeline", slug="heartbeat-pipeline")
         self.pipeline.projects.add(self.project)
@@ -1228,3 +1234,15 @@ class TestPipelineHeartbeatTask(APITestCase):
 
         self.service.refresh_from_db()
         self.assertEqual(self.service.last_seen, newer_time)
+
+    def test_view_gate_suppresses_redundant_dispatches(self):
+        """Rapid repeated calls to _mark_pipeline_pull_services_seen should only enqueue once per window."""
+        from unittest.mock import patch
+
+        from ami.jobs.views import _mark_pipeline_pull_services_seen
+
+        with patch("ami.jobs.views.update_pipeline_pull_services_seen.delay") as mock_delay:
+            for _ in range(5):
+                _mark_pipeline_pull_services_seen(self.job)
+
+        self.assertEqual(mock_delay.call_count, 1)

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -1047,7 +1047,7 @@ class TestPipelineHeartbeatTask(APITestCase):
 
     def test_tasks_endpoint_dispatches_heartbeat_task(self):
         """The /tasks endpoint calls update_pipeline_pull_services_seen.delay(), not the DB directly."""
-        from unittest.mock import patch
+        from unittest.mock import ANY, patch
 
         job = self.job
         job.status = JobState.STARTED
@@ -1071,11 +1071,11 @@ class TestPipelineHeartbeatTask(APITestCase):
             resp = self.client.post(tasks_url, {"batch_size": 1}, format="json")
 
         self.assertEqual(resp.status_code, 200)
-        mock_delay.assert_called_once_with(job.pk)
+        mock_delay.assert_called_once_with(job.pk, seen_at_iso=ANY)
 
     def test_result_endpoint_dispatches_heartbeat_task(self):
         """The /result endpoint calls update_pipeline_pull_services_seen.delay(), not the DB directly."""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import ANY, MagicMock, patch
 
         user = User.objects.create_user(email="hbresult@example.com", is_superuser=True, is_active=True)
         self.client.force_authenticate(user=user)
@@ -1108,7 +1108,37 @@ class TestPipelineHeartbeatTask(APITestCase):
             resp = self.client.post(result_url, result_data, format="json")
 
         self.assertEqual(resp.status_code, 200)
-        mock_delay.assert_called_once_with(self.job.pk)
+        mock_delay.assert_called_once_with(self.job.pk, seen_at_iso=ANY)
+
+    def test_tasks_endpoint_tolerates_heartbeat_dispatch_failure(self):
+        """Heartbeat enqueue errors should not fail the /tasks response."""
+        from unittest.mock import patch
+
+        from kombu.exceptions import OperationalError
+
+        job = self.job
+        job.status = JobState.STARTED
+        job.save(update_fields=["status"])
+
+        image = SourceImage.objects.create(
+            path="hb_tasks_broker.jpg",
+            public_base_url="http://example.com",
+            project=self.project,
+        )
+        queue_images_to_nats(job, [image])
+
+        user = User.objects.create_user(email="hbbroker@example.com", is_superuser=True, is_active=True)
+        self.client.force_authenticate(user=user)
+
+        with patch(
+            "ami.jobs.views.update_pipeline_pull_services_seen.delay",
+            side_effect=OperationalError("broker unavailable"),
+        ):
+            tasks_url = reverse_with_params("api:job-tasks", args=[job.pk], params={"project_id": self.project.pk})
+            resp = self.client.post(tasks_url, {"batch_size": 1}, format="json")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.json()["tasks"]), 1)
 
     def test_heartbeat_task_updates_last_seen_when_stale(self):
         """update_pipeline_pull_services_seen writes last_seen when the service is stale."""
@@ -1122,11 +1152,12 @@ class TestPipelineHeartbeatTask(APITestCase):
         self.service.last_seen_live = False
         self.service.save(update_fields=["last_seen", "last_seen_live"])
 
-        update_pipeline_pull_services_seen(self.job.pk)
+        seen_at = datetime.datetime.now()
+        update_pipeline_pull_services_seen(self.job.pk, seen_at_iso=seen_at.isoformat())
 
         self.service.refresh_from_db()
         self.assertTrue(self.service.last_seen_live)
-        self.assertGreater(self.service.last_seen, old_time)
+        self.assertEqual(self.service.last_seen, seen_at)
 
     def test_heartbeat_task_skips_update_when_recent(self):
         """update_pipeline_pull_services_seen skips the UPDATE when last_seen is within the throttle window."""
@@ -1140,7 +1171,7 @@ class TestPipelineHeartbeatTask(APITestCase):
         self.service.last_seen_live = True
         self.service.save(update_fields=["last_seen", "last_seen_live"])
 
-        update_pipeline_pull_services_seen(self.job.pk)
+        update_pipeline_pull_services_seen(self.job.pk, seen_at_iso=datetime.datetime.now().isoformat())
 
         self.service.refresh_from_db()
         # last_seen should not have advanced significantly (throttle skipped the UPDATE)
@@ -1175,8 +1206,25 @@ class TestPipelineHeartbeatTask(APITestCase):
         self.service.last_seen = old_time
         self.service.save(update_fields=["last_seen"])
 
-        update_pipeline_pull_services_seen(job_no_pipeline.pk)
+        update_pipeline_pull_services_seen(job_no_pipeline.pk, seen_at_iso=datetime.datetime.now().isoformat())
 
         # Service last_seen should be unchanged because the task returned early
         self.service.refresh_from_db()
         self.assertAlmostEqual(self.service.last_seen.timestamp(), old_time.timestamp(), delta=1.0)
+
+    def test_heartbeat_task_does_not_regress_newer_last_seen(self):
+        """Delayed heartbeats must not overwrite a newer last_seen value."""
+        import datetime
+
+        from ami.jobs.tasks import update_pipeline_pull_services_seen
+
+        newer_time = datetime.datetime.now()
+        delayed_seen_at = newer_time - datetime.timedelta(minutes=1)
+        self.service.last_seen = newer_time
+        self.service.last_seen_live = True
+        self.service.save(update_fields=["last_seen", "last_seen_live"])
+
+        update_pipeline_pull_services_seen(self.job.pk, seen_at_iso=delayed_seen_at.isoformat())
+
+        self.service.refresh_from_db()
+        self.assertEqual(self.service.last_seen, newer_time)

--- a/ami/jobs/views.py
+++ b/ami/jobs/views.py
@@ -1,5 +1,4 @@
 import asyncio
-import datetime
 import logging
 
 import kombu.exceptions
@@ -57,13 +56,10 @@ def _mark_pipeline_pull_services_seen(job: "Job") -> None:
     Enqueue a fire-and-forget heartbeat for async (pull-mode) processing services
     linked to the job's pipeline.
 
-    Dispatches update_pipeline_pull_services_seen via Celery .delay() so the view
-    is never blocked on the DB write. A view-level Redis cache gate skips the
-    .delay() entirely when a heartbeat for the same (pipeline, project) has been
-    enqueued within HEARTBEAT_THROTTLE_SECONDS — so under concurrent polling we
-    avoid broker + task churn, not just the DB write. The task itself also
-    re-checks staleness before writing (belt + suspenders, and safe under cache
-    eviction).
+    A Redis cache gate skips the dispatch when a heartbeat for the same
+    (pipeline, project) has already fired within HEARTBEAT_THROTTLE_SECONDS,
+    so under concurrent polling we avoid broker + task churn. The Celery task
+    keeps the DB write off the HTTP request path.
 
     Cache key scope: currently `heartbeat:pipeline:<pipeline_id>:project:<project_id>`
     because we cannot yet identify the specific calling service. Once
@@ -77,7 +73,7 @@ def _mark_pipeline_pull_services_seen(job: "Job") -> None:
     if not cache.add(cache_key, 1, timeout=HEARTBEAT_THROTTLE_SECONDS):
         return
     try:
-        update_pipeline_pull_services_seen.delay(job.pk, seen_at_iso=datetime.datetime.now().isoformat())
+        update_pipeline_pull_services_seen.delay(job.pk)
     except (kombu.exceptions.KombuError, ConnectionError, OSError) as exc:
         msg = f"Failed to enqueue non-critical pipeline heartbeat for job {job.pk}: {exc}"
         logger.warning(msg)

--- a/ami/jobs/views.py
+++ b/ami/jobs/views.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import logging
 
 import kombu.exceptions
@@ -57,9 +58,10 @@ def _mark_pipeline_pull_services_seen(job: "Job") -> None:
 
     Dispatches update_pipeline_pull_services_seen via Celery .delay() so the view
     is never blocked on the DB write. The task throttles writes to at most once per
-    ~30 seconds per job, keeping last_seen current relative to the 60s
-    PROCESSING_SERVICE_LAST_SEEN_MAX threshold without hammering the same rows on
-    every concurrent task-fetch or result-submit request.
+    ~30 seconds per pipeline within this project, keeping last_seen current
+    relative to the 60s PROCESSING_SERVICE_LAST_SEEN_MAX threshold without
+    hammering the same rows on every concurrent task-fetch or result-submit
+    request.
 
     Per-service scoping is not yet possible — marks ALL async services on the
     pipeline within this project as live. Once application-token auth lands
@@ -67,7 +69,12 @@ def _mark_pipeline_pull_services_seen(job: "Job") -> None:
     """
     if not job.pipeline_id:
         return
-    update_pipeline_pull_services_seen.delay(job.pk)
+    try:
+        update_pipeline_pull_services_seen.delay(job.pk, seen_at_iso=datetime.datetime.now().isoformat())
+    except (kombu.exceptions.KombuError, ConnectionError, OSError) as exc:
+        msg = f"Failed to enqueue non-critical pipeline heartbeat for job {job.pk}: {exc}"
+        logger.warning(msg)
+        job.logger.warning(msg)
 
 
 class JobFilterSet(filters.FilterSet):

--- a/ami/jobs/views.py
+++ b/ami/jobs/views.py
@@ -24,7 +24,7 @@ from ami.jobs.serializers import (
     MLJobTasksRequestSerializer,
     MLJobTasksResponseSerializer,
 )
-from ami.jobs.tasks import process_nats_pipeline_result
+from ami.jobs.tasks import process_nats_pipeline_result, update_pipeline_pull_services_seen
 from ami.main.api.schemas import project_id_doc_param
 from ami.main.api.views import DefaultViewSet
 from ami.utils.fields import url_boolean_param
@@ -52,26 +52,22 @@ def _actor_log_context(request) -> tuple[str, str | None]:
 
 def _mark_pipeline_pull_services_seen(job: "Job") -> None:
     """
-    Record a heartbeat for async (pull-mode) processing services linked to the job's pipeline.
+    Enqueue a fire-and-forget heartbeat for async (pull-mode) processing services
+    linked to the job's pipeline.
 
-    Called on every task-fetch and result-submit request so that the worker's polling activity
-    keeps last_seen/last_seen_live current. The periodic check_processing_services_online task
-    will mark services offline if this heartbeat stops arriving within PROCESSING_SERVICE_LAST_SEEN_MAX.
+    Dispatches update_pipeline_pull_services_seen via Celery .delay() so the view
+    is never blocked on the DB write. The task throttles writes to at most once per
+    ~30 seconds per job, keeping last_seen current relative to the 60s
+    PROCESSING_SERVICE_LAST_SEEN_MAX threshold without hammering the same rows on
+    every concurrent task-fetch or result-submit request.
 
-    IMPORTANT: This marks ALL async services on the pipeline within this project as live, not just
-    the specific service that made the request. If multiple async services share the same pipeline
-    within a project, a single worker polling will keep all of them appearing online.
-    Once application-token auth is available (PR #1117), this should be scoped to the individual
-    calling service instead.
+    Per-service scoping is not yet possible — marks ALL async services on the
+    pipeline within this project as live. Once application-token auth lands
+    (PR #1117) this can be scoped to the individual calling service.
     """
-    import datetime
-
     if not job.pipeline_id:
         return
-    job.pipeline.processing_services.async_services().filter(projects=job.project_id).update(
-        last_seen=datetime.datetime.now(),
-        last_seen_live=True,
-    )
+    update_pipeline_pull_services_seen.delay(job.pk)
 
 
 class JobFilterSet(filters.FilterSet):

--- a/ami/jobs/views.py
+++ b/ami/jobs/views.py
@@ -5,6 +5,7 @@ import logging
 import kombu.exceptions
 import nats.errors
 from asgiref.sync import async_to_sync
+from django.core.cache import cache
 from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.forms import IntegerField
@@ -25,7 +26,7 @@ from ami.jobs.serializers import (
     MLJobTasksRequestSerializer,
     MLJobTasksResponseSerializer,
 )
-from ami.jobs.tasks import process_nats_pipeline_result, update_pipeline_pull_services_seen
+from ami.jobs.tasks import HEARTBEAT_THROTTLE_SECONDS, process_nats_pipeline_result, update_pipeline_pull_services_seen
 from ami.main.api.schemas import project_id_doc_param
 from ami.main.api.views import DefaultViewSet
 from ami.utils.fields import url_boolean_param
@@ -57,17 +58,23 @@ def _mark_pipeline_pull_services_seen(job: "Job") -> None:
     linked to the job's pipeline.
 
     Dispatches update_pipeline_pull_services_seen via Celery .delay() so the view
-    is never blocked on the DB write. The task throttles writes to at most once per
-    ~30 seconds per pipeline within this project, keeping last_seen current
-    relative to the 60s PROCESSING_SERVICE_LAST_SEEN_MAX threshold without
-    hammering the same rows on every concurrent task-fetch or result-submit
-    request.
+    is never blocked on the DB write. A view-level Redis cache gate skips the
+    .delay() entirely when a heartbeat for the same (pipeline, project) has been
+    enqueued within HEARTBEAT_THROTTLE_SECONDS — so under concurrent polling we
+    avoid broker + task churn, not just the DB write. The task itself also
+    re-checks staleness before writing (belt + suspenders, and safe under cache
+    eviction).
 
-    Per-service scoping is not yet possible — marks ALL async services on the
-    pipeline within this project as live. Once application-token auth lands
-    (PR #1117) this can be scoped to the individual calling service.
+    Cache key scope: currently `heartbeat:pipeline:<pipeline_id>:project:<project_id>`
+    because we cannot yet identify the specific calling service. Once
+    application-token auth lands (PR #1117), the key should become
+    `heartbeat:service:<service_id>` so each service gets its own throttle
+    window and one service's poll does not suppress another's heartbeat.
     """
     if not job.pipeline_id:
+        return
+    cache_key = f"heartbeat:pipeline:{job.pipeline_id}:project:{job.project_id}"
+    if not cache.add(cache_key, 1, timeout=HEARTBEAT_THROTTLE_SECONDS):
         return
     try:
         update_pipeline_pull_services_seen.delay(job.pk, seen_at_iso=datetime.datetime.now().isoformat())


### PR DESCRIPTION
## Problem

Under concurrent async_api jobs, N gunicorn workers call `_mark_pipeline_pull_services_seen` simultaneously from both the `/tasks` (GET) and `/result` (POST) endpoints. The function issued an unguarded `QuerySet.update()` that hit every async `ProcessingService` row matching the `(pipeline, project)` pair — so every request wrote the same shared rows with no throttle, no `F()` expression, and no coordination.

py-spy dumps taken 26s and 57s before a gunicorn SIGSEGV in a deployment under concurrent load showed two threads blocked in this exact `.update()` → psycopg `wait()`. The function runs inside cachalot's monkey-patch, which layers cache invalidation on top of the concurrent UPDATE. Whether the lock contention is a direct contributor to the C-level crash is still being investigated separately; this PR is scoped to relieve the concurrency hotspot regardless of that outcome.

The heartbeat is a visibility feature — `check_processing_services_online` reads `last_seen` against a 60s window — not a correctness-critical path. Writing on every request is unnecessary.

## Goal

Get this DB write off the gunicorn request path entirely, and stop firing it on every request when once per ~30s is enough to keep the 60s offline check honest.

## Changes

**1. Fire-and-forget via Celery.** The view now dispatches `update_pipeline_pull_services_seen.delay(job.pk)` (new task in `ami/jobs/tasks.py`) instead of running the UPDATE inline. The HTTP request returns without waiting on the DB write, so the gunicorn path — where the SIGSEGV was observed — no longer touches this UPDATE at all. The task itself is minimal: one `QuerySet.update()`.

**2. Throttle at the view, before dispatch.** Before `.delay()`, the view takes a Redis cache lock via `cache.add(key, timeout=HEARTBEAT_THROTTLE_SECONDS)` keyed on `(pipeline_id, project_id)`. `cache.add` is cross-process atomic on Redis, so concurrent gunicorn workers see exactly one winner per 30s window; the rest short-circuit before hitting the broker. This is what collapses the write rate — the task itself has no throttle because it doesn't need one.

**3. Broker tolerance.** If `.delay()` raises (broker down, connection reset, OSError), the view logs and continues. The heartbeat is non-critical; a broker blip should not fail the request.

**4. Scope note.** The existing filter — `pipeline.processing_services.async_services().filter(projects=job.project_id)` — is the tightest scope available until per-service application-token auth lands. Once #1117 is merged, the cache key and the UPDATE target should narrow to the individual calling service; the docstrings call this out and a tracking comment has been posted on #1117.

## What we still need to verify

- **Whether the SIGSEGV recurs after deploy.** The `psycopg wait()` → C-level crash link is inferred from py-spy stacks, not a controlled experiment. Moving the write off the request path should remove the specific contention signal py-spy saw, but the crash could have co-factors. Next step if it recurs: gdb + core dump on the crashing container.
- **That `last_seen` stays fresh enough under the 30s gate.** The offline check uses a 60s window, so the margin is 2×. Should be fine, but flagging as a theoretical edge case if Celery queues back up.
- **Broker load.** The gate collapses repeated polls for the same `(pipeline, project)` to one `.delay()` per 30s, so task volume should scale roughly with `active_jobs / 30s` rather than request rate.

## Tests

4 tests in `TestPipelineHeartbeatTask`:

- `test_tasks_endpoint_dispatches_heartbeat_task` — `.delay(job.pk)` fires from `/tasks`
- `test_result_endpoint_dispatches_heartbeat_task` — `.delay(job.pk)` fires from `/result`
- `test_tasks_endpoint_tolerates_heartbeat_dispatch_failure` — `/tasks` still returns 200 when the broker raises
- `test_view_gate_suppresses_redundant_dispatches` — 5 rapid calls collapse to 1 `.delay()`

Pre-existing failures in `TestJobView` (duplicate-key) are unrelated and present on `main`.

## Relation to upcoming work

Once application-token auth (#1117) lands, this can be scoped from `(pipeline, project)` to the individual calling service — cutting the UPDATE target from N services to 1 and letting each service have its own independent 30s gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Implemented intelligent throttling for service heartbeat tracking, reducing database operations while maintaining accurate status monitoring.
  * Service status updates now execute asynchronously for improved system responsiveness and resource efficiency.

* **Testing**
  * Expanded test coverage for heartbeat tracking and service monitoring across job operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->