### PR TITLE
fix(monitoring): allow distinguishing data from different deployments in New Relic

### DIFF
--- a/.envs/.production/.django-example
+++ b/.envs/.production/.django-example
@@ -62,8 +62,19 @@ SENDGRID_API_KEY=
 NEW_RELIC_CONFIG_FILE=/app/config/newrelic.ini
 NEW_RELIC_ENVIRONMENT=development
 # NEW_RELIC_LICENSE_KEY=        # overrides license_key in ini (preferred — keep key out of repo)
-# NEW_RELIC_APP_NAME=AMI Backend (Demo)
 # NEW_RELIC_MONITOR_MODE=true   # set false to silence the agent without removing it
+#
+# REQUIRED per deploy — config/newrelic.ini intentionally does not set
+# app_name. Examples (use the "Antenna Backend (<env>)" pattern for any
+# new entity; the legacy "AMI Backend (Staging)" entity already exists
+# in NR and can keep that name for history continuity if desired):
+#   NEW_RELIC_APP_NAME=Antenna Backend (live)       # production
+#   NEW_RELIC_APP_NAME=Antenna Backend (Demo)       # demo
+#   NEW_RELIC_APP_NAME=Antenna Backend (Staging)    # staging (new entity)
+#   NEW_RELIC_APP_NAME=Antenna Backend (preview-N)  # ephemeral preview stacks
+# Missing → agent reports under the literal name "Python Application", which
+# is an easy-to-spot orphan rather than a silent merge into another env.
+NEW_RELIC_APP_NAME=Antenna Backend (development)
 # NEW_RELIC_LOG_LEVEL=info      # bump to debug only when reproducing an agent issue
 # NEW_RELIC_HIGH_SECURITY=false # true forces obfuscated SQL + drops request params, irreversible per app
 #

--- a/config/newrelic.ini
+++ b/config/newrelic.ini
@@ -40,7 +40,17 @@ license_key = a36747a6cc9bc083de03a9fb51dc4d32FFFFNRAL
 # app names to group your aggregated data. For further details,
 # please see:
 # https://docs.newrelic.com/docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app/
-app_name = AMI Backend
+#
+# app_name is intentionally NOT set here. Each deploy supplies it via the
+# NEW_RELIC_APP_NAME env var in .envs/.production/.django. The env var only
+# wins if no [newrelic*] section in this file sets app_name — so leaving
+# it unset here (and in every [newrelic:<env>] section below) is what
+# makes env-var-driven naming work in agent 12.1.0.
+#
+# Missing env var → agent reports under the literal name "Python
+# Application" (a recognizable orphan), not silently merged into another
+# env's entity. This is the failure mode we want — visible misconfig,
+# not silent data pollution.
 
 # When "true", the agent collects performance data about your
 # application and reports this data to the New Relic UI at
@@ -286,7 +296,6 @@ application_logging.metrics.enabled = true
 #
 
 [newrelic:development]
-app_name = AMI Backend (Development)
 # monitor_mode = true
 monitor_mode = false
 
@@ -294,15 +303,20 @@ monitor_mode = false
 monitor_mode = false
 
 [newrelic:staging]
-app_name = AMI Backend (Staging)
 monitor_mode = true
 
 [newrelic:production]
 monitor_mode = true
 
-# Per-env tuning lives in .envs/.production/.django (template:
-# .envs/.production/.django-example). Common defaults in this file are
-# production-safe; staging/demo opts into more aggressive tracing via
-# NEW_RELIC_* env vars at deploy time.
+# NOTE on app_name: per-env app_name is supplied via the NEW_RELIC_APP_NAME
+# env var, not via a [newrelic:<env>] override here. None of the sections
+# above set app_name, so the env var is free to define it at deploy time.
+# This is what makes dynamic preview-stack deploys work without churning
+# this file.
+#
+# Per-env tuning (sample rates, tracer thresholds, etc.) also lives in
+# .envs/.production/.django (template: .envs/.production/.django-example).
+# Common defaults in this file are production-safe; staging/demo opts into
+# more aggressive tracing via NEW_RELIC_* env vars at deploy time.
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Narrow follow-up to #1299. The `NEW_RELIC_APP_NAME` env var is **silently ignored** by `newrelic` agent **12.1.0** when any `[newrelic*]` section in `config/newrelic.ini` sets `app_name`. The previous PR removed it from `[newrelic:production]` only and assumed the env var would supply it — but the *base* `[newrelic]` section still set it, so the env var was never consulted.

