### PR TITLE
Scale celeryworkers to keep up with async ML processing

### DIFF
--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -55,7 +55,7 @@ services:
 
   celeryworker_ml:
     <<: *django
-    scale: 1
+    scale: 4
     ports: []
     command: /start-celeryworker
     environment:


### PR DESCRIPTION
## What this proposes

Bumps the default `scale` of `celeryworker_ml` in `docker-compose.worker.yml` from 1 to 4.

## Why

When async ML jobs run with high concurrency, we observed the `ml_results` queue growing long enough that result-processing tasks waited past their retry timeouts and exhausted `max_retries`. User-visible effect: results from successfully-processed images getting recorded as failures because the result-handling task couldn't be picked up in time.

Splitting `ml_results` into its own dedicated celery service (the existing `celeryworker_ml` setup in this file) was the first mitigation. Bumping its default scale to 4 is the second. Together they appear to have helped, though we don't have a clean isolated before/after measurement for the scale change on its own.

## Tradeoffs / things to discuss

- 4 is a starting point rather than something we've empirically tuned. Open to a different number with measurements.
- 4× the prefork pool means roughly 4× the memory footprint per host. Smaller VMs may want to lower `CELERY_WORKER_CONCURRENCY` in `.env` to compensate.
- The other two celery services (`celeryworker` for the antenna queue and `celeryworker_jobs`) stay at `scale: 1` — they haven't shown the same retry-timeout pattern.

## Test plan

- [ ] Deploy to a worker host; confirm 4 `celeryworker_ml` containers come up
- [ ] Watch host memory; tune `CELERY_WORKER_CONCURRENCY` if pressure rises
- [ ] Watch `ml_results` task retry counts under load; should drop relative to single-worker baseline