### PR TITLE
feat(exports): add taxa_list_csv export format

### DIFF
--- a/ami/exports/base.py
+++ b/ami/exports/base.py
@@ -11,6 +11,7 @@ class BaseExporter(ABC):
     """Base class for all data export handlers."""
 
     file_format = ""  # To be defined in child classes
+    filename_label = ""  # Optional slug token inserted into export filenames (e.g. "taxa_list")
     serializer_class = None
     filter_backends = []
 

--- a/ami/exports/format_types.py
+++ b/ami/exports/format_types.py
@@ -1,6 +1,7 @@
 import csv
 import json
 import logging
+import os
 import tempfile
 
 from django.core.serializers.json import DjangoJSONEncoder
@@ -328,6 +329,16 @@ class TaxaListCSVExporter(BaseExporter):
         """
         return Taxon.objects.none()
 
+    def update_export_stats(self, file_temp_path=None):
+        """Override base behaviour: report the number of CSV rows we actually
+        wrote (one per unique taxon), not the occurrence count from the source
+        queryset.
+        """
+        self.data_export.record_count = self._rows_written
+        if file_temp_path and os.path.exists(file_temp_path):
+            self.data_export.file_size = os.path.getsize(file_temp_path)
+        self.data_export.save()
+
     def export(self):
         """Stream filtered occurrences once, aggregate per-taxon, write CSV."""
         temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".csv", mode="w", newline="", encoding="utf-8")
@@ -379,5 +390,6 @@ class TaxaListCSVExporter(BaseExporter):
                 records_exported += 1
                 self.update_job_progress(records_exported)
 
+        self._rows_written = records_exported
         self.update_export_stats(file_temp_path=temp_file.name)
         return temp_file.name

--- a/ami/exports/format_types.py
+++ b/ami/exports/format_types.py
@@ -285,6 +285,7 @@ class TaxaListCSVExporter(BaseExporter):
 
     def __init__(self, data_export):
         super().__init__(data_export)
+        self._rows_written = 0
         # The base class's `total_records` counts occurrences, but each output
         # row is one taxon. Reset progress denominators so the percentage
         # tracks the file we're actually writing.

--- a/ami/exports/format_types.py
+++ b/ami/exports/format_types.py
@@ -7,8 +7,10 @@ from django.core.serializers.json import DjangoJSONEncoder
 from rest_framework import serializers
 
 from ami.exports.base import BaseExporter
+from ami.exports.taxa_list import COLUMN_ORDER as TAXA_LIST_COLUMNS
+from ami.exports.taxa_list import TaxonAccumulator, empty_row_for_taxon, row_for_taxon
 from ami.exports.utils import get_data_in_batches
-from ami.main.models import Occurrence, SourceImage, get_media_url
+from ami.main.models import Occurrence, SourceImage, Taxon, get_media_url
 from ami.ml.schemas import BoundingBox
 
 logger = logging.getLogger(__name__)
@@ -247,3 +249,135 @@ class CSVExporter(BaseExporter):
                 self.update_job_progress(records_exported)
         self.update_export_stats(file_temp_path=temp_file.name)
         return temp_file.name  # Return the file path
+
+
+class TaxaListCSVExporter(BaseExporter):
+    """Export the unique taxa observed in a SourceImageCollection as a CSV.
+
+    One row per `Taxon` that appears as the `determination` of at least one
+    valid occurrence (after applying the project's default filters) within the
+    selected collection. Aggregations cover occurrence count, classification
+    score, occurrence date, and time-of-night.
+
+    Future hooks (intentionally stubbed; see project design doc):
+
+    1. **Absence rows.** When a project declares an explicit "taxonomic scope"
+       (today: `Project.default_filters_include_taxa` recursively expanded;
+       eventually a per-Project default `TaxaList`, and per-Site `TaxaList`
+       for the deployment-level case), this exporter will emit a row per
+       scope-taxon that was not observed, with `direct_occurrences_count = 0`.
+       That turns the file into a presence/absence checklist. Wired via
+       `_get_expected_taxa()`; v1 returns nothing so the column shape is
+       stable when absence rows turn on.
+
+    2. **Darwin Core Taxon-Core archive variant.** A sibling `taxa_list_dwca`
+       format can ship later by reusing this aggregator + Taxon fetch and
+       emitting a DwC `taxon.txt` (plus `meta.xml` / `eml.xml`) zip instead of
+       a flat CSV. The columns this format produces are intentionally a
+       superset of DwC Taxon-Core fields. See PR #1131 for the surrounding
+       DwC-A export and `targetscope.derive_target_taxonomic_scope` for the
+       expected-taxa derivation.
+    """
+
+    file_format = "csv"
+    filename_label = "taxa_list"
+
+    def __init__(self, data_export):
+        super().__init__(data_export)
+        # The base class's `total_records` counts occurrences, but each output
+        # row is one taxon. Reset progress denominators so the percentage
+        # tracks the file we're actually writing.
+        unique_taxa_count = (
+            self.queryset.filter(determination__isnull=False).values("determination_id").distinct().count()
+        )
+        self.total_records = unique_taxa_count
+        if self.job:
+            self.job.progress.add_or_update_stage_param(
+                self.job.job_type_key, "Total records to export", self.total_records
+            )
+            self.job.save()
+
+    def get_queryset(self):
+        """Filtered occurrence queryset.
+
+        We start from the Occurrence model (not Taxon) so the existing
+        `OccurrenceCollectionFilter` filter backend can scope to the user's
+        selected collection. The taxa set is derived from this queryset's
+        `determination_id` column during `export()`.
+        """
+        return (
+            Occurrence.objects.valid()  # type: ignore[union-attr]  Custom queryset method
+            .filter(project=self.project, determination__isnull=False)
+            .apply_default_filters(self.project)  # type: ignore[union-attr]  Custom queryset method
+            .with_timestamps()  # type: ignore[union-attr]  Custom queryset method
+        )
+
+    def _get_expected_taxa(self):
+        """Return the taxa expected to be observable in this project.
+
+        Stub for the future "absence rows" feature. Currently returns an empty
+        queryset, so v1 only emits rows for taxa actually observed. When a
+        project gets a populated taxonomic scope (any of:
+          - `Project.default_filters_include_taxa`, recursively expanded via
+            `parents_json__contains`,
+          - a per-project default TaxaList,
+          - a per-Site TaxaList),
+        this method will be updated to return that set, and the writer below
+        will emit zero-count rows for any expected taxon not in the observed
+        accumulator.
+        """
+        return Taxon.objects.none()
+
+    def export(self):
+        """Stream filtered occurrences once, aggregate per-taxon, write CSV."""
+        temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".csv", mode="w", newline="", encoding="utf-8")
+
+        # Streaming pass: build per-taxon accumulators.
+        accumulators: dict[int, TaxonAccumulator] = {}
+        occurrence_values = self.queryset.values(
+            "determination_id",
+            "determination_score",
+            "first_appearance_timestamp",
+            "last_appearance_timestamp",
+        )
+        for occ in occurrence_values.iterator(chunk_size=500):
+            det_id = occ["determination_id"]
+            if det_id is None:
+                continue
+            accum = accumulators.get(det_id)
+            if accum is None:
+                accum = TaxonAccumulator()
+                accumulators[det_id] = accum
+            accum.add(
+                score=occ.get("determination_score"),
+                first_dt=occ.get("first_appearance_timestamp"),
+                last_dt=occ.get("last_appearance_timestamp"),
+            )
+
+        # Fetch taxon rows in a single query, ordered by name for stable output.
+        observed_taxa = list(Taxon.objects.filter(id__in=accumulators.keys()).order_by("name"))
+
+        # Future absence rows: any expected taxon not in `accumulators` would
+        # be emitted with a zero-count placeholder row. v1 returns an empty
+        # queryset so this loop is a no-op.
+        observed_ids = set(accumulators.keys())
+        absent_taxa = list(self._get_expected_taxa().exclude(id__in=observed_ids).order_by("name"))
+
+        records_exported = 0
+        with open(temp_file.name, "w", newline="", encoding="utf-8") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=TAXA_LIST_COLUMNS)
+            writer.writeheader()
+
+            for taxon in observed_taxa:
+                row = row_for_taxon(taxon, accumulators[taxon.pk])
+                writer.writerow(row)
+                records_exported += 1
+                self.update_job_progress(records_exported)
+
+            for taxon in absent_taxa:
+                writer.writerow(empty_row_for_taxon(taxon))
+                records_exported += 1
+                self.update_job_progress(records_exported)
+
+        self.update_export_stats(file_temp_path=temp_file.name)
+        return temp_file.name

--- a/ami/exports/models.py
+++ b/ami/exports/models.py
@@ -66,14 +66,21 @@ class DataExport(BaseModel):
         return filters_display
 
     def generate_filename(self):
-        """Generates a slugified filename using project name and export ID."""
+        """Generates a slugified filename using project name and export ID.
+
+        When the exporter sets a non-empty `filename_label` (e.g. "taxa_list"),
+        the label is inserted between the project slug and the export id so
+        users can tell formats apart in their downloads folder.
+        """
         from ami.exports.registry import ExportRegistry
 
         registry = ExportRegistry.get_exporter(self.format)
         assert registry, f"Export format '{self.format}' not found in registry"
         extension = registry.file_format
+        label = getattr(registry, "filename_label", "") or ""
         project_slug = slugify(self.project.name)  # Convert project name to a slug
-        return f"{project_slug}_export-{self.pk}.{extension}"
+        label_token = f"{label}_" if label else ""
+        return f"{project_slug}_{label_token}export-{self.pk}.{extension}"
 
     def save_export_file(self, file_temp_path):
         """

--- a/ami/exports/registry.py
+++ b/ami/exports/registry.py
@@ -27,3 +27,4 @@ class ExportRegistry:
 
 ExportRegistry.register("occurrences_api_json")(format_types.JSONExporter)
 ExportRegistry.register("occurrences_simple_csv")(format_types.CSVExporter)
+ExportRegistry.register("taxa_list_csv")(format_types.TaxaListCSVExporter)

--- a/ami/exports/taxa_list.py
+++ b/ami/exports/taxa_list.py
@@ -81,6 +81,14 @@ class TaxonAccumulator:
     time_sum_shifted: int = 0
     time_count: int = 0
 
+    # Per-occurrence duration in seconds (last_appearance - first_appearance).
+    # Will be more meaningful once detection tracking is wired up; today many
+    # occurrences are single-detection and end up with duration 0 / blank.
+    duration_min_seconds: float | None = None
+    duration_max_seconds: float | None = None
+    duration_sum_seconds: float = 0.0
+    duration_count: int = 0
+
     def add(
         self,
         score: float | None,
@@ -117,6 +125,20 @@ class TaxonAccumulator:
         if widening is not None:
             self.first_dt_max = widening if self.first_dt_max is None else max(self.first_dt_max, widening)
 
+        # Per-occurrence duration. Skipped when either bound is missing OR
+        # when there's only one detection (first == last), which would always
+        # be 0 and clutter the aggregations.
+        if first_dt is not None and last_dt is not None and last_dt > first_dt:
+            seconds = (last_dt - first_dt).total_seconds()
+            self.duration_min_seconds = (
+                seconds if self.duration_min_seconds is None else min(self.duration_min_seconds, seconds)
+            )
+            self.duration_max_seconds = (
+                seconds if self.duration_max_seconds is None else max(self.duration_max_seconds, seconds)
+            )
+            self.duration_sum_seconds += seconds
+            self.duration_count += 1
+
     @property
     def avg_score(self) -> float | None:
         if self.score_count == 0:
@@ -142,6 +164,12 @@ class TaxonAccumulator:
         if self.time_count == 0:
             return None
         return noon_unshift(self.time_sum_shifted / self.time_count)
+
+    @property
+    def duration_avg_seconds(self) -> float | None:
+        if self.duration_count == 0:
+            return None
+        return self.duration_sum_seconds / self.duration_count
 
 
 def hierarchy_columns_from_parents_json(taxon: Taxon) -> dict[str, str]:
@@ -209,6 +237,9 @@ COLUMN_ORDER: list[str] = [
     "min_time_of_night",
     "max_time_of_night",
     "avg_time_of_night",
+    "min_duration_seconds",
+    "max_duration_seconds",
+    "avg_duration_seconds",
     "gbif_taxon_key",
     "gbif_url",
     "inat_taxon_id",
@@ -233,6 +264,13 @@ def _format_date(value: datetime.datetime | datetime.date | None) -> str:
     return value.isoformat()
 
 
+def _format_seconds(value: float | None) -> str:
+    """Render duration seconds. Empty for None; otherwise rounded to int."""
+    if value is None:
+        return ""
+    return str(int(round(value)))
+
+
 def row_for_taxon(taxon: Taxon, accum: TaxonAccumulator) -> dict[str, str]:
     """Build a single CSV row dict for a taxon + its accumulator."""
     hierarchy = hierarchy_columns_from_parents_json(taxon)
@@ -253,6 +291,9 @@ def row_for_taxon(taxon: Taxon, accum: TaxonAccumulator) -> dict[str, str]:
         "min_time_of_night": seconds_to_clock_str(accum.time_min_clock),
         "max_time_of_night": seconds_to_clock_str(accum.time_max_clock),
         "avg_time_of_night": seconds_to_clock_str(accum.time_avg_clock),
+        "min_duration_seconds": _format_seconds(accum.duration_min_seconds),
+        "max_duration_seconds": _format_seconds(accum.duration_max_seconds),
+        "avg_duration_seconds": _format_seconds(accum.duration_avg_seconds),
         "gbif_taxon_key": str(taxon.gbif_taxon_key) if taxon.gbif_taxon_key else "",
         "gbif_url": gbif_url(taxon.gbif_taxon_key),
         "inat_taxon_id": str(taxon.inat_taxon_id) if taxon.inat_taxon_id else "",

--- a/ami/exports/taxa_list.py
+++ b/ami/exports/taxa_list.py
@@ -58,9 +58,30 @@ def seconds_to_clock_str(seconds: int | float | None) -> str:
     return f"{h:02d}:{m:02d}:{sec:02d}"
 
 
+def _median_int(values: list[int]) -> int | None:
+    """Median of an integer list, rounded toward 0 for even-length lists.
+    Returns None for empty input.
+    """
+    if not values:
+        return None
+    s = sorted(values)
+    n = len(s)
+    mid = n // 2
+    if n % 2 == 1:
+        return s[mid]
+    return (s[mid - 1] + s[mid]) // 2
+
+
 @dataclasses.dataclass
 class TaxonAccumulator:
-    """Streaming per-taxon aggregator. Memory: O(1) per taxon."""
+    """Per-taxon aggregator. Stores one entry per occurrence for the
+    `first_appearance_timestamp`-derived "session" stats so we can compute
+    medians; running stats elsewhere stay O(1).
+
+    "Session" here means the monitoring session (typically one night) the
+    occurrence was observed in. We use `first_appearance_timestamp` as the
+    canonical anchor for that session's day-of-year, time-of-night, and month.
+    """
 
     direct_occurrences_count: int = 0
 
@@ -69,17 +90,14 @@ class TaxonAccumulator:
     score_sum: float = 0.0
     score_count: int = 0  # occurrences with a non-null score
 
-    first_dt_min: datetime.datetime | None = None
-    first_dt_max: datetime.datetime | None = None
-    first_dt_epoch_sum: float = 0.0
-    first_dt_count: int = 0  # occurrences with a non-null first_appearance_timestamp
-
-    # Time-of-night aggregations are stored in noon-anchored seconds (see
-    # noon_shift) so they survive midnight wraparound.
-    time_min_shifted: int | None = None
-    time_max_shifted: int | None = None
-    time_sum_shifted: int = 0
-    time_count: int = 0
+    # Per-occurrence session anchors derived from first_appearance_timestamp.
+    # We keep all values to compute medians; min/max/mean are derived from the
+    # same lists rather than maintaining parallel running stats.
+    session_doys: list[int] = dataclasses.field(default_factory=list)  # 1..366
+    session_months: list[int] = dataclasses.field(default_factory=list)  # 1..12
+    # Times of night are stored noon-anchored so midnight-spanning windows
+    # work for min/max/median.
+    session_times_shifted: list[int] = dataclasses.field(default_factory=list)
 
     # Per-occurrence duration in seconds (last_appearance - first_appearance).
     # Will be more meaningful once detection tracking is wired up; today many
@@ -103,27 +121,10 @@ class TaxonAccumulator:
             self.score_sum += score
             self.score_count += 1
 
-        # We use the OCCURRENCE's first_appearance_timestamp as the canonical
-        # "when this taxon was seen on this occasion" anchor for date and
-        # time-of-night stats. The last_dt is used only to widen the date
-        # range so the displayed [first_date, last_date] window covers all
-        # appearances.
         if first_dt is not None:
-            self.first_dt_min = first_dt if self.first_dt_min is None else min(self.first_dt_min, first_dt)
-            epoch = first_dt.timestamp()
-            self.first_dt_epoch_sum += epoch
-            self.first_dt_count += 1
-
-            shifted = noon_shift(time_to_seconds(first_dt.time()))
-            self.time_min_shifted = shifted if self.time_min_shifted is None else min(self.time_min_shifted, shifted)
-            self.time_max_shifted = shifted if self.time_max_shifted is None else max(self.time_max_shifted, shifted)
-            self.time_sum_shifted += shifted
-            self.time_count += 1
-
-        # Widen the [min, max] datetime window with last_dt as well.
-        widening = last_dt or first_dt
-        if widening is not None:
-            self.first_dt_max = widening if self.first_dt_max is None else max(self.first_dt_max, widening)
+            self.session_doys.append(first_dt.timetuple().tm_yday)
+            self.session_months.append(first_dt.month)
+            self.session_times_shifted.append(noon_shift(time_to_seconds(first_dt.time())))
 
         # Per-occurrence duration. Skipped when either bound is missing OR
         # when there's only one detection (first == last), which would always
@@ -145,25 +146,49 @@ class TaxonAccumulator:
             return None
         return self.score_sum / self.score_count
 
+    # Session-day stats — day of year, 1..366. Min/max are calendar bounds;
+    # median is the day-of-year of the typical observation.
     @property
-    def avg_first_dt(self) -> datetime.datetime | None:
-        if self.first_dt_count == 0:
+    def session_day_min(self) -> int | None:
+        return min(self.session_doys) if self.session_doys else None
+
+    @property
+    def session_day_max(self) -> int | None:
+        return max(self.session_doys) if self.session_doys else None
+
+    @property
+    def session_day_median(self) -> int | None:
+        return _median_int(self.session_doys)
+
+    # Session-time stats — clock seconds-since-midnight, midnight-spanning.
+    @property
+    def session_time_min(self) -> int | None:
+        return None if not self.session_times_shifted else noon_unshift(min(self.session_times_shifted))
+
+    @property
+    def session_time_max(self) -> int | None:
+        return None if not self.session_times_shifted else noon_unshift(max(self.session_times_shifted))
+
+    @property
+    def session_time_median(self) -> int | None:
+        med = _median_int(self.session_times_shifted)
+        return None if med is None else noon_unshift(med)
+
+    # Session-month stats — calendar month, 1..12. Mean is informative for
+    # phenology bucketing (e.g. "mostly mid-July").
+    @property
+    def session_month_min(self) -> int | None:
+        return min(self.session_months) if self.session_months else None
+
+    @property
+    def session_month_max(self) -> int | None:
+        return max(self.session_months) if self.session_months else None
+
+    @property
+    def session_month_mean(self) -> float | None:
+        if not self.session_months:
             return None
-        return datetime.datetime.fromtimestamp(self.first_dt_epoch_sum / self.first_dt_count)
-
-    @property
-    def time_min_clock(self) -> int | None:
-        return None if self.time_min_shifted is None else noon_unshift(self.time_min_shifted)
-
-    @property
-    def time_max_clock(self) -> int | None:
-        return None if self.time_max_shifted is None else noon_unshift(self.time_max_shifted)
-
-    @property
-    def time_avg_clock(self) -> int | None:
-        if self.time_count == 0:
-            return None
-        return noon_unshift(self.time_sum_shifted / self.time_count)
+        return sum(self.session_months) / len(self.session_months)
 
     @property
     def duration_avg_seconds(self) -> float | None:
@@ -231,12 +256,15 @@ COLUMN_ORDER: list[str] = [
     "min_score",
     "max_score",
     "avg_score",
-    "first_occurrence_date",
-    "last_occurrence_date",
-    "avg_occurrence_date",
-    "min_time_of_night",
-    "max_time_of_night",
-    "avg_time_of_night",
+    "session_day_min",
+    "session_day_max",
+    "session_day_median",
+    "session_time_min",
+    "session_time_max",
+    "session_time_median",
+    "session_month_min",
+    "session_month_max",
+    "session_month_mean",
     "min_duration_seconds",
     "max_duration_seconds",
     "avg_duration_seconds",
@@ -256,19 +284,19 @@ def _format_score(value: float | None) -> str:
     return "" if value is None else f"{value:.4f}"
 
 
-def _format_date(value: datetime.datetime | datetime.date | None) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, datetime.datetime):
-        value = value.date()
-    return value.isoformat()
-
-
 def _format_seconds(value: float | None) -> str:
     """Render duration seconds. Empty for None; otherwise rounded to int."""
     if value is None:
         return ""
     return str(int(round(value)))
+
+
+def _format_int(value: int | None) -> str:
+    return "" if value is None else str(value)
+
+
+def _format_float_1dp(value: float | None) -> str:
+    return "" if value is None else f"{value:.1f}"
 
 
 def row_for_taxon(taxon: Taxon, accum: TaxonAccumulator) -> dict[str, str]:
@@ -285,12 +313,15 @@ def row_for_taxon(taxon: Taxon, accum: TaxonAccumulator) -> dict[str, str]:
         "min_score": _format_score(accum.score_min),
         "max_score": _format_score(accum.score_max),
         "avg_score": _format_score(accum.avg_score),
-        "first_occurrence_date": _format_date(accum.first_dt_min),
-        "last_occurrence_date": _format_date(accum.first_dt_max),
-        "avg_occurrence_date": _format_date(accum.avg_first_dt),
-        "min_time_of_night": seconds_to_clock_str(accum.time_min_clock),
-        "max_time_of_night": seconds_to_clock_str(accum.time_max_clock),
-        "avg_time_of_night": seconds_to_clock_str(accum.time_avg_clock),
+        "session_day_min": _format_int(accum.session_day_min),
+        "session_day_max": _format_int(accum.session_day_max),
+        "session_day_median": _format_int(accum.session_day_median),
+        "session_time_min": seconds_to_clock_str(accum.session_time_min),
+        "session_time_max": seconds_to_clock_str(accum.session_time_max),
+        "session_time_median": seconds_to_clock_str(accum.session_time_median),
+        "session_month_min": _format_int(accum.session_month_min),
+        "session_month_max": _format_int(accum.session_month_max),
+        "session_month_mean": _format_float_1dp(accum.session_month_mean),
         "min_duration_seconds": _format_seconds(accum.duration_min_seconds),
         "max_duration_seconds": _format_seconds(accum.duration_max_seconds),
         "avg_duration_seconds": _format_seconds(accum.duration_avg_seconds),

--- a/ami/exports/taxa_list.py
+++ b/ami/exports/taxa_list.py
@@ -1,0 +1,286 @@
+"""Helpers for the `taxa_list_csv` export.
+
+One row per unique taxon that appears as the `determination` of at least one
+valid occurrence (after project default filters) in the user-selected
+`SourceImageCollection`. The aggregations and column shape are also intended to
+cover the data needed for a future Darwin Core Taxon-Core archive variant
+(`taxa_list_dwca`) — see the project design doc at
+`docs/claude/planning/2026-05-05-taxa-list-export-design.md`.
+
+Time-of-night handling: the typical AMI monitoring window straddles midnight,
+so naive midnight-anchored aggregation of clock times misbehaves (the average
+of 22:00 and 02:00 is 12:00 noon, not 00:00 midnight). We aggregate in
+"seconds since noon" space and convert back. See `noon_shift` /
+`noon_unshift` below.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import math
+from collections.abc import Iterable
+
+from ami.main.models import DEFAULT_RANKS, Taxon, TaxonRank
+
+# Linnaean rank columns emitted in the CSV, in this order. Lower-cased so the
+# column headers read naturally in a spreadsheet.
+HIERARCHY_RANKS: list[TaxonRank] = list(DEFAULT_RANKS)
+HIERARCHY_COLUMN_NAMES: list[str] = [r.value.lower() for r in HIERARCHY_RANKS]
+
+SECONDS_PER_DAY = 24 * 60 * 60
+NOON_SECONDS = 12 * 60 * 60
+
+
+def noon_shift(seconds_since_midnight: int) -> int:
+    """Map clock seconds-since-midnight into a "noon-anchored" axis where 12:00
+    is 0 and the typical nocturnal AMI window (e.g. 18:00 → 06:00) is contiguous.
+    """
+    return (seconds_since_midnight - NOON_SECONDS + SECONDS_PER_DAY) % SECONDS_PER_DAY
+
+
+def noon_unshift(noon_anchored_seconds: float) -> int:
+    """Inverse of `noon_shift`. Returns clock seconds-since-midnight (0 - 86399)."""
+    return int((noon_anchored_seconds + NOON_SECONDS) % SECONDS_PER_DAY)
+
+
+def time_to_seconds(t: datetime.time) -> int:
+    return t.hour * 3600 + t.minute * 60 + t.second
+
+
+def seconds_to_clock_str(seconds: int | float | None) -> str:
+    """Render `HH:MM:SS` from seconds-since-midnight, or empty string for None."""
+    if seconds is None:
+        return ""
+    s = int(round(seconds)) % SECONDS_PER_DAY
+    h, rem = divmod(s, 3600)
+    m, sec = divmod(rem, 60)
+    return f"{h:02d}:{m:02d}:{sec:02d}"
+
+
+@dataclasses.dataclass
+class TaxonAccumulator:
+    """Streaming per-taxon aggregator. Memory: O(1) per taxon."""
+
+    direct_occurrences_count: int = 0
+
+    score_min: float | None = None
+    score_max: float | None = None
+    score_sum: float = 0.0
+    score_count: int = 0  # occurrences with a non-null score
+
+    first_dt_min: datetime.datetime | None = None
+    first_dt_max: datetime.datetime | None = None
+    first_dt_epoch_sum: float = 0.0
+    first_dt_count: int = 0  # occurrences with a non-null first_appearance_timestamp
+
+    # Time-of-night aggregations are stored in noon-anchored seconds (see
+    # noon_shift) so they survive midnight wraparound.
+    time_min_shifted: int | None = None
+    time_max_shifted: int | None = None
+    time_sum_shifted: int = 0
+    time_count: int = 0
+
+    def add(
+        self,
+        score: float | None,
+        first_dt: datetime.datetime | None,
+        last_dt: datetime.datetime | None,
+    ) -> None:
+        self.direct_occurrences_count += 1
+
+        if score is not None and not math.isnan(score):
+            self.score_min = score if self.score_min is None else min(self.score_min, score)
+            self.score_max = score if self.score_max is None else max(self.score_max, score)
+            self.score_sum += score
+            self.score_count += 1
+
+        # We use the OCCURRENCE's first_appearance_timestamp as the canonical
+        # "when this taxon was seen on this occasion" anchor for date and
+        # time-of-night stats. The last_dt is used only to widen the date
+        # range so the displayed [first_date, last_date] window covers all
+        # appearances.
+        if first_dt is not None:
+            self.first_dt_min = first_dt if self.first_dt_min is None else min(self.first_dt_min, first_dt)
+            epoch = first_dt.timestamp()
+            self.first_dt_epoch_sum += epoch
+            self.first_dt_count += 1
+
+            shifted = noon_shift(time_to_seconds(first_dt.time()))
+            self.time_min_shifted = shifted if self.time_min_shifted is None else min(self.time_min_shifted, shifted)
+            self.time_max_shifted = shifted if self.time_max_shifted is None else max(self.time_max_shifted, shifted)
+            self.time_sum_shifted += shifted
+            self.time_count += 1
+
+        # Widen the [min, max] datetime window with last_dt as well.
+        widening = last_dt or first_dt
+        if widening is not None:
+            self.first_dt_max = widening if self.first_dt_max is None else max(self.first_dt_max, widening)
+
+    @property
+    def avg_score(self) -> float | None:
+        if self.score_count == 0:
+            return None
+        return self.score_sum / self.score_count
+
+    @property
+    def avg_first_dt(self) -> datetime.datetime | None:
+        if self.first_dt_count == 0:
+            return None
+        return datetime.datetime.fromtimestamp(self.first_dt_epoch_sum / self.first_dt_count)
+
+    @property
+    def time_min_clock(self) -> int | None:
+        return None if self.time_min_shifted is None else noon_unshift(self.time_min_shifted)
+
+    @property
+    def time_max_clock(self) -> int | None:
+        return None if self.time_max_shifted is None else noon_unshift(self.time_max_shifted)
+
+    @property
+    def time_avg_clock(self) -> int | None:
+        if self.time_count == 0:
+            return None
+        return noon_unshift(self.time_sum_shifted / self.time_count)
+
+
+def hierarchy_columns_from_parents_json(taxon: Taxon) -> dict[str, str]:
+    """Extract one column per Linnaean rank from `parents_json`, plus the
+    taxon's own name on its own rank. Returns lowercase rank → name string;
+    missing ranks map to empty strings.
+    """
+    out: dict[str, str] = {col: "" for col in HIERARCHY_COLUMN_NAMES}
+    parents = list(getattr(taxon, "parents_json", None) or [])
+    for parent in parents:
+        # parent is a TaxonParent pydantic model with .rank (TaxonRank enum)
+        rank = getattr(parent, "rank", None)
+        if rank is None:
+            continue
+        rank_value = rank.value if hasattr(rank, "value") else str(rank)
+        col = rank_value.lower()
+        if col in out:
+            out[col] = parent.name
+    own_rank = getattr(taxon, "rank", None)
+    if own_rank:
+        col = str(own_rank).lower()
+        if col in out:
+            out[col] = taxon.name
+    return out
+
+
+# External link templates. Empty string when the underlying ID is missing.
+def gbif_url(key: int | None) -> str:
+    return f"https://www.gbif.org/species/{key}" if key else ""
+
+
+def inat_url(taxon_id: int | None) -> str:
+    return f"https://www.inaturalist.org/taxa/{taxon_id}" if taxon_id else ""
+
+
+def bold_url(bin_id: str | None) -> str:
+    if not bin_id:
+        return ""
+    # BOLD's BIN viewer URL pattern.
+    return (
+        "https://www.boldsystems.org/index.php/Public_BarcodeIndexNumber_RecordView"
+        f"?searchtype=records&recordID={bin_id}"
+    )
+
+
+def fieldguide_url(fg_id: str | None) -> str:
+    return f"https://fieldguide.app/taxa/{fg_id}" if fg_id else ""
+
+
+# Column order. Keep this in sync with `row_for_taxon` below.
+COLUMN_ORDER: list[str] = [
+    "id",
+    "name",
+    "display_name",
+    "rank",
+    "common_name_en",
+    *HIERARCHY_COLUMN_NAMES,
+    "direct_occurrences_count",
+    "min_score",
+    "max_score",
+    "avg_score",
+    "first_occurrence_date",
+    "last_occurrence_date",
+    "avg_occurrence_date",
+    "min_time_of_night",
+    "max_time_of_night",
+    "avg_time_of_night",
+    "gbif_taxon_key",
+    "gbif_url",
+    "inat_taxon_id",
+    "inat_url",
+    "bold_taxon_bin",
+    "bold_url",
+    "fieldguide_id",
+    "fieldguide_url",
+    "cover_image_url",
+]
+
+
+def _format_score(value: float | None) -> str:
+    return "" if value is None else f"{value:.4f}"
+
+
+def _format_date(value: datetime.datetime | datetime.date | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, datetime.datetime):
+        value = value.date()
+    return value.isoformat()
+
+
+def row_for_taxon(taxon: Taxon, accum: TaxonAccumulator) -> dict[str, str]:
+    """Build a single CSV row dict for a taxon + its accumulator."""
+    hierarchy = hierarchy_columns_from_parents_json(taxon)
+    row: dict[str, str] = {
+        "id": str(taxon.pk),
+        "name": taxon.name or "",
+        "display_name": taxon.display_name or "",
+        "rank": str(taxon.rank or ""),
+        "common_name_en": taxon.common_name_en or "",
+        **hierarchy,
+        "direct_occurrences_count": str(accum.direct_occurrences_count),
+        "min_score": _format_score(accum.score_min),
+        "max_score": _format_score(accum.score_max),
+        "avg_score": _format_score(accum.avg_score),
+        "first_occurrence_date": _format_date(accum.first_dt_min),
+        "last_occurrence_date": _format_date(accum.first_dt_max),
+        "avg_occurrence_date": _format_date(accum.avg_first_dt),
+        "min_time_of_night": seconds_to_clock_str(accum.time_min_clock),
+        "max_time_of_night": seconds_to_clock_str(accum.time_max_clock),
+        "avg_time_of_night": seconds_to_clock_str(accum.time_avg_clock),
+        "gbif_taxon_key": str(taxon.gbif_taxon_key) if taxon.gbif_taxon_key else "",
+        "gbif_url": gbif_url(taxon.gbif_taxon_key),
+        "inat_taxon_id": str(taxon.inat_taxon_id) if taxon.inat_taxon_id else "",
+        "inat_url": inat_url(taxon.inat_taxon_id),
+        "bold_taxon_bin": taxon.bold_taxon_bin or "",
+        "bold_url": bold_url(taxon.bold_taxon_bin),
+        "fieldguide_id": taxon.fieldguide_id or "",
+        "fieldguide_url": fieldguide_url(taxon.fieldguide_id),
+        "cover_image_url": taxon.cover_image_url or "",
+    }
+    return row
+
+
+def empty_row_for_taxon(taxon: Taxon) -> dict[str, str]:
+    """Row for a taxon expected to be in the project's taxonomic scope but not
+    observed in the selected collection. All aggregation columns blank;
+    `direct_occurrences_count = 0`. Currently unused — see
+    `TaxaListCSVExporter._get_expected_taxa`.
+    """
+    return row_for_taxon(taxon, TaxonAccumulator())
+
+
+def iter_observed_taxa(taxa: Iterable[Taxon], accumulators: dict[int, TaxonAccumulator]):
+    """Yield (taxon, accumulator) pairs for taxa that appear in the
+    accumulator dict. Caller controls ordering via the `taxa` iterable.
+    """
+    for taxon in taxa:
+        accum = accumulators.get(taxon.pk)
+        if accum is None:
+            continue
+        yield taxon, accum

--- a/ami/exports/tests.py
+++ b/ami/exports/tests.py
@@ -408,14 +408,14 @@ class TaxaListExportTest(TestCase):
         row = next(r for r in rows if r["name"] == self.taxon_with_ids.name)
         # In noon-anchored space, 22:00 is the start of the night (10h after
         # noon) and 02:00 is the end (14h after noon).
-        self.assertEqual(row["min_time_of_night"], "22:00:00")
-        self.assertEqual(row["max_time_of_night"], "02:00:00")
-        h, m, s = row["avg_time_of_night"].split(":")
-        avg_seconds = int(h) * 3600 + int(m) * 60 + int(s)
-        # Avg should land at the midnight midpoint; accept ±60s for rounding.
+        self.assertEqual(row["session_time_min"], "22:00:00")
+        self.assertEqual(row["session_time_max"], "02:00:00")
+        h, m, s = row["session_time_median"].split(":")
+        median_seconds = int(h) * 3600 + int(m) * 60 + int(s)
+        # Median of two values lands at the midnight midpoint; accept ±60s.
         self.assertTrue(
-            avg_seconds <= 60 or avg_seconds >= 86340,
-            f"avg_time_of_night {row['avg_time_of_night']} should be near 00:00",
+            median_seconds <= 60 or median_seconds >= 86340,
+            f"session_time_median {row['session_time_median']} should be near 00:00",
         )
 
 

--- a/ami/exports/tests.py
+++ b/ami/exports/tests.py
@@ -1,4 +1,5 @@
 import csv
+import datetime
 import json
 import logging
 
@@ -8,6 +9,7 @@ from django.test import TestCase
 from rest_framework.test import APIClient
 
 from ami.exports.models import DataExport
+from ami.exports.registry import ExportRegistry
 from ami.main.models import Detection, Identification, Occurrence, SourceImageCollection, Taxon
 from ami.ml.models import Algorithm
 from ami.tests.fixtures.main import (
@@ -209,6 +211,212 @@ class DataExportTest(TestCase):
 
         # Clean up the exported file after the test
         default_storage.delete(file_path)
+
+
+class TaxaListExportTest(TestCase):
+    """Tests for the `taxa_list_csv` export format."""
+
+    def setUp(self):
+        self.project, self.deployment = setup_test_project(reuse=False)
+        self.user = self.project.owner
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        # Two nights so we can test cross-midnight time-of-night aggregations.
+        create_captures(deployment=self.deployment, num_nights=2, images_per_night=4, interval_minutes=30)
+        group_images_into_events(self.deployment)
+        create_taxa(self.project)
+        # Ensure the project does not score-filter our test occurrences.
+        self.project.default_filters_score_threshold = 0.0
+        self.project.save()
+        # All other tests in this suite share these defaults; reset M2M filters.
+        self.project.default_filters_include_taxa.clear()
+        self.project.default_filters_exclude_taxa.clear()
+
+        # Build hierarchy ancestors first; reuse if create_taxa already made them.
+        kingdom, _ = Taxon.objects.get_or_create(name="Animalia", defaults={"rank": "KINGDOM"})
+        family, _ = Taxon.objects.get_or_create(
+            name="Nymphalidae",
+            defaults={"rank": "FAMILY", "parent": kingdom},
+        )
+        if family.parent_id != kingdom.pk:
+            family.parent = kingdom
+            family.save()
+
+        # Three distinct taxa with different external-ID populations. Names
+        # chosen to not collide with the create_taxa() fixture set.
+        self.taxon_with_ids = Taxon.objects.create(
+            name="Aglais io",
+            rank="SPECIES",
+            parent=family,
+            gbif_taxon_key=1898286,
+            inat_taxon_id=48662,
+            bold_taxon_bin="BOLD:AAA0001",
+            fieldguide_id="vanessa-cardui",
+            cover_image_url="https://example.com/vc.jpg",
+        )
+        self.taxon_with_ids.projects.add(self.project)
+
+        self.taxon_no_ids = Taxon.objects.create(name="Polygonia c-album", rank="SPECIES")
+        self.taxon_no_ids.projects.add(self.project)
+
+        self.taxon_genus_only = Taxon.objects.create(name="Aglais", rank="GENUS")
+        self.taxon_genus_only.projects.add(self.project)
+
+        # parents_json is populated via the manager helper.
+        Taxon.objects.update_all_parents()
+        self.taxon_with_ids.refresh_from_db()
+
+        self.collection = self._create_collection()
+
+    def _create_collection(self):
+        images = list(self.project.captures.all())
+        # Half the images go in the collection.
+        half = len(images) // 2
+        collection_images = images[:half]
+        collection = SourceImageCollection.objects.create(
+            name="taxa-list-test-collection",
+            project=self.project,
+            method="manual",
+            kwargs={"image_ids": [img.pk for img in collection_images]},
+        )
+        collection.save()
+        collection.populate_sample()
+        return collection
+
+    def _make_occurrence(self, taxon, source_image, score, timestamp=None):
+        """Create one Occurrence with one Detection at a known timestamp+score."""
+        ts = timestamp or source_image.timestamp
+        detection = Detection.objects.create(
+            source_image=source_image,
+            timestamp=ts,
+            bbox=[0.1, 0.1, 0.2, 0.2],
+            path=f"detections/test_{taxon.pk}_{source_image.pk}.jpg",
+        )
+        detection.classifications.create(taxon=taxon, score=score, timestamp=ts)
+        occurrence = detection.associate_new_occurrence()
+        return occurrence, detection
+
+    def _run_export(self, extra_filters=None):
+        filters = {"collection_id": self.collection.pk}
+        if extra_filters:
+            filters.update(extra_filters)
+        data_export = DataExport.objects.create(
+            user=self.user,
+            project=self.project,
+            format="taxa_list_csv",
+            filters=filters,
+            job=None,
+        )
+        file_url = data_export.run_export()
+        self.assertIsNotNone(file_url)
+        file_path = file_url.replace("/media/", "")
+        with default_storage.open(file_path, "r") as f:
+            rows = list(csv.DictReader(f))
+        default_storage.delete(file_path)
+        return rows, data_export
+
+    def test_smoke_collection_filter_and_filename_label(self):
+        """End-to-end smoke: format is registered, the export writes a file
+        scoped to the selected collection, and the filename carries the
+        `taxa_list` label so it's distinguishable from occurrence exports."""
+        self.assertIn("taxa_list_csv", ExportRegistry.get_supported_formats())
+
+        in_capture = self.collection.images.first()
+        self._make_occurrence(self.taxon_with_ids, in_capture, score=0.9)
+        # Occurrence outside the collection — must not appear in output.
+        all_images = list(self.project.captures.all())
+        out_image = next(img for img in all_images if img.pk not in {c.pk for c in self.collection.images.all()})
+        self._make_occurrence(self.taxon_no_ids, out_image, score=0.9)
+
+        rows, data_export = self._run_export()
+        names = {row["name"] for row in rows}
+        self.assertEqual(names, {self.taxon_with_ids.name})
+        self.assertEqual(rows[0]["direct_occurrences_count"], "1")
+        self.assertIn("taxa_list", data_export.file_url or "")
+
+    def test_score_aggregations_and_default_threshold(self):
+        """min/max/avg score across occurrences, and project default
+        score-threshold filter wires through (low-score occurrences excluded)."""
+        self.project.default_filters_score_threshold = 0.5
+        self.project.save()
+
+        captures = list(self.collection.images.all()[:4])
+        self.assertGreaterEqual(len(captures), 4)
+        # Three high-score occurrences for the same taxon — these survive.
+        for cap, score in zip(captures[:3], [0.6, 0.8, 1.0]):
+            self._make_occurrence(self.taxon_with_ids, cap, score=score)
+        # One low-score occurrence for a different taxon — filtered out.
+        self._make_occurrence(self.taxon_no_ids, captures[3], score=0.1)
+
+        rows, _ = self._run_export()
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["name"], self.taxon_with_ids.name)
+        self.assertEqual(row["direct_occurrences_count"], "3")
+        self.assertAlmostEqual(float(row["min_score"]), 0.6, places=4)
+        self.assertAlmostEqual(float(row["max_score"]), 1.0, places=4)
+        self.assertAlmostEqual(float(row["avg_score"]), 0.8, places=4)
+
+    def test_external_links_and_hierarchy_columns(self):
+        """One row with full external IDs + hierarchy populated; one row with
+        none, to confirm both shapes render correctly."""
+        cap1, cap2 = list(self.collection.images.all())[:2]
+        self._make_occurrence(self.taxon_with_ids, cap1, score=0.9)
+        self._make_occurrence(self.taxon_no_ids, cap2, score=0.9)
+
+        rows, _ = self._run_export()
+        by_name = {row["name"]: row for row in rows}
+        with_ids = by_name[self.taxon_with_ids.name]
+        no_ids = by_name[self.taxon_no_ids.name]
+
+        # External links populated.
+        self.assertEqual(with_ids["gbif_url"], "https://www.gbif.org/species/1898286")
+        self.assertEqual(with_ids["inat_url"], "https://www.inaturalist.org/taxa/48662")
+        self.assertIn("BOLD:AAA0001", with_ids["bold_url"])
+        self.assertEqual(with_ids["fieldguide_url"], "https://fieldguide.app/taxa/vanessa-cardui")
+        self.assertEqual(with_ids["cover_image_url"], "https://example.com/vc.jpg")
+        # Hierarchy columns populated from parents_json + own rank.
+        self.assertEqual(with_ids["kingdom"], "Animalia")
+        self.assertEqual(with_ids["family"], "Nymphalidae")
+        self.assertEqual(with_ids["species"], "Aglais io")
+
+        # No-ID taxon has blank link columns and no hierarchy ancestors.
+        self.assertEqual(no_ids["gbif_url"], "")
+        self.assertEqual(no_ids["inat_url"], "")
+        self.assertEqual(no_ids["bold_url"], "")
+        self.assertEqual(no_ids["fieldguide_url"], "")
+        self.assertEqual(no_ids["kingdom"], "")
+        self.assertEqual(no_ids["family"], "")
+
+    def test_time_of_night_wraparound(self):
+        """Avg of 22:00 and 02:00 should be ~00:00 (midnight), not 12:00 (noon).
+
+        This is the only nontrivial aggregation in the format and the reason
+        we shift to a noon-anchored axis before averaging.
+        """
+        captures = list(self.collection.images.all())
+        self.assertGreaterEqual(len(captures), 2)
+
+        base_date = datetime.date(2026, 5, 1)
+        ts_evening = datetime.datetime.combine(base_date, datetime.time(22, 0, 0))
+        ts_early_morning = datetime.datetime.combine(base_date + datetime.timedelta(days=1), datetime.time(2, 0, 0))
+
+        self._make_occurrence(self.taxon_with_ids, captures[0], score=0.9, timestamp=ts_evening)
+        self._make_occurrence(self.taxon_with_ids, captures[1], score=0.9, timestamp=ts_early_morning)
+
+        rows, _ = self._run_export()
+        row = next(r for r in rows if r["name"] == self.taxon_with_ids.name)
+        # In noon-anchored space, 22:00 is the start of the night (10h after
+        # noon) and 02:00 is the end (14h after noon).
+        self.assertEqual(row["min_time_of_night"], "22:00:00")
+        self.assertEqual(row["max_time_of_night"], "02:00:00")
+        h, m, s = row["avg_time_of_night"].split(":")
+        avg_seconds = int(h) * 3600 + int(m) * 60 + int(s)
+        # Avg should land at the midnight midpoint; accept ±60s for rounding.
+        self.assertTrue(
+            avg_seconds <= 60 or avg_seconds >= 86340,
+            f"avg_time_of_night {row['avg_time_of_night']} should be near 00:00",
+        )
 
 
 class DataExportPermissionTest(TestCase):

--- a/docs/claude/planning/2026-05-05-taxa-list-export-design.md
+++ b/docs/claude/planning/2026-05-05-taxa-list-export-design.md
@@ -1,0 +1,240 @@
+# Taxa List Export — Design
+
+**Date**: 2026-05-05
+**Branch**: `worktree-taxa-list-export`
+**Author**: Michael + Claude
+
+## Goal
+
+Add a new export format `taxa_list_csv` to the existing export framework
+(`ami/exports/`). One row per unique taxon that has at least one valid
+occurrence (after applying project default filters) in the user-selected
+`SourceImageCollection`. Output is a tabular CSV.
+
+This is not Darwin Core. It is a project-internal summary file for collaborators
+who want a quick "what showed up in this capture set" report.
+
+## Scope decisions
+
+| Question | Decision | Why |
+|---|---|---|
+| Which taxa? | Distinct `determination` taxa from valid occurrences in the collection, **with project default filters applied** (score threshold + include/exclude taxa lists, via `Occurrence.objects.apply_default_filters`) | Matches what users see in the Taxa list view. Screens out unreviewed low-score ML output before it leaves the system. |
+| Hierarchical roll-ups (a row for the species *and* its genus, family, etc.) | **No.** One row per directly-determined taxon. | Simpler. Most projects don't classify at every rank, but when they do (e.g. genus-level when species fails), each taxon already gets its own row because it appears as someone's `determination`. |
+| Column name for occurrence count | `direct_occurrences_count` | Makes it explicit that this counts occurrences whose `determination` *is* this taxon, not descendants. Leaves room for a future `recursive_occurrences_count` column if requested. |
+| Output formats | CSV only (v1) | Matches existing `occurrences_simple_csv`. JSON variant deferrable. |
+| Time-of-night handling | Shift to "minutes from noon" before aggregating to handle midnight wraparound. Output as `HH:MM:SS`. Use first-appearance time of each occurrence (i.e. earliest detection timestamp). | Naive midnight-anchored avg of 22:00 and 02:00 is 12:00 (wrong). Noon-anchored avg is 00:00 (correct midpoint). |
+| Filter backend | New `TaxaListCollectionFilter` that consumes `collection_id` and constrains to occurrences in that collection. (Cannot reuse `OccurrenceCollectionFilter` because it wraps the queryset in a subquery on `Occurrence`, not on the per-taxon aggregate.) | Filter backend pattern is the right place to apply the collection scope; the rest of the framework (`apply_filters`) already invokes it. |
+
+## Output columns
+
+Group A — Taxon identity:
+- `id`, `name`, `display_name`, `rank`, `common_name_en`
+
+Group B — Taxonomy hierarchy from `parents_json` (one column per Linnaean rank in `DEFAULT_RANKS`):
+- `kingdom`, `phylum`, `class`, `order`, `family`, `subfamily`, `tribe`, `genus`, `species`
+  (extracted from `parents_json`; populated only if a parent at that rank exists; the row's own taxon fills in its rank's column)
+
+Group C — Occurrence aggregations (over filtered occurrences in collection):
+- `direct_occurrences_count` (int)
+- `min_score`, `max_score`, `avg_score` (float, 4 decimal places)
+- `first_occurrence_date`, `last_occurrence_date`, `avg_occurrence_date` (`YYYY-MM-DD`)
+- `min_time_of_night`, `max_time_of_night`, `avg_time_of_night` (`HH:MM:SS`, noon-anchored aggregation)
+
+Group D — External IDs and links (blank when the field is null):
+- `gbif_taxon_key`, `gbif_url`
+- `inat_taxon_id`, `inat_url`
+- `bold_taxon_bin`, `bold_url`
+- `fieldguide_id`, `fieldguide_url`
+- `cover_image_url`
+
+Link templates:
+- GBIF: `https://www.gbif.org/species/{key}`
+- iNaturalist: `https://www.inaturalist.org/taxa/{id}`
+- BOLD: `https://www.boldsystems.org/index.php/Public_BarcodeIndexNumber_RecordView?searchtype=records&recordID={bin}`
+- Fieldguide: `https://fieldguide.app/taxa/{id}`
+
+## Architecture
+
+```
+ami/exports/
+├── base.py              # add `filename_label` class attr (generic, copied from PR #1131)
+├── format_types.py      # add TaxaListCSVExporter
+├── taxa_list.py         # NEW — column getters, time-of-night helpers, aggregator
+├── registry.py          # register "taxa_list_csv"
+├── models.py            # generate_filename uses filename_label if set
+└── tests.py             # add TaxaListExportTest
+
+ami/main/api/views.py    # NEW filter backend: TaxaListExportCollectionFilter (or
+                         # reuse TaxonCollectionFilter if signature aligns)
+
+ui/src/data-services/models/export.ts   # add 'taxa_list_csv' to SERVER_EXPORT_TYPES
+                                        # add label "Taxa list (CSV)"
+```
+
+## Data flow
+
+1. `DataExport` row created with `format='taxa_list_csv'` and `filters={'collection_id': N}`.
+2. Job kicked off → `DataExport.run_export()` → `TaxaListCSVExporter.__init__` calls
+   `BaseExporter.apply_filters` to apply the collection filter to the **occurrence**
+   queryset (so we can count/aggregate without touching N taxa rows).
+3. `total_records` becomes the count of distinct taxa with ≥1 filtered occurrence
+   (computed via `qs.values('determination_id').distinct().count()`), so progress
+   reflects the real output size.
+4. `export()` does:
+   - **One streaming pass** over the filtered occurrence queryset, ordered by
+     `determination_id`, yielding `.values('determination_id', 'determination_score',
+     'first_appearance_timestamp', 'last_appearance_timestamp')` (use `with_timestamps()`).
+   - Per-taxon accumulator dict `{ det_id: TaxonAccumulator }` — running min/max/sum
+     for score, first_appearance_dt, last_appearance_dt, and noon-anchored
+     time-of-night seconds.
+   - After streaming, `Taxon.objects.filter(id__in=accum.keys())` fetches taxon
+     rows for the column-A/B/D fields.
+   - For each taxon, write one CSV row using the accumulator + taxon fields.
+   - `update_job_progress` ticks per row.
+
+## Aggregation details
+
+### Score
+Running `min`, `max`, `sum`, `count` (skip None). `avg = sum / count` if `count > 0`.
+
+### Date (date-of-occurrence)
+Use `first_appearance_timestamp.date()`. Running min, max, and "average epoch seconds"
+(via Welford's incremental mean to avoid overflow). Convert avg back to `date`.
+For exports the average-date column is informational; not a quantity anyone
+math-aggregates further.
+
+### Time of night
+For each occurrence, take `first_appearance_timestamp.time()`. Convert to seconds
+since midnight. Apply noon shift: `shifted = (secs - 43200 + 86400) % 86400`.
+Aggregate min/max/avg in shifted space. Convert back: `secs = (shifted + 43200) % 86400`.
+Format as `HH:MM:SS`.
+
+This handles the typical AMI monitoring window (dusk through dawn) without the
+naive "average of 22:00 and 02:00 = 12:00 noon" failure.
+
+## Filter backend
+
+`OccurrenceCollectionFilter` is the right shape (`collection_id` → filter on
+`detections__source_image__collections`). Override `get_filter_backends()` on
+`TaxaListCSVExporter` to return `[OccurrenceCollectionFilter]`. The filtered
+queryset stays an `Occurrence` queryset; we group/aggregate from there.
+
+## Generic optimization carried over from PR #1131
+
+Add `filename_label` class attribute to `BaseExporter` (defaults to `""`). When
+non-empty, `DataExport.generate_filename` inserts it as a slug token between the
+project slug and the export pk:
+
+`project_slug-{label}_export-{pk}.{ext}`
+
+For `TaxaListCSVExporter`, set `filename_label = "taxa_list"` so the file lands
+as `vermont-atlas_taxa_list_export-42.csv` instead of `vermont-atlas_export-42.csv`,
+making it distinguishable from occurrence exports in a user's downloads folder.
+
+The two existing exporters keep `filename_label = ""` and produce the same
+filenames they do today (no migration / regression).
+
+## Testing
+
+Add `TaxaListExportTest` in `ami/exports/tests.py`:
+
+1. Set up project, deployment, two captures-per-night events spanning midnight.
+2. Create occurrences across 3 distinct taxa (different ranks, different
+   external-ID populations).
+3. Run export; read CSV.
+4. Assertions:
+   - Row count = distinct determinations (after default filters).
+   - `direct_occurrences_count` per row matches manual count.
+   - Score min/max/avg are correct.
+   - `first_occurrence_date` ≤ `last_occurrence_date`.
+   - Time-of-night roundtrip: an occurrence at 22:00 and one at 02:00 next-day
+     yield avg ≈ 00:00 (within ±1 minute).
+   - `gbif_url` populated when `gbif_taxon_key` is set; blank otherwise.
+   - Hierarchy columns populated from `parents_json`.
+
+## Future hook: taxonomic scope / absence rows
+
+A project will eventually declare a "taxonomic scope" — the set of taxa
+expected to be observable. Today this is implicit in
+`Project.default_filters_include_taxa` (recursively expanded). Per-Site
+`TaxaList` may follow.
+
+When the scope is declared, the export should emit a row per scope-taxon that
+*was not* observed in the collection, with `direct_occurrences_count = 0`. This
+turns the file into a presence/absence checklist rather than a "what we saw"
+list — important for ecological interpretation (a taxon is meaningfully
+*absent* only against an explicit expected list).
+
+The exporter has a `_get_expected_taxa()` hook returning an empty queryset by
+default. When a project gets a populated scope (any of: a non-empty
+`default_filters_include_taxa`, a per-project default `TaxaList`, a per-Site
+`TaxaList`), this method will be updated to return that taxa set. The writer
+loop emits a zero-count row for each expected taxon not in the observed
+accumulator.
+
+For v1 the hook is wired but inert (returns nothing); the column shape stays
+identical so the format is stable when absence rows turn on.
+
+## DwC Taxon Core compatibility (future `taxa_list_dwca` format)
+
+The DwC-A export in PR #1131 explicitly defers a species-checklist
+(`taxon.txt`). The columns this format already produces cover the DwC
+Taxon Core terms needed for that follow-up:
+
+| DwC term | Source in this export |
+|---|---|
+| `taxonID` | `id` (or scoped URN) |
+| `scientificName` | `name` |
+| `taxonRank` | `rank` |
+| `kingdom`, `phylum`, `class`, `order`, `family`, `genus` | hierarchy columns from `parents_json` |
+| `specificEpithet` | derivable from `name` when `rank=SPECIES` |
+| `vernacularName` | `common_name_en` |
+| `scientificNameAuthorship` | `Taxon.author` |
+| `nameAccordingToID` | `gbif_url` |
+| `references` | `inat_url` / `fieldguide_url` / `bold_url` (pipe-joined) |
+
+Scientific-name authorship + author date are not in v1 columns but are
+trivially addable. Implication: a sibling `taxa_list_dwca` format reusing the
+same accumulator and Taxon fetch can ship as a single Taxon-Core DwC archive
+later. No schema changes needed; just an alternate writer that emits TSV +
+`meta.xml` + `eml.xml` in a zip.
+
+For v1 we do NOT ship the DwC variant. The column choices in this CSV are
+intentionally a superset of the data needed for it, so the work isn't
+re-done.
+
+## Out of scope (follow-up)
+
+- JSON variant (`taxa_list_json`) — straightforward once CSV is in.
+- DwC Taxon-Core archive variant (`taxa_list_dwca`) — see above.
+- Zero-count absence rows — see "Future hook" above.
+- Recursive (`recursive_occurrences_count`) — needs `parents_json__contains`
+  count subquery per row; defer until a user asks.
+- Per-event time-of-night (some projects might want "average time within event",
+  not absolute clock time).
+- Tag column / TaxaList membership column.
+- `scientificNameAuthorship`, `authorship_date` columns (for DwC variant).
+
+## Implementation order
+
+1. Add `filename_label` to `BaseExporter` + wire through `DataExport.generate_filename`.
+2. Implement `ami/exports/taxa_list.py` (accumulator, helpers, CSV writer).
+3. Implement `TaxaListCSVExporter` in `format_types.py`.
+4. Register `taxa_list_csv` in `registry.py`.
+5. Update UI `export.ts` (type + label).
+6. Tests.
+7. Run full export test suite.
+
+## Risks
+
+- **Memory**: per-taxon accumulators are bounded by the number of distinct taxa
+  in the collection. For typical projects (≤ a few thousand taxa), this is well
+  under 1 MB. Documented; not actively guarded.
+- **Time-of-night assumption**: noon shift is correct for nocturnal AMI traps
+  (the only documented use case). For diurnal observations the noon-anchored
+  aggregation could be misleading. Not currently a concern; revisit if a daytime
+  project shows up.
+- **Cross-product on collection filter**: filtering `Occurrence` by
+  `detections__source_image__collections` introduces duplicate occurrence rows
+  in the join. The `.values('determination_id', ..., 'id')` with `Count('id',
+  distinct=True)` pattern handles this. Tests verify counts.

--- a/ui/src/data-services/models/export.ts
+++ b/ui/src/data-services/models/export.ts
@@ -6,6 +6,7 @@ import { JobDetails } from './job-details'
 export const SERVER_EXPORT_TYPES = [
   'occurrences_simple_csv',
   'occurrences_api_json',
+  'taxa_list_csv',
 ] as const
 
 export type ServerExportType = (typeof SERVER_EXPORT_TYPES)[number]
@@ -27,6 +28,7 @@ export class Export extends Entity {
     const label = {
       occurrences_simple_csv: 'Occurrences (simple CSV)',
       occurrences_api_json: 'Occurrences (API JSON)',
+      taxa_list_csv: 'Taxa list (CSV)',
     }[key]
 
     return {


### PR DESCRIPTION
## Summary

New export format `taxa_list_csv` — emits one CSV row per unique `Taxon` observed in a user-selected `SourceImageCollection`, with full Linnaean hierarchy columns and per-taxon aggregations (occurrence count, score, session-day / session-time / session-month, per-occurrence duration) plus external-DB IDs/URLs (GBIF, iNat, BOLD, Fieldguide). Collection-scoped via the existing `OccurrenceCollectionFilter`; project default filters (score threshold + include/exclude taxa) are applied so output matches what users see in the taxa list view.

The aggregator and Taxon-fetch path are designed to also feed a future Darwin Core Taxon-Core archive variant (`taxa_list_dwca`) and a future "absence rows" mode driven by a project-level taxonomic scope.

Carried over a small generic optimization from #1131: a `filename_label` class attr on `BaseExporter` so each format can inject a slug (`taxa_list`) into its filename.

## Reusable helpers added to models

A handful of helpers that started life inside the exporter were moved to the natural model so other code (API serializers, future DwC-A export, UI) can use them without duplicating logic:

- **`Taxon.gbif_url` / `inat_url` / `bold_url` / `fieldguide_url`** — properties returning the public URL for the taxon on each external database, or `None` when the underlying ID isn't set.
- **`Taxon.linnaean_hierarchy(ranks=None)`** — returns `{lowercase-rank: taxon-name}` dict from `parents_json` + own rank. All requested rank keys present; unfilled ranks are empty string. Defaults to `DEFAULT_RANKS` (Kingdom..Species). Useful for any flat-rank rendering — CSV columns, DwC Taxon-Core, GBIF-style hierarchy fields.
- **`Project.get_taxonomic_scope()`** — stub returning `None` today. The real impl will return a queryset from a per-project default `TaxaList` (coming soon). Reference impl + a DwC-A "single root via lowest common ancestor" alternative are sketched in the docstring. The exporter consumes it now: when scope becomes non-`None`, absence rows light up automatically (`direct_occurrences_count = 0` placeholder rows for in-scope-but-unobserved taxa).

## Phenology-friendly temporal columns

The temporal aggregations are session-anchored (a session = the monitoring night the occurrence was first seen on, via `first_appearance_timestamp`). The shape is built around the typical phenology question "when does this taxon usually fly?":

| Column group | Unit | Aggregation |
|---|---|---|
| `session_day_{min,max,median}` | day of year, 1-366 | median (robust to outlier nights) |
| `session_time_{min,max,median}` | clock `HH:MM:SS`, noon-anchored so midnight-spanning windows work | median |
| `session_month_{min,max,mean}` | calendar month, 1-12 | mean (fractional `6.3` reads better than a stepped median) |
| `min/max/avg_duration_seconds` | seconds | mean |

Time-of-night aggregations are computed in a noon-anchored axis so midnight-spanning monitoring nights work correctly (median of 22:00 + 02:00 = 00:00, not 12:00 noon).

## Output preview

E2E run against project 18 (Vermont Atlas of Life), collection 176 (363 images, full event 5297, 2022-06-18 to 2022-06-19). After `apply_default_filters`: 92 occurrences → 13 unique taxa → 13 CSV rows.

**Columns** (in CSV order):

| Column | Sample value | Notes |
|---|---|---|
| `id` | `3839` | Antenna `Taxon.pk` |
| `name` | `Xestia c-nigrum` | scientificName |
| `display_name` | `Xestia c-nigrum` | UI-formatted |
| `rank` | `SPECIES` | `TaxonRank` enum |
| `common_name_en` | _(empty)_ | when set |
| `kingdom` ... `species` | `Lepidoptera` / `Noctuidae` / `Noctuinae` / `Noctuini` / `Xestia` / `Xestia c-nigrum` | from `Taxon.linnaean_hierarchy()` |
| `direct_occurrences_count` | `17` | clearly named to leave room for a future `recursive_occurrences_count` |
| `min_score` / `max_score` / `avg_score` | `0.5025` / `0.9073` / `0.6516` | classification confidence |
| `session_day_min` / `_max` / `_median` | `169` / `170` / `169` | day of year (June 18 = 169, June 19 = 170) |
| `session_time_min` / `_max` / `_median` | `21:12:00` / `01:25:16` / `23:48:06` | noon-anchored median → spans midnight correctly |
| `session_month_min` / `_max` / `_mean` | `6` / `6` / `6.0` | June |
| `min_duration_seconds` / `_max` / `_avg` | _(empty for single-detection occurrences)_; `2` / `6` / `4` for `Scoparia biplagialis` | becomes meaningful once detection tracking is wired up |
| `gbif_taxon_key` / `gbif_url` | `5714973` / `https://www.gbif.org/species/5714973` | from `Taxon.gbif_url`, empty when ID missing |
| `inat_taxon_id` / `inat_url` | _(empty)_ | from `Taxon.inat_url` |
| `bold_taxon_bin` / `bold_url` | _(empty)_ | from `Taxon.bold_url` |
| `fieldguide_id` / `fieldguide_url` | _(empty)_ | from `Taxon.fieldguide_url` |
| `cover_image_url` | _(empty)_ | populated when set on Taxon |

**Sample rows** (lightly trimmed):

```csv
id,name,rank,order,family,genus,species,direct_occurrences_count,min_score,max_score,avg_score,session_day_min,session_day_max,session_day_median,session_time_min,session_time_max,session_time_median,session_month_min,session_month_max,session_month_mean,min_duration_seconds,max_duration_seconds,avg_duration_seconds,gbif_taxon_key
6135,Agriphila vulgivagellus,SPECIES,Lepidoptera,Crambidae,Agriphila,Agriphila vulgivagellus,1,0.5545,0.5545,0.5545,169,169,169,22:42:20,22:42:20,22:42:20,6,6,6.0,372,372,372,1878937
6,Campaea perlata,SPECIES,Lepidoptera,Geometridae,Campaea,Campaea perlata,2,0.7378,0.8981,0.8180,169,169,169,23:51:41,23:51:43,23:51:42,6,6,6.0,,,,
11613,Not Lepidoptera,ORDER,Not Lepidoptera,,,,34,0.5002,0.9580,0.8986,169,170,169,22:10:48,04:37:58,22:46:21,6,6,6.0,,,,
6935,Scoparia biplagialis,SPECIES,Lepidoptera,Crambidae,Scoparia,Scoparia biplagialis,15,0.6337,0.9183,0.7751,169,170,169,21:45:57,00:44:38,23:36:03,6,6,6.0,2,6,4,5126963
3839,Xestia c-nigrum,SPECIES,Lepidoptera,Noctuidae,Xestia,Xestia c-nigrum,17,0.5025,0.9073,0.6516,169,170,169,21:12:00,01:25:16,23:48:06,6,6,6.0,,,,5714973
```

Wraparound check: `Xestia c-nigrum` first seen at 21:12, last at 01:25 (next morning), median 23:48 — straddles midnight cleanly thanks to noon-anchored time aggregation. `Not Lepidoptera` (34 occurrences across two nights, days 169-170): median day 169, median time 22:46.

Duration is empty for single-detection occurrences (most current rows). When it shows up — `Agriphila vulgivagellus` 372s, `Scoparia biplagialis` 2-6s avg 4s — it's the `(last_appearance - first_appearance)` window already exposed via `with_timestamps()`. Once detection tracking lands, more occurrences will have multi-detection durations and these columns will populate.

## Test plan

- [x] 4 unit tests in `ami/exports/tests.py::TaxaListExportTest` — registry/scope/filename, score aggregation + threshold, external links + hierarchy, time-of-night wraparound (asserts on `session_time_*`).
- [x] Full `ami.exports.tests` suite (23/23) and `ami.main.tests.TestTaxonomy` + `TestTaxonomyViews` (13/13) green after the model-migration refactor.
- [x] E2E export against real project 18 data (collection 176): 13 rows, columns + values verified per preview above.
- [ ] UI smoke: trigger `taxa_list_csv` from the export dropdown and confirm download (UI label already wired in `ui/src/data-services/models/export.ts`).

## Future hooks (stubbed only)

- **Absence rows.** When `Project.get_taxonomic_scope()` returns a non-`None` queryset (per-project default `TaxaList`, landing soon), the writer emits `direct_occurrences_count = 0` rows for unobserved in-scope taxa. v1 returns `None` so column shape is stable when this turns on.
- **DwC Taxon-Core archive variant.** Columns are intentionally a superset of DwC Taxon-Core terms so a sibling `taxa_list_dwca` format can reuse the aggregator + Taxon fetch and emit `taxon.txt` + `meta.xml` + `eml.xml` zip. See PR #1131 for the surrounding DwC-A export. A "single-root via lowest common ancestor" scope shape is sketched in `Project.get_taxonomic_scope()`'s docstring as a sibling method (`get_taxonomic_scope_root()`) for that variant — different consumers want different shapes (enumerated set vs single root).
- **Tracking-derived duration.** `min/max/avg_duration_seconds` use the existing first/last-appearance window. When detection tracking is wired up these fields stay valid and become more meaningful (multi-detection, post-tracking) without schema churn.

## Design doc

`docs/claude/planning/2026-05-05-taxa-list-export-design.md`