This PR drops `app_name` from *every* `[newrelic*]` section, making `NEW_RELIC_APP_NAME` in `.envs/.production/.django` the single source of truth. This is the only configuration shape that actually lets per-deploy app naming work in 12.1.0, and it suits the upcoming dynamic preview stacks (each preview sets its own `NEW_RELIC_APP_NAME` at spawn time, no repo churn).

## Evidence

Reproduced inside a deployed django container (agent 12.1.0):

```
$ docker exec <c> newrelic-admin run-program python -c \
  ""from newrelic.core.config import global_settings; \
   import os; \
   print('env:', repr(os.environ.get('NEW_RELIC_APP_NAME'))); \
   print('app:', repr(global_settings().app_name))""

env: 'Antenna Backend (Demo)'
app: 'AMI Backend'         ← base ini wins, env var ignored
```

Comment out the base `app_name = AMI Backend` line in a temp ini and re-run with the same env var:

```
env: 'Antenna Backend (Demo)'
app: 'Antenna Backend (Demo)'  ← env var now resolves
```

Confirms the ini base entry — not the env var read path — is the blocker. Removing `app_name` from the ini is the fix.

## Failure mode is visible, not silent

If a deploy forgets to set `NEW_RELIC_APP_NAME`, the agent reports under the literal name `Python Application`. That is an easy-to-spot orphan in NR's APM list, not a silent merge into another env's entity. Verified:

```
# (no env var, no ini app_name)
$ ... print(global_settings().app_name)
'Python Application'
```

This is the opposite of the pre-fix behavior, which (combined with an NR account-side alias mapping `AMI Backend` → the production entity) caused unrelated deploys to silently merge into prod APM metrics. That issue is what surfaced this PR.

## Suits dynamic preview stacks

Per-PR / per-branch preview stacks set `NEW_RELIC_APP_NAME` at spawn time without committing a new `[newrelic:<env>]` section to this repo for every ephemeral environment.

## Deploy coordination — required before merge

Each long-lived environment must set `NEW_RELIC_APP_NAME` in its deploy-time `.envs/.production/.django` **before** this lands. Suggested values (use the `Antenna Backend (<env>)` pattern for any new entity; the legacy `AMI Backend (Staging)` entity already exists in NR and can keep that name for history continuity if preferred):

| Env | NEW_RELIC_APP_NAME |
|-----|--------------------|
| production | `Antenna Backend (live)` |
| demo | `Antenna Backend (Demo)` |
| staging | `Antenna Backend (Staging)` *(new)* or `AMI Backend (Staging)` *(keep)* |
| preview stacks | `Antenna Backend (preview-<id>)` |

Adding the env var on hosts where the ini still sets `app_name` is a no-op today (ini wins), so it can be staged in advance of merging without risk.

## Test plan

- [x] In a running django container, build a temp ini with no `app_name` anywhere + set `NEW_RELIC_APP_NAME` env var → `global_settings()` resolves to the env var value.
- [x] Same with no env var set → resolves to `Python Application` (confirmed orphan, no silent merge).
- [x] Confirmed in NR APM with the corresponding ini hot-patch on one env: agent registers under the env-var name, transactions land in the expected entity (not another env's entity).
- [ ] After deploy: each env's `appName` in NR matches the value of its `NEW_RELIC_APP_NAME` env var; no env reports as `Python Application` or `AMI Backend`.
- [ ] Agent log shows `NR-Activate-Session/<expected app name>` per env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)