### PR TITLE
Update agree logic for human identifications

### DIFF
--- a/ui/src/pages/occurrence-details/identification-card/human-identification.tsx
+++ b/ui/src/pages/occurrence-details/identification-card/human-identification.tsx
@@ -102,7 +102,7 @@ export const HumanIdentification = ({
                           )
                         : false
                     }
-                    agreeWith={{ predictionId: identification.id }}
+                    agreeWith={{ identificationId: identification.id }}
                     applied={identification.applied}
                     occurrenceId={occurrence.id}
                     taxonId={identification.taxon.id}


### PR DESCRIPTION
### Background
When confirming a human identification from the history view, we were passing the wrong key to the API.

<img width="418" height="282" alt="Screenshot 2026-04-30 at 15 24 26" src="https://github.com/user-attachments/assets/e2960109-0ab8-479d-901e-1a80ce983833" />

### The solution
In this PR we adjust the key. This will allow the update, and also we can see more details in the export. Fixes #1226.

<img width="718" height="185" alt="Screenshot 2026-04-30 at 15 33 01" src="https://github.com/user-attachments/assets/18143e0c-e286-4f3b-99af-358a79762650" />

### Notes
- I see some inconsistencies in the export. Sometimes we refer to users by name and sometimes by email. No biggie but could be nice to streamline.
- When confirming IDs from the list view, we also pass "agree with". If "agree with" will be a machine prediction or human identification depends on how the final determination was derived. Is this inline with how you would like it to be @mihow?