### PR TITLE
chore(newrelic): upgrade agent to 12.1.0 and tune tracer config

### DIFF
--- a/.envs/.production/.django-example
+++ b/.envs/.production/.django-example
@@ -53,8 +53,58 @@ RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit consumer_timeout 604800000
 SENDGRID_API_KEY=
 
 # Newrelic
+# ------------------------------------------------------------------------------
+# Common defaults live in config/newrelic.ini and are tuned for production
+# safety (apdex_f trace threshold, obfuscated SQL, 0.5s stack/explain).
+# Staging/demo opts into more aggressive tracing here.
+#
+# Identity / lifecycle
 NEW_RELIC_CONFIG_FILE=/app/config/newrelic.ini
 NEW_RELIC_ENVIRONMENT=development
+# NEW_RELIC_LICENSE_KEY=        # overrides license_key in ini (preferred — keep key out of repo)
+# NEW_RELIC_APP_NAME=AMI Backend (Demo)
+# NEW_RELIC_MONITOR_MODE=true   # set false to silence the agent without removing it
+# NEW_RELIC_LOG_LEVEL=info      # bump to debug only when reproducing an agent issue
+# NEW_RELIC_HIGH_SECURITY=false # true forces obfuscated SQL + drops request params, irreversible per app
+#
+# Apdex / trace thresholds — the headline knobs
+#
+# NEW_RELIC_APDEX_T sets the satisfactory response time (default 0.5s). The
+# `apdex_f` threshold used below is automatically 4*Apdex T (so ~2s by default).
+# Raise Apdex T if antenna's normal latency drifts upward and you want the
+# Apdex score to track user expectations rather than alert-floor noise.
+# NEW_RELIC_APDEX_T=0.5
+#
+# Staging / demo — maximum visibility, no cost pressure:
+# NEW_RELIC_TRANSACTION_TRACER_TRANSACTION_THRESHOLD=0.5
+# NEW_RELIC_TRANSACTION_TRACER_STACK_TRACE_THRESHOLD=0.1
+# NEW_RELIC_TRANSACTION_TRACER_EXPLAIN_THRESHOLD=0.1
+# NEW_RELIC_TRANSACTION_TRACER_RECORD_SQL=raw
+#
+# Production — conservative; ini defaults are already production-safe so most
+# lines below can stay commented. Uncomment only the ones you want explicit.
+# NEW_RELIC_TRANSACTION_TRACER_TRANSACTION_THRESHOLD=apdex_f
+# NEW_RELIC_TRANSACTION_TRACER_STACK_TRACE_THRESHOLD=0.5
+# NEW_RELIC_TRANSACTION_TRACER_EXPLAIN_THRESHOLD=0.5
+# NEW_RELIC_TRANSACTION_TRACER_RECORD_SQL=obfuscated
+#
+# Attributes / privacy
+# NEW_RELIC_ATTRIBUTES_INCLUDE=request.parameters.*
+#   Captures ?project_id=12&page=4 on traces. Audit GET params for tokens / PII
+#   first. Safe-ish on antenna (mostly numeric IDs + pagination).
+# NEW_RELIC_ATTRIBUTES_EXCLUDE=request.headers.authorization,request.headers.cookie
+#   Belt-and-braces if you turn on parameters and want to hard-strip auth.
+#
+# Logging — already enabled in ini; cap volume here if needed
+# NEW_RELIC_APPLICATION_LOGGING_ENABLED=true
+# NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=true
+# NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED=10000
+# NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED=true
+#
+# Sampling caps — only touch if hitting the NR trace cap on a hot env
+# NEW_RELIC_TRANSACTION_EVENTS_MAX_SAMPLES_STORED=10000
+# NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED=2000
+# NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true
 
 # Storage
 DJANGO_AWS_S3_CUSTOM_DOMAIN=

--- a/.github/workflows/test.backend.yml
+++ b/.github/workflows/test.backend.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
 
+      - name: Verify newrelic.ini function_trace symbols resolve
+        run: python scripts/check_newrelic_function_trace.py
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/config/newrelic.ini
+++ b/config/newrelic.ini
@@ -156,6 +156,18 @@ transaction_tracer.explain_enabled = true
 # is true.
 transaction_tracer.explain_threshold = 0.1
 
