### PR TITLE
fix(jobs): wrap JobLogHandler insert in savepoint

### DIFF
--- a/ami/jobs/models.py
+++ b/ami/jobs/models.py
@@ -414,12 +414,20 @@ class JobLogHandler(logging.Handler):
         # Append-only insert on the JobLog child table. Unlike the legacy
         # jobs_job.logs JSONB update path, this does not contend with
         # _update_job_progress on the parent row.
+        #
+        # Wrap in a savepoint so a failed INSERT (schema drift, FK violation,
+        # DB hiccup) rolls back only this statement instead of poisoning the
+        # surrounding ATOMIC_REQUESTS transaction. Without the savepoint,
+        # every subsequent query in the same request raises
+        # TransactionManagementError and the view returns 500 — even though
+        # the except below swallows the original error.
         try:
-            JobLog.objects.create(
-                job_id=self.job.pk,
-                level=record.levelname,
-                message=self.format(record),
-            )
+            with transaction.atomic(savepoint=True):
+                JobLog.objects.create(
+                    job_id=self.job.pk,
+                    level=record.levelname,
+                    message=self.format(record),
+                )
         except Exception as e:
             logger.error(f"Failed to save log for job #{self.job.pk}: {e}")
 

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -959,6 +959,45 @@ class TestJobLogPersistence(TestCase):
         self.assertEqual(self.job.logs.stdout, [])
         self.assertEqual(self.job.logs.stderr, [])
 
+    def test_emit_failure_does_not_poison_outer_transaction(self):
+        """A failed JobLog INSERT (e.g. schema drift, FK violation) must not
+        break the surrounding atomic block. Without the savepoint in emit(),
+        the failed INSERT poisons the parent transaction and every subsequent
+        query raises TransactionManagementError, which surfaces as HTTP 500
+        in the cancel/run views (both wrapped in ATOMIC_REQUESTS).
+
+        The failure must occur at the DB layer (not the Python layer) to
+        reproduce the bug — mocking the manager method bypasses the DB and
+        leaves the transaction clean even without the fix."""
+        from unittest.mock import patch
+
+        from django.db import connection, transaction
+
+        def insert_with_null_level(*args, **kwargs):
+            # Real INSERT that violates the NOT NULL constraint on `level`,
+            # triggering an immediate IntegrityError at the DB layer just like
+            # a schema-drift failure would. (FK violations are deferred in
+            # Django's TestCase via ``SET CONSTRAINTS ALL DEFERRED``, so they
+            # don't reproduce the bug — the row is accepted until teardown.)
+            # The except in emit() swallows the error; without the savepoint
+            # the parent transaction is left poisoned.
+            with connection.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO jobs_joblog (job_id, level, message, created_at, updated_at, context) "
+                    "VALUES (%s, NULL, %s, NOW(), NOW(), '{}'::jsonb)",
+                    (self.job.pk, "null-level-violation"),
+                )
+
+        with transaction.atomic():
+            with patch.object(JobLog.objects, "create", side_effect=insert_with_null_level):
+                # emit() catches and logs; must not propagate.
+                self.job.logger.info("trigger failing insert")
+
+            # Outer transaction must still be usable.
+            Project.objects.create(name="post-failure write")
+
+        self.assertTrue(Project.objects.filter(name="post-failure write").exists())
+
     def test_serialize_job_logs_reads_from_joblog_table(self):
         from ami.jobs.serializers import serialize_job_logs
 


### PR DESCRIPTION
## Summary

`JobLogHandler.emit` wraps `JobLog.objects.create` in a try/except, so the Python exception is swallowed — but under PostgreSQL a failed INSERT leaves the surrounding transaction in a broken state regardless. Inside `ATOMIC_REQUESTS`, every subsequent query in the same request then raises `TransactionManagementError`, which surfaces as HTTP 500 from views like `JobViewSet.cancel` and `JobViewSet.run`.

Wrapping the INSERT in `transaction.atomic(savepoint=True)` rolls a failed INSERT back to the savepoint instead of poisoning the outer transaction. The existing `except` still catches and logs the error so the calling code is unaware.

## Repro

Surfaced today on a local stack where `jobs_joblog` was missing the `updated_at` column (an early draft of #1259's `0021_joblog` migration was applied locally before the final form was merged). Every emit raised `UndefinedColumn`; cancel returned 500 instead of `REVOKED`. The same failure mode applies to any DB-layer error on the JobLog INSERT (FK violation, DB hiccup, future schema changes).

## Test plan

- [x] New regression test `test_emit_failure_does_not_poison_outer_transaction` triggers a real NOT NULL violation at the DB layer and asserts the outer transaction is still usable. Without the fix the test fails with `TransactionManagementError` on a post-emit `Project.objects.create`. With the fix it passes.
- [x] Full `TestJobLogPersistence` (9 tests) green.

### Notes for reviewers

- FK violations are deferred under Django's `TestCase` (`SET CONSTRAINTS ALL DEFERRED` at start of each test), so they don't reproduce the bug — the row is accepted until teardown. The test uses a NOT NULL violation, which is non-deferrable and fires immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job logging reliability to prevent database errors from interrupting system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->