### PR TITLE
Show the status of the collect stage when starting a processing job

### DIFF
--- a/ami/ml/models/pipeline.py
+++ b/ami/ml/models/pipeline.py
@@ -233,10 +233,15 @@ def collect_images(
     """
     task_logger = logger
     if job_id:
-        from ami.jobs.models import Job
+        from ami.jobs.models import Job, JobState
 
         job = Job.objects.get(pk=job_id)
         task_logger = job.logger
+        # Persist the collect stage as STARTED for every path: the filtered branch's throttle
+        # below updates only `progress` (never status), and reprocess-all has no loop at all,
+        # so without this neither path reports STARTED while collection runs.
+        job.progress.update_stage("collect", status=JobState.STARTED, progress=0)
+        job.save(update_fields=["progress", "updated_at"])
     else:
         job = None
 


### PR DESCRIPTION
## Summary

When an ML job starts it transitions to STARTED, but the UI can show no progress with the stages still gray, because the long-running "collect" stage does not report itself as in-progress until collection finishes. On a large collection that call runs for minutes, so the job looks frozen.

This change makes `collect_images()` persist the collect stage as STARTED the moment collection begins, for every path. The job already sets the stage to STARTED in memory, but that value was never written to the database before the multi-minute collection ran: the filtered path's throttled progress emit (added in #1322) only updates the `progress` fraction, never the status, and the reprocess-all path has no per-image loop at all. So the stage stayed at its default status until collection finished and the job flipped it straight to SUCCESS. Now it shows in-progress as soon as collection begins, on both paths.

### List of Changes

| # | Change (user-facing effect) | How |
|---|---|---|
| 1 | The Collect stage shows as in-progress immediately when a job starts, instead of looking frozen until collection finishes — on both the normal (filtered) and reprocess-all paths. | `collect_images()` calls `update_stage("collect", status=STARTED, progress=0)` and a narrow `save(update_fields=["progress", "updated_at"])` right after fetching the Job, before any branch. |
| 2 | (filtered path) The throttled progress fraction from #1322 now also carries the STARTED status. | No change to the throttle itself: it operates on the same in-memory Job object that change 1 marked STARTED, so its whole-`progress` save persists the status as a side effect. |

**Scope note:** the throttled scan-progress fraction and its constants are unchanged from #1322. This PR adds only the missing STARTED status persist; it does not touch the throttle behavior. The `progress` JSONB is written whole (all stages) on each save, which is safe here because collect is stage 1 on a freshly-fetched row; the atomic per-stage write is tracked in #1337.

Before:
<img width="714" height="591" alt="image" src="https://github.com/user-attachments/assets/5a92610e-3e43-43f4-a6da-b01297e2bbb2" />

After:
<img width="714" height="591" alt="image" src="https://github.com/user-attachments/assets/7b08b39c-83c3-4ac9-9196-37875739f731" />

## Test plan

- [x] Live end-to-end: trigger an ML job and confirm the Job row shows the `collect` stage as in-progress while `collect_images()` runs, on both the filtered and reprocess-all paths (below).
- [x] Existing #1322 filter tests still pass — this PR does not change `filter_processed_images`.

## What has been tested

**Unit** (`ami/ml/tests.py::TestPipeline`): the pre-existing #1322 throttle tests (`test_filter_processed_images_emits_throttled_collect_progress`, `test_filter_processed_images_skips_progress_emission_without_job`) are unchanged and still pass, confirming this PR leaves `filter_processed_images` untouched. The change itself — a one-line status persist in `collect_images()` — is verified by the live end-to-end run below rather than a dedicated unit test, which would be too narrow (asserting one stage's status after one function call) to justify the added CI weight.

**Live end-to-end** (deployed stack, real `run_job` via the Celery worker, external poller reading the Job row every 50ms):

- *Filtered path* (363-image collection, default flags): the collect stage was observed transitioning `CREATED` → **`STARTED` (+53ms)** → `SUCCESS` (+207ms). Before this change it stayed at the default status and jumped straight to SUCCESS, so a poller never saw STARTED.
- *Reprocess-all path* (same collection, `reprocess_all_images=True`): `CREATED` → **`STARTED` (+53ms)** → `SUCCESS` (+105ms).

Both confirm the stage reports in-progress *during* collection, on the real dispatch path, for both branches.

## Follow-up (not in this PR)

Review whether the throttled scan-progress emit introduced in #1322 (the `time.monotonic()` cadence machinery and the `COLLECT_PROGRESS_SAVE_INTERVAL_SECONDS` / `COLLECT_PROGRESS_MAX_FRACTION` constants in `filter_processed_images`) is worth keeping. The emitted fraction is *scan progress* — the share of input images inspected by the filter — not the count of images that need processing (that count is only known after collection and is reported via `total_images`). It animates a progress bar during collect but conveys little the operator acts on, so it may be removable in a follow-up. With this PR, the STARTED status no longer depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