+# Independent slow-SQL collector. Captures slow individual queries even
+# when the parent transaction did not cross transaction_threshold.
+# Default is true in agent 10+, set explicitly so we do not regress on
+# future agent upgrades.
+slow_sql.enabled = true
+
+# Tag datastore spans with db.instance + peer.hostname + peer.port so
+# we can facet by DB target (primary vs replica, demo vs staging cluster)
+# in the NR UI. Defaults to true in agent 10+, set explicitly.
+datastore_tracer.instance_reporting.enabled = true
+datastore_tracer.database_name_reporting.enabled = true
+
 # Space separated list of function or method names in form
 # 'module:function' or 'module:class.function' for which
 # additional function timing instrumentation will be added.
@@ -274,7 +286,51 @@ monitor_mode = false
 app_name = AMI Backend (Staging)
 monitor_mode = true
 
+# Suggested staging/demo overrides — uncomment after deploy verification.
+# These are MORE aggressive than common defaults; staging/demo absorb the
+# extra trace volume + EXPLAIN load without cost concerns and benefit from
+# maximum visibility during workshops + active debugging.
+#
+# attributes.include = request.parameters.*
+#   Captures ?project_id=12&page=4 on traces. Audit GET params for auth
+#   tokens / PII first. Antenna's GET params are mostly numeric IDs +
+#   pagination — likely safe. record_sql is already raw so SQL bodies
+#   are already in NR; adding params is incremental.
+#
+# transaction_tracer.transaction_threshold = 0.25
+#   Drop from common 0.5s to 0.25s on staging/demo. Catches median-path
+#   regressions before they hit production. Verify trace volume after 1h.
+#
+# transaction_tracer.stack_trace_threshold = 0.05
+# transaction_tracer.explain_threshold = 0.05
+#   More aggressive than common 0.1. Helps catch N+1 patterns where each
+#   query is <100ms but the chain is slow.
+#
+# thread_profiler.enabled = true
+#   Already true in common. Worth re-confirming for staging since this
+#   is where we run controlled load tests.
+
 [newrelic:production]
 monitor_mode = true
+
+# Suggested production overrides — uncomment when promoting these changes
+# beyond staging. Production prioritises cost + DB load over visibility.
+#
+# transaction_tracer.transaction_threshold = 1.0
+#   Raise from common 0.5s. Production QPS is higher; 0.5s threshold
+#   could push us into NR's trace cap. 1.0s still captures real
+#   user-visible slowness.
+#
+# transaction_tracer.stack_trace_threshold = 0.25
+# transaction_tracer.explain_threshold = 0.25
+#   EXPLAIN runs against the live DB. On production with high QPS the
+#   extra load from EXPLAIN-ing every 100ms query is not free. 0.25
+#   keeps the feature useful for actually-slow queries.
+#
+# transaction_tracer.record_sql = obfuscated
+#   Downgrade from common raw. Eliminates risk of literal values
+#   (filenames, user-supplied search terms) showing up in NR UI for
+#   anyone with NR account access. Trade-off: harder to spot bad
+#   parameter patterns. Keep raw if the team is small + trusted.
 
 # ---------------------------------------------------------------------------

--- a/config/newrelic.ini
+++ b/config/newrelic.ini
@@ -124,27 +124,34 @@ transaction_tracer.enabled = true
 # the UI. Valid values are any positive float value, or (default)
 # "apdex_f", which will use the threshold for a dissatisfying
 # Apdex controller action - four times the Apdex T value.
-# Lowered from apdex_f (~2s) to 0.5s so sub-Apdex requests still produce
-# transaction traces. Antenna's median web latency is 200-600ms so the
-# default threshold captures almost nothing.
-transaction_tracer.transaction_threshold = 0.5
+#
+# Default `apdex_f` (~2s) is the safe production-grade value. For
+# staging/demo override via NEW_RELIC_TRANSACTION_TRACER_TRANSACTION_THRESHOLD
+# in .envs/.production/.django (see .django-example for the full set).
+transaction_tracer.transaction_threshold = apdex_f
 
 # When the transaction tracer is on, SQL statements can
 # optionally be recorded. The recorder has three modes, "off"
 # which sends no SQL, "raw" which sends the SQL statement in its
 # original form, and "obfuscated", which strips out numeric and
 # string literals.
-# transaction_tracer.record_sql = obfuscated
-transaction_tracer.record_sql = raw
+#
+# Default `obfuscated` is the safe production-grade value (no
+# user-supplied literals leak into the NR UI). Staging/demo can
+# override via NEW_RELIC_TRANSACTION_TRACER_RECORD_SQL=raw when full
+# query visibility is needed for an investigation.
+transaction_tracer.record_sql = obfuscated
 
 # Threshold in seconds for when to collect stack trace for a SQL
 # call. In other words, when SQL statements exceed this
 # threshold, then capture and send to the UI the current stack
 # trace. This is helpful for pinpointing where long SQL calls
 # originate from in an application.
-# Lowered from 0.5 to 0.1 to catch N+1 query patterns (individual queries
-# 50-200ms but compound) with stack traces.
-transaction_tracer.stack_trace_threshold = 0.1
+#
+# Default 0.5s is safe for production. Override via
+# NEW_RELIC_TRANSACTION_TRACER_STACK_TRACE_THRESHOLD on staging/demo to catch
+# N+1 patterns (50-200ms queries that compound).
+transaction_tracer.stack_trace_threshold = 0.5
 
 # Determines whether the agent will capture query plans for slow
 # SQL queries. Only supported in MySQL and PostgreSQL. Set this
@@ -154,7 +161,11 @@ transaction_tracer.explain_enabled = true
 # Threshold for query execution time below which query plans
 # will not be captured. Relevant only when "explain_enabled"
 # is true.
-transaction_tracer.explain_threshold = 0.1
+#
+# EXPLAIN runs against the live DB so a low threshold on production
+# adds load. Default 0.5s is safe; override via
+# NEW_RELIC_TRANSACTION_TRACER_EXPLAIN_THRESHOLD on staging/demo.
+transaction_tracer.explain_threshold = 0.5
 
 # Independent slow-SQL collector. Captures slow individual queries even
 # when the parent transaction did not cross transaction_threshold.
@@ -286,51 +297,12 @@ monitor_mode = false
 app_name = AMI Backend (Staging)
 monitor_mode = true
 
-# Suggested staging/demo overrides — uncomment after deploy verification.
-# These are MORE aggressive than common defaults; staging/demo absorb the
-# extra trace volume + EXPLAIN load without cost concerns and benefit from
-# maximum visibility during workshops + active debugging.
-#
-# attributes.include = request.parameters.*
-#   Captures ?project_id=12&page=4 on traces. Audit GET params for auth
-#   tokens / PII first. Antenna's GET params are mostly numeric IDs +
-#   pagination — likely safe. record_sql is already raw so SQL bodies
-#   are already in NR; adding params is incremental.
-#
-# transaction_tracer.transaction_threshold = 0.25
-#   Drop from common 0.5s to 0.25s on staging/demo. Catches median-path
-#   regressions before they hit production. Verify trace volume after 1h.
-#
-# transaction_tracer.stack_trace_threshold = 0.05
-# transaction_tracer.explain_threshold = 0.05
-#   More aggressive than common 0.1. Helps catch N+1 patterns where each
-#   query is <100ms but the chain is slow.
-#
-# thread_profiler.enabled = true
-#   Already true in common. Worth re-confirming for staging since this
-#   is where we run controlled load tests.
-
 [newrelic:production]
 monitor_mode = true
 
-# Suggested production overrides — uncomment when promoting these changes
-# beyond staging. Production prioritises cost + DB load over visibility.
-#
-# transaction_tracer.transaction_threshold = 1.0
-#   Raise from common 0.5s. Production QPS is higher; 0.5s threshold
-#   could push us into NR's trace cap. 1.0s still captures real
-#   user-visible slowness.
-#
-# transaction_tracer.stack_trace_threshold = 0.25
-# transaction_tracer.explain_threshold = 0.25
-#   EXPLAIN runs against the live DB. On production with high QPS the
-#   extra load from EXPLAIN-ing every 100ms query is not free. 0.25
-#   keeps the feature useful for actually-slow queries.
-#
-# transaction_tracer.record_sql = obfuscated
-#   Downgrade from common raw. Eliminates risk of literal values
-#   (filenames, user-supplied search terms) showing up in NR UI for
-#   anyone with NR account access. Trade-off: harder to spot bad
-#   parameter patterns. Keep raw if the team is small + trusted.
+# Per-env tuning lives in .envs/.production/.django (template:
+# .envs/.production/.django-example). Common defaults in this file are
+# production-safe; staging/demo opts into more aggressive tracing via
+# NEW_RELIC_* env vars at deploy time.
 
 # ---------------------------------------------------------------------------

--- a/config/newrelic.ini
+++ b/config/newrelic.ini
@@ -124,7 +124,10 @@ transaction_tracer.enabled = true
 # the UI. Valid values are any positive float value, or (default)
 # "apdex_f", which will use the threshold for a dissatisfying
 # Apdex controller action - four times the Apdex T value.
-transaction_tracer.transaction_threshold = apdex_f
+# Lowered from apdex_f (~2s) to 0.5s so sub-Apdex requests still produce
+# transaction traces. Antenna's median web latency is 200-600ms so the
+# default threshold captures almost nothing.
+transaction_tracer.transaction_threshold = 0.5
 
 # When the transaction tracer is on, SQL statements can
 # optionally be recorded. The recorder has three modes, "off"
@@ -139,7 +142,9 @@ transaction_tracer.record_sql = raw
 # threshold, then capture and send to the UI the current stack
 # trace. This is helpful for pinpointing where long SQL calls
 # originate from in an application.
-transaction_tracer.stack_trace_threshold = 0.5
+# Lowered from 0.5 to 0.1 to catch N+1 query patterns (individual queries
+# 50-200ms but compound) with stack traces.
+transaction_tracer.stack_trace_threshold = 0.1
 
 # Determines whether the agent will capture query plans for slow
 # SQL queries. Only supported in MySQL and PostgreSQL. Set this
@@ -149,12 +154,29 @@ transaction_tracer.explain_enabled = true
 # Threshold for query execution time below which query plans
 # will not not be captured. Relevant only when "explain_enabled"
 # is true.
-transaction_tracer.explain_threshold = 0.5
+transaction_tracer.explain_threshold = 0.1
 
 # Space separated list of function or method names in form
 # 'module:function' or 'module:class.function' for which
 # additional function timing instrumentation will be added.
+#
+# Targets are hot paths identified in the 2026-04-23 workshop postmortem:
+# - OccurrenceViewSet.list + serializer/model methods drive /api/v2/occurrences/
+# - JobViewSet.result is the /result/ POST handler (Pydantic-heavy)
+# - run_job / process_nats_pipeline_result are the Celery sync + async paths
+#
+# NOTE: rename-fragile. If any of these symbols move/rename, the agent
+# silently stops tracing them with no error. Audit on view/serializer
+# refactors.
 transaction_tracer.function_trace =
+    ami.main.api.views:OccurrenceViewSet.list
+    ami.main.api.serializers:OccurrenceListSerializer.get_determination_details
+    ami.main.models:Occurrence.detection_images
+    ami.main.models:Occurrence.best_prediction
+    ami.main.models:Occurrence.best_identification
+    ami.jobs.views:JobViewSet.result
+    ami.jobs.tasks:run_job
+    ami.jobs.tasks:process_nats_pipeline_result
 
 # The error collector captures information about uncaught
 # exceptions or logged exceptions and sends them to UI for

--- a/config/newrelic.ini
+++ b/config/newrelic.ini
@@ -152,7 +152,7 @@ transaction_tracer.stack_trace_threshold = 0.1
 transaction_tracer.explain_enabled = true
 
 # Threshold for query execution time below which query plans
-# will not not be captured. Relevant only when "explain_enabled"
+# will not be captured. Relevant only when "explain_enabled"
 # is true.
 transaction_tracer.explain_threshold = 0.1
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -97,6 +97,6 @@ pytest-django==4.5.2  # https://github.com/pytest-dev/pytest-django
 # @TODO move to Python Poetry or pyproject.toml for dependencies
 # ------------------------------------------------------------------------------
 
-newrelic==9.6.0
+newrelic==12.1.0
 gunicorn==23.0.0  # https://github.com/benoitc/gunicorn
 # psycopg[c]==3.1.9  # https://github.com/psycopg/psycopg

--- a/scripts/check_newrelic_function_trace.py
+++ b/scripts/check_newrelic_function_trace.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+"""Verify config/newrelic.ini transaction_tracer.function_trace entries.
+
+Every entry must resolve to a real symbol in the repo. New Relic silently
+drops traces for renamed/missing symbols with no error, so a stale entry
+can hide useful telemetry indefinitely. This guard fails CI when an
+entry stops resolving.
+
+Uses AST instead of import so no Django bootstrap is required.
+"""
+from __future__ import annotations
+
+import ast
+import configparser
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+INI_PATH = REPO_ROOT / "config" / "newrelic.ini"
+
+
+def find_symbol(tree: ast.Module, dotted: str) -> bool:
+    parts = dotted.split(".")
+    nodes: list[ast.stmt] = list(tree.body)
+    for part in parts:
+        match: ast.stmt | None = None
+        for node in nodes:
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == part:
+                match = node
+                break
+        if match is None:
+            return False
+        nodes = list(match.body) if isinstance(match, ast.ClassDef) else []
+    return True
+
+
+def main() -> int:
+    cfg = configparser.ConfigParser()
+    cfg.read(INI_PATH)
+    raw = cfg.get("newrelic", "transaction_tracer.function_trace", fallback="")
+    entries = [line.strip() for line in raw.splitlines() if line.strip()]
+
+    if not entries:
+        print("No transaction_tracer.function_trace entries to check.")
+        return 0
+
+    missing: list[tuple[str, str]] = []
+    for entry in entries:
+        module, _, dotted = entry.partition(":")
+        if not dotted:
+            missing.append((entry, "expected 'module:symbol' form"))
+            continue
+        path = REPO_ROOT / pathlib.Path(*module.split(".")).with_suffix(".py")
+        if not path.exists():
+            missing.append((entry, f"module file not found: {path.relative_to(REPO_ROOT)}"))
+            continue
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError as e:
+            missing.append((entry, f"syntax error in {path.relative_to(REPO_ROOT)}: {e}"))
+            continue
+        if not find_symbol(tree, dotted):
+            missing.append((entry, f"symbol '{dotted}' not found in {path.relative_to(REPO_ROOT)}"))
+
+    if missing:
+        print("ERROR: newrelic.ini function_trace entries that do not resolve:", file=sys.stderr)
+        for entry, reason in missing:
+            print(f"  - {entry}\n      {reason}", file=sys.stderr)
+        print(
+            "\nFix: update config/newrelic.ini to point at the real symbol, " "or remove the entry.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"All {len(entries)} function_trace entries resolved.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Upgrade `newrelic` Python agent: `9.6.0` → `12.1.0` (three majors behind).
- Default `config/newrelic.ini` to **production-safe** values; staging/demo opts into more aggressive tracing via `NEW_RELIC_*` env vars on the live VM.
- Add `NEW_RELIC_*` override surface to `.envs/.production/.django-example` so per-env tuning lives next to the rest of the deploy config.
- Add a CI guard against silent `function_trace` rename drift.

## The big one: agent upgrade should finally restore DB call visibility

`databaseCallCount` has been `null` on antenna's web transactions for a long time (noted in `docs/claude/TRIAGE_GUIDE.md:135`). Standing theory was "ASGI + uvicorn workers, NR can't follow async context." That theory was wrong, or at best partial.

The actual cause: **`newrelic` 9.6.0 has no instrumentation for psycopg3.** psycopg3 support landed in agent **10.2** (mid-2024). Antenna pins `psycopg[binary]==3.1.9` in `requirements/base.txt:56`, so every cursor call has been going through an uninstrumented driver since the switch to psycopg3. The agent saw `requests` in, `requests` out, and nothing in between.

Upgrading to **12.1.0** picks up:

- **10.2** — psycopg3 instrumentation (the main fix here)
- **10.7** — native asyncio task instrumentation (helps the ASGI side)
- **11.x** — improved DRF view introspection
- **12.x** — Pydantic v2 native traces, better Celery 5.4 chain visibility

After merge + deploy, expect to see for the first time:

- `databaseCallCount`, `databaseDuration` populated on web `Transaction` events
- `Span WHERE category = 'datastore'` returning rows in NRQL
- SQL statements appearing in the Databases tab in NR APM
- `db.statement`, `db.instance`, `peer.hostname` attributes on datastore spans

If DB call counts are *still* null after this, then the ASGI theory was the right secondary cause and we'd need to look at `async_to_sync` wrappings.

## Production-safe ini defaults, env-var-driven per-env tuning

Key shift from earlier revisions of this PR: the common `[newrelic]` section now ships **production-safe** values. Aggressive demo/staging values live as commented `NEW_RELIC_*` overrides in `.envs/.production/.django-example`. Each env opts in at deploy time without touching the antenna repo.

### Common defaults (active, prod-safe)

| Setting | Value | Why |
|---------|-------|-----|
| `transaction_threshold` | `apdex_f` (~2s) | No risk of NR trace-cap hit on prod QPS |
| `stack_trace_threshold` | `0.5` | Default; lower on demo via env var |
| `explain_threshold` | `0.5` | `EXPLAIN` does not hammer prod DB |
| `record_sql` | `obfuscated` | No literals leak into NR UI |
| `slow_sql.enabled` | `true` (explicit) | Independent collector from transaction tracer; pin so future agent upgrade can't flip it off |
| `datastore_tracer.instance_reporting` + `database_name_reporting` | `true` (explicit) | Tag spans with `db.instance` / `peer.hostname` for facetable queries |
| `function_trace` | 8 hot-path symbols | NR auto-instruments middleware + view dispatch + DB driver but does not descend into Python method bodies. List makes `OccurrenceListSerializer.get_determination_details`, `Occurrence.best_prediction`, `JobViewSet.result`, `run_job`, `process_nats_pipeline_result` visible. |

### Per-env overrides (`.envs/.production/.django-example`)

- Identity: `LICENSE_KEY`, `APP_NAME`, `MONITOR_MODE`, `LOG_LEVEL`, `HIGH_SECURITY`
- **`APDEX_T`** (controls `apdex_f = 4×T`) — raise if antenna's normal latency drifts upward and Apdex should track user expectations rather than alert on every slow query
- Tracer thresholds for staging/demo (`THRESHOLD=0.5`, `STACK_TRACE=0.1`, `EXPLAIN=0.1`, `RECORD_SQL=raw`) and a production block (defaults are already safe, lines stay commented unless wanted explicit)
- Privacy: `ATTRIBUTES_INCLUDE=request.parameters.*` with sibling `ATTRIBUTES_EXCLUDE` for auth headers
- Logging caps: `APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED`
- Sample caps: `TRANSACTION_EVENTS_MAX_SAMPLES_STORED` / `SPAN_EVENTS_MAX_SAMPLES_STORED` for trace-cap pressure

### What deploys do after merge

- **Production**: no env-var action needed. Ini defaults are production-safe. Agent bump + DB instrumentation kick in automatically. Conservative tracing stays conservative.
- **Staging / demo**: uncomment the staging block in each box's `.envs/.production/.django` to opt into aggressive tracing. Without that step, staging/demo behaves like prod (trace-light) — trade for maturity.

### Why env vars over `[newrelic:<env>]` sections

The `[newrelic:staging]` / `[newrelic:production]` ini sections only activate when `NEW_RELIC_ENVIRONMENT` matches the section name. Current deploy configs set `NEW_RELIC_ENVIRONMENT=local`, so neither section ever matched anyway. Env vars are the real mechanism. Verbose per-section override blocks deleted from the ini accordingly.

## Function-trace symbol verification

Verified every symbol path before listing it — proposal had `JobResultView.post`, actual is `JobViewSet.result`. Corrected.

`scripts/check_newrelic_function_trace.py` — AST-walks every entry, verifies the module file exists and the symbol resolves. Stdlib only, runs in <1s. Wired into the lint job. Catches silent rename drift (the NR agent doesn't warn when a listed symbol disappears — it just stops collecting). Already passing on the latest commit.

## Skipped from proposal

- **cachalot import-hook** — requires a code drop, not config-only. Real blind spot (cache hits = no SQL = no NR span) but separate PR.

## Changes

| File | Change |
|------|--------|
| `requirements/base.txt` | `newrelic==9.6.0` → `newrelic==12.1.0` |
| `config/newrelic.ini` | Production-safe defaults + 8-symbol `function_trace` list; verbose per-env override blocks removed |
| `.envs/.production/.django-example` | `NEW_RELIC_*` override surface for staging/demo and production deploys |
| `scripts/check_newrelic_function_trace.py` | New AST-based symbol-resolution check |
| `.github/workflows/test.backend.yml` | Wire check into lint job |

## Test plan

- [x] CI lint job passes — `check_newrelic_function_trace.py` resolves all 8 entries.
- [ ] CI test job builds the django + celeryworker images with `newrelic 12.1.0` cleanly.
- [ ] After deploy to demo: `docker compose logs django | grep -i 'new relic'` shows agent init at 12.1.0 with no config errors.
- [ ] **Headline check** — within ~5min of post-deploy traffic, NRQL `SELECT count(*) FROM Transaction WHERE appName = 'AMI Backend' AND databaseCallCount IS NOT NULL SINCE 10 minutes ago` returns non-zero. If still zero, ASGI is the secondary cause.
- [ ] After opting demo into the staging override block in `.envs/.production/.django`: 10–100× more transaction traces, with inline `OccurrenceListSerializer.get_determination_details` spans on `/api/v2/occurrences/` traces. SQL statements + EXPLAIN plans appear on the Databases tab.
- [ ] No regression in transaction throughput / error rate on demo over 1h.