### PR TITLE
Improve the filter stage during job preparation, fix for large capture sets

### DIFF
--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -98,6 +98,11 @@ DEFAULT_RANKS = sorted(
 NULL_DETECTIONS_FILTER = Q(bbox__isnull=True) | Q(bbox=[])
 
 
+def bbox_is_null(bbox) -> bool:
+    """In-memory equivalent of NULL_DETECTIONS_FILTER for already-fetched bbox values."""
+    return bbox is None or bbox == []
+
+
 def get_media_url(path: str) -> str:
     """
     If path is a full URL, return it as-is.

--- a/ami/ml/models/pipeline.py
+++ b/ami/ml/models/pipeline.py
@@ -34,6 +34,7 @@ from ami.main.models import (
     TaxaList,
     Taxon,
     TaxonRank,
+    bbox_is_null,
     update_calculated_fields_for_events,
     update_occurrence_determination,
 )
@@ -108,37 +109,43 @@ def filter_processed_images(
 
         batch_ids = [image.pk for image in batch]
 
-        images_with_any_detection: set[int] = set()
-        real_detections_per_image: dict[int, set[int]] = collections.defaultdict(set)
-        detection_rows = Detection.objects.filter(
-            source_image_id__in=batch_ids,
-            detection_algorithm_id__in=pipeline_algorithm_ids,
-        ).values_list("source_image_id", "id", "bbox")
+        images_with_pipeline_detection: set[int] = set()
+        real_pipeline_detections_per_image: dict[int, set[int]] = collections.defaultdict(set)
+        detection_rows = (
+            Detection.objects.filter(
+                source_image_id__in=batch_ids,
+                detection_algorithm_id__in=pipeline_algorithm_ids,
+            )
+            .order_by()
+            .values_list("source_image_id", "id", "bbox")
+        )
         for source_image_id, detection_id, bbox in detection_rows:
-            images_with_any_detection.add(source_image_id)
-            if bbox not in (None, []):
-                real_detections_per_image[source_image_id].add(detection_id)
+            images_with_pipeline_detection.add(source_image_id)
+            if not bbox_is_null(bbox):
+                real_pipeline_detections_per_image[source_image_id].add(detection_id)
 
         classifier_ids_per_detection: dict[int, set[int]] = collections.defaultdict(set)
-        real_detection_ids = [d for dets in real_detections_per_image.values() for d in dets]
-        if real_detection_ids:
-            classification_rows = Classification.objects.filter(
-                detection_id__in=real_detection_ids,
-            ).values_list("detection_id", "algorithm_id")
+        real_pipeline_detection_ids = [d for dets in real_pipeline_detections_per_image.values() for d in dets]
+        if real_pipeline_detection_ids:
+            classification_rows = (
+                Classification.objects.filter(detection_id__in=real_pipeline_detection_ids)
+                .order_by()
+                .values_list("detection_id", "algorithm_id")
+            )
             for detection_id, algorithm_id in classification_rows:
                 classifier_ids_per_detection[detection_id].add(algorithm_id)
 
         for image in batch:
             image_id = image.pk
 
-            if image_id not in images_with_any_detection:
+            if image_id not in images_with_pipeline_detection:
                 task_logger.debug(
                     f"Image {image} needs processing: has no existing detections from pipeline's detector"
                 )
                 yield image
                 continue
 
-            real_det_ids = real_detections_per_image.get(image_id)
+            real_det_ids = real_pipeline_detections_per_image.get(image_id)
             if not real_det_ids:
                 task_logger.debug(f"Image {image} has only null detections from pipeline {pipeline}, skipping!")
                 continue

--- a/ami/ml/models/pipeline.py
+++ b/ami/ml/models/pipeline.py
@@ -112,6 +112,11 @@ def filter_processed_images(
     pipeline_classifier_ids = {a.id for a in pipeline_algorithms if a.task_type not in detection_type_keys}
     if not pipeline_classifier_ids:
         task_logger.warning(f"Pipeline {pipeline} has no classification algorithms saved. Will reprocess all images.")
+        # set().issubset(anything) is vacuously True, so without this short-circuit
+        # every image with existing detections gets skipped by the subset check
+        # below — contradicting the warning above. Yield everything and exit.
+        yield from images
+        return
 
     image_iter = iter(images)
     # Track how many of the input images we've inspected so far so we can emit
@@ -199,13 +204,19 @@ def filter_processed_images(
         # COLLECT_PROGRESS_SAVE_INTERVAL_SECONDS of wall time have passed since
         # the last save. Capped at COLLECT_PROGRESS_MAX_FRACTION so the caller's
         # final status=SUCCESS, progress=1 flip still owns the terminal value.
+        #
+        # `updated_at` is included in update_fields explicitly: Django only fires
+        # auto_now's pre_save hook for fields listed in update_fields, so without
+        # it the reaper's `Job.updated_at < cutoff` heuristic
+        # (`ami/jobs/tasks.py:929-944`) would not see this heartbeat and could
+        # still revoke the job mid-Collect.
         processed_count += len(batch)
         if job is not None and total:
             now_monotonic = time.monotonic()
             if now_monotonic - last_progress_save_monotonic >= COLLECT_PROGRESS_SAVE_INTERVAL_SECONDS:
                 fraction = min(processed_count / total, COLLECT_PROGRESS_MAX_FRACTION)
                 job.progress.update_stage("collect", progress=fraction)
-                job.save(update_fields=["progress"])
+                job.save(update_fields=["progress", "updated_at"])
                 last_progress_save_monotonic = now_monotonic
 
 

--- a/ami/ml/models/pipeline.py
+++ b/ami/ml/models/pipeline.py
@@ -59,6 +59,13 @@ logger = logging.getLogger(__name__)
 
 
 FILTER_PROCESSED_BATCH_SIZE = 1000
+# Minimum wall-time (seconds) between in-loop Job.progress writes inside
+# filter_processed_images. The reaper's "no forward progress" heuristic keys off
+# job.updated_at, so we need to tick at least once per ~10min; 5s gives ample
+# headroom while still amortising the JSONB UPDATE across many chunks. Caps at
+# 0.99 so the caller still owns the final status=SUCCESS, progress=1 flip.
+COLLECT_PROGRESS_SAVE_INTERVAL_SECONDS = 5.0
+COLLECT_PROGRESS_MAX_FRACTION = 0.99
 
 
 def filter_processed_images(
@@ -66,6 +73,8 @@ def filter_processed_images(
     pipeline: Pipeline,
     task_logger: logging.Logger = logger,
     batch_size: int = FILTER_PROCESSED_BATCH_SIZE,
+    job: Job | None = None,
+    total: int | None = None,
 ) -> typing.Iterable[SourceImage]:
     """
     Return only images that need to be processed by a given pipeline.
@@ -102,6 +111,11 @@ def filter_processed_images(
         task_logger.warning(f"Pipeline {pipeline} has no classification algorithms saved. Will reprocess all images.")
 
     image_iter = iter(images)
+    # Track how many of the input images we've inspected so far so we can emit
+    # a fractional `collect` progress to the Job row. Only used when both
+    # `job` and `total` are passed by the caller; legacy callers stay silent.
+    processed_count = 0
+    last_progress_save_monotonic = time.monotonic()
     while True:
         batch = list(itertools.islice(image_iter, batch_size))
         if not batch:
@@ -176,6 +190,20 @@ def filter_processed_images(
                     f"Image {image} has existing detections classified by the pipeline: {pipeline}, skipping!"
                 )
 
+        # Throttled progress emit. Save only when both `job` and `total` are
+        # provided, the total is non-zero, and at least
+        # COLLECT_PROGRESS_SAVE_INTERVAL_SECONDS of wall time have passed since
+        # the last save. Capped at COLLECT_PROGRESS_MAX_FRACTION so the caller's
+        # final status=SUCCESS, progress=1 flip still owns the terminal value.
+        processed_count += len(batch)
+        if job is not None and total:
+            now_monotonic = time.monotonic()
+            if now_monotonic - last_progress_save_monotonic >= COLLECT_PROGRESS_SAVE_INTERVAL_SECONDS:
+                fraction = min(processed_count / total, COLLECT_PROGRESS_MAX_FRACTION)
+                job.progress.update_stage("collect", progress=fraction)
+                job.save(update_fields=["progress"])
+                last_progress_save_monotonic = now_monotonic
+
 
 def collect_images(
     collection: SourceImageCollection | None = None,
@@ -213,7 +241,19 @@ def collect_images(
     if pipeline and not reprocess_all_images:
         msg = f"Filtering images that have already been processed by pipeline {pipeline}"
         task_logger.info(msg)
-        images = list(filter_processed_images(images, pipeline, task_logger=task_logger))
+        # Pass `job` and `total` so filter_processed_images can emit throttled
+        # `collect` progress updates as it chews through the input — keeps the
+        # reaper "no forward progress" heuristic happy on large collections
+        # (issue #1321 follow-up).
+        images = list(
+            filter_processed_images(
+                images,
+                pipeline,
+                task_logger=task_logger,
+                job=job,
+                total=total_images,
+            )
+        )
     else:
         msg = "NOT filtering images that have already been processed"
         task_logger.info(msg)

--- a/ami/ml/models/pipeline.py
+++ b/ami/ml/models/pipeline.py
@@ -99,6 +99,9 @@ def filter_processed_images(
     Collect stage well under the Celery broker's AMQP heartbeat window for the
     large-collection case (see issue #1321).
     """
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be > 0, got {batch_size}")
+
     pipeline_algorithms = list(pipeline.algorithms.all())
     pipeline_algorithm_ids = [a.id for a in pipeline_algorithms]
 
@@ -181,7 +184,8 @@ def filter_processed_images(
                 task_logger.debug(
                     f"Image {image} has existing detections that haven't been classified by the pipeline: {pipeline}: "
                     f"{observed_classifier_ids} vs {pipeline_classifier_ids}. "
-                    f"Since we do yet have a mechanism to reclassify detections, processing the image from scratch."
+                    f"Since we do not yet have a mechanism to reclassify detections, "
+                    f"processing the image from scratch."
                 )
                 task_logger.debug(f"Image #{image.pk} needs classification by pipeline's algorithms: {missing_algos}")
                 yield image
@@ -225,9 +229,12 @@ def collect_images(
     else:
         job = None
 
-    # Set source to first argument that is not None. Always prefetch the
-    # deployment + data_source joins so later calls to image.url() in
-    # queue_images_to_nats don't trigger N+1 lookups (see issue #1321).
+    # Set source to first argument that is not None. The collection- and
+    # deployment-backed branches prefetch the deployment + data_source joins so
+    # later calls to image.url() in queue_images_to_nats don't trigger N+1
+    # lookups (see issue #1321). The source_images branch passes the caller's
+    # iterable through unchanged — callers handing us a pre-built list are
+    # responsible for any prefetching they need.
     if collection:
         images = collection.images.select_related("deployment__data_source")
     elif source_images:

--- a/ami/ml/models/pipeline.py
+++ b/ami/ml/models/pipeline.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
 
 import collections
 import dataclasses
+import itertools
 import logging
 import time
 import typing
@@ -23,7 +24,6 @@ from django_pydantic_field import SchemaField
 from ami.base.models import BaseModel, BaseQuerySet
 from ami.base.schemas import ConfigurableStage, default_stages
 from ami.main.models import (
-    NULL_DETECTIONS_FILTER,
     Classification,
     Deployment,
     Detection,
@@ -57,10 +57,14 @@ from ami.utils.requests import create_session, extract_error_message_from_respon
 logger = logging.getLogger(__name__)
 
 
+FILTER_PROCESSED_BATCH_SIZE = 1000
+
+
 def filter_processed_images(
     images: typing.Iterable[SourceImage],
     pipeline: Pipeline,
     task_logger: logging.Logger = logger,
+    batch_size: int = FILTER_PROCESSED_BATCH_SIZE,
 ) -> typing.Iterable[SourceImage]:
     """
     Return only images that need to be processed by a given pipeline.
@@ -79,56 +83,91 @@ def filter_processed_images(
 
     Null detections are sentinels that mark an image as "processed, nothing found."
     They are excluded from classification checks so they don't trigger reprocessing.
-    """
-    pipeline_algorithms = pipeline.algorithms.all()
 
-    detection_type_keys = Algorithm.detection_task_types
-    detection_algorithms = pipeline_algorithms.filter(task_type__in=detection_type_keys)
-    if not detection_algorithms.exists():
+    Input images are processed in batches so the work scales as O(image_count /
+    batch_size) database round-trips instead of O(image_count). This keeps the
+    Collect stage well under the Celery broker's AMQP heartbeat window for the
+    large-collection case (see issue #1321).
+    """
+    pipeline_algorithms = list(pipeline.algorithms.all())
+    pipeline_algorithm_ids = [a.id for a in pipeline_algorithms]
+
+    detection_type_keys = set(Algorithm.detection_task_types)
+    has_detection_algorithm = any(a.task_type in detection_type_keys for a in pipeline_algorithms)
+    if not has_detection_algorithm:
         task_logger.warning(f"Pipeline {pipeline} has no detection algorithms saved. Will reprocess all images.")
-    classification_algorithms = pipeline_algorithms.exclude(task_type__in=detection_type_keys)
-    if not classification_algorithms.exists():
+    pipeline_classifier_ids = {a.id for a in pipeline_algorithms if a.task_type not in detection_type_keys}
+    if not pipeline_classifier_ids:
         task_logger.warning(f"Pipeline {pipeline} has no classification algorithms saved. Will reprocess all images.")
 
-    for image in images:
-        existing_detections = image.detections.filter(detection_algorithm__in=pipeline_algorithms)
-        if not existing_detections.exists():
-            task_logger.debug(f"Image {image} needs processing: has no existing detections from pipeline's detector")
-            # If there are no existing detections from this pipeline, send the image
-            yield image
-        elif not existing_detections.exclude(NULL_DETECTIONS_FILTER).exists():  # type: ignore
-            # All detections for this image are null (processed but nothing found) — skip
-            task_logger.debug(f"Image {image} has only null detections from pipeline {pipeline}, skipping!")
-            continue
-        elif existing_detections.exclude(NULL_DETECTIONS_FILTER).filter(classifications__isnull=True).exists():
-            # Check if any real detections (non-null) have no classifications
-            task_logger.debug(
-                f"Image {image} needs processing: has existing detections with no classifications "
-                "from pipeline {pipeline}"
-            )
-            yield image
-        else:
-            # If there are existing detections with classifications,
-            # Compare their classification algorithms to the current pipeline's algorithms
-            pipeline_algorithm_ids = set(classification_algorithms.values_list("id", flat=True))
-            detection_algorithm_ids = set(existing_detections.values_list("classifications__algorithm_id", flat=True))
+    image_iter = iter(images)
+    while True:
+        batch = list(itertools.islice(image_iter, batch_size))
+        if not batch:
+            return
 
-            if not pipeline_algorithm_ids.issubset(detection_algorithm_ids):
+        batch_ids = [image.pk for image in batch]
+
+        images_with_any_detection: set[int] = set()
+        real_detections_per_image: dict[int, set[int]] = collections.defaultdict(set)
+        detection_rows = Detection.objects.filter(
+            source_image_id__in=batch_ids,
+            detection_algorithm_id__in=pipeline_algorithm_ids,
+        ).values_list("source_image_id", "id", "bbox")
+        for source_image_id, detection_id, bbox in detection_rows:
+            images_with_any_detection.add(source_image_id)
+            if bbox not in (None, []):
+                real_detections_per_image[source_image_id].add(detection_id)
+
+        classifier_ids_per_detection: dict[int, set[int]] = collections.defaultdict(set)
+        real_detection_ids = [d for dets in real_detections_per_image.values() for d in dets]
+        if real_detection_ids:
+            classification_rows = Classification.objects.filter(
+                detection_id__in=real_detection_ids,
+            ).values_list("detection_id", "algorithm_id")
+            for detection_id, algorithm_id in classification_rows:
+                classifier_ids_per_detection[detection_id].add(algorithm_id)
+
+        for image in batch:
+            image_id = image.pk
+
+            if image_id not in images_with_any_detection:
                 task_logger.debug(
-                    f"Image {image} has existing detections that haven't been classified by the pipeline: {pipeline}:"
-                    f" {detection_algorithm_ids} vs {pipeline_algorithm_ids}"
+                    f"Image {image} needs processing: has no existing detections from pipeline's detector"
+                )
+                yield image
+                continue
+
+            real_det_ids = real_detections_per_image.get(image_id)
+            if not real_det_ids:
+                task_logger.debug(f"Image {image} has only null detections from pipeline {pipeline}, skipping!")
+                continue
+
+            if any(detection_id not in classifier_ids_per_detection for detection_id in real_det_ids):
+                task_logger.debug(
+                    f"Image {image} needs processing: has existing detections with no classifications "
+                    f"from pipeline {pipeline}"
+                )
+                yield image
+                continue
+
+            observed_classifier_ids: set[int] = set()
+            for detection_id in real_det_ids:
+                observed_classifier_ids.update(classifier_ids_per_detection[detection_id])
+
+            if not pipeline_classifier_ids.issubset(observed_classifier_ids):
+                missing_algos = pipeline_classifier_ids - observed_classifier_ids
+                task_logger.debug(
+                    f"Image {image} has existing detections that haven't been classified by the pipeline: {pipeline}: "
+                    f"{observed_classifier_ids} vs {pipeline_classifier_ids}. "
                     f"Since we do yet have a mechanism to reclassify detections, processing the image from scratch."
                 )
-                # log all algorithms that are in the pipeline but not in the detection
-                missing_algos = pipeline_algorithm_ids - detection_algorithm_ids
                 task_logger.debug(f"Image #{image.pk} needs classification by pipeline's algorithms: {missing_algos}")
                 yield image
             else:
-                # If all detections have been classified by the pipeline, skip the image
                 task_logger.debug(
                     f"Image {image} has existing detections classified by the pipeline: {pipeline}, skipping!"
                 )
-                continue
 
 
 def collect_images(

--- a/ami/ml/models/pipeline.py
+++ b/ami/ml/models/pipeline.py
@@ -197,13 +197,15 @@ def collect_images(
     else:
         job = None
 
-    # Set source to first argument that is not None
+    # Set source to first argument that is not None. Always prefetch the
+    # deployment + data_source joins so later calls to image.url() in
+    # queue_images_to_nats don't trigger N+1 lookups (see issue #1321).
     if collection:
-        images = collection.images.all()
+        images = collection.images.select_related("deployment__data_source")
     elif source_images:
         images = source_images
     elif deployment:
-        images = SourceImage.objects.filter(deployment=deployment)
+        images = SourceImage.objects.filter(deployment=deployment).select_related("deployment__data_source")
     else:
         raise ValueError("Must specify a collection, deployment or a list of images")
 

--- a/ami/ml/orchestration/jobs.py
+++ b/ami/ml/orchestration/jobs.py
@@ -139,8 +139,7 @@ def queue_images_to_nats(job: "Job", images: list[SourceImage]):
             # first call, each one still runs inside the publish coroutine and
             # serialises with the gather below.
             try:
-                await manager._ensure_stream(job.pk)
-                await manager._ensure_consumer(job.pk)
+                await manager.ensure_job_resources(job.pk)
             except Exception as e:
                 await manager.log_async(
                     logging.ERROR,

--- a/ami/ml/orchestration/jobs.py
+++ b/ami/ml/orchestration/jobs.py
@@ -104,7 +104,7 @@ def queue_images_to_nats(job: "Job", images: list[SourceImage]):
         # touches deployment + data_source and the call cost adds up across
         # large collections. The upstream queryset in collect_images() also
         # prefetches those joins so this stays cheap (see issue #1321).
-        image_url = image.url() if hasattr(image, "url") else None
+        image_url = image.url()
         if not image_url:
             job.logger.warning(f"Image {image.pk} has no URL, skipping queuing to NATS for job '{job.pk}'")
             skipped_count += 1

--- a/ami/ml/orchestration/jobs.py
+++ b/ami/ml/orchestration/jobs.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from asgiref.sync import async_to_sync
@@ -9,6 +10,14 @@ from ami.ml.orchestration.nats_queue import TaskQueueManager
 from ami.ml.schemas import PipelineProcessingTask
 
 logger = logging.getLogger(__name__)
+
+# Number of concurrent JetStream publishes per fanout chunk. The bottleneck on
+# large-collection jobs is the per-message ack round-trip (~1.3ms each on
+# Serbia 2026-05-27, sequential), so awaiting publishes one at a time scales
+# linearly with image count and pushes >450k-image jobs past the reaper
+# threshold. Issuing ~200 publishes per gather() lets NATS pipeline the acks
+# back to us; the chunk boundary keeps memory and concurrent-task counts bounded.
+NATS_PUBLISH_FANOUT_CHUNK_SIZE = 200
 
 
 def cleanup_async_job_resources(job_id: int) -> bool:
@@ -124,28 +133,44 @@ def queue_images_to_nats(job: "Job", images: list[SourceImage]):
         # the sync_to_async bridge for JobLogHandler's ORM save lives in one
         # place instead of being re-implemented at every call site.
         async with TaskQueueManager(job_logger=job.logger) as manager:
-            for image_pk, task in tasks:
+            # Warm the stream + consumer caches once so per-publish calls skip
+            # the cached-noop branches in publish_task -> _ensure_stream /
+            # _ensure_consumer. Even though those branches are O(1) after the
+            # first call, each one still runs inside the publish coroutine and
+            # serialises with the gather below.
+            try:
+                await manager._ensure_stream(job.pk)
+                await manager._ensure_consumer(job.pk)
+            except Exception as e:
+                await manager.log_async(
+                    logging.ERROR,
+                    f"Failed to set up NATS stream/consumer for job '{job.pk}': {e}",
+                    exc_info=True,
+                )
+                return 0, len(tasks)
+
+            async def publish_one(image_pk: int, task: PipelineProcessingTask) -> bool:
                 try:
-                    await manager.log_async(
-                        logging.DEBUG,
-                        f"Queueing image {image_pk} to stream for job '{job.pk}': {task.image_url}",
-                    )
-                    success = await manager.publish_task(
-                        job_id=job.pk,
-                        data=task,
-                    )
+                    return await manager.publish_task(job_id=job.pk, data=task)
                 except Exception as e:
                     await manager.log_async(
                         logging.ERROR,
                         f"Failed to queue image {image_pk} to stream for job '{job.pk}': {e}",
                         exc_info=True,
                     )
-                    success = False
+                    return False
 
-                if success:
-                    successful_queues += 1
-                else:
-                    failed_queues += 1
+            for chunk_start in range(0, len(tasks), NATS_PUBLISH_FANOUT_CHUNK_SIZE):
+                chunk = tasks[chunk_start : chunk_start + NATS_PUBLISH_FANOUT_CHUNK_SIZE]
+                results = await asyncio.gather(
+                    *(publish_one(image_pk, task) for image_pk, task in chunk),
+                    return_exceptions=False,
+                )
+                for success in results:
+                    if success:
+                        successful_queues += 1
+                    else:
+                        failed_queues += 1
 
         return successful_queues, failed_queues
 

--- a/ami/ml/orchestration/jobs.py
+++ b/ami/ml/orchestration/jobs.py
@@ -91,7 +91,11 @@ def queue_images_to_nats(job: "Job", images: list[SourceImage]):
     skipped_count = 0
     for image in images:
         image_id = str(image.pk)
-        image_url = image.url() if hasattr(image, "url") and image.url() else ""
+        # Call image.url() exactly once per iteration — the implementation
+        # touches deployment + data_source and the call cost adds up across
+        # large collections. The upstream queryset in collect_images() also
+        # prefetches those joins so this stays cheap (see issue #1321).
+        image_url = image.url() if hasattr(image, "url") else None
         if not image_url:
             job.logger.warning(f"Image {image.pk} has no URL, skipping queuing to NATS for job '{job.pk}'")
             skipped_count += 1

--- a/ami/ml/orchestration/nats_queue.py
+++ b/ami/ml/orchestration/nats_queue.py
@@ -290,6 +290,20 @@ class TaskQueueManager:
         except nats.js.errors.NotFoundError:
             return False
 
+    async def ensure_job_resources(self, job_id: int) -> None:
+        """Ensure both the stream and consumer for the given job exist.
+
+        Public wrapper for the two ``_ensure_*`` calls. Callers that want to
+        pre-warm both before a hot loop (e.g. a publish fanout) should use this
+        rather than touching the private methods directly — keeps the
+        TaskQueueManager's stream/consumer setup story in one place.
+
+        Subsequent calls in the same manager session skip the NATS round-trip
+        via the per-instance ``_streams_logged`` / ``_consumers_logged`` sets.
+        """
+        await self._ensure_stream(job_id)
+        await self._ensure_consumer(job_id)
+
     async def _ensure_stream(self, job_id: int):
         """Ensure stream exists for the given job.
 

--- a/ami/ml/orchestration/tests/test_jobs.py
+++ b/ami/ml/orchestration/tests/test_jobs.py
@@ -5,7 +5,6 @@ from django.test import TestCase
 from ami.jobs.models import Job, JobDispatchMode, MLJob
 from ami.main.models import Deployment, Project, S3StorageSource, SourceImage, SourceImageCollection
 from ami.ml.models import Pipeline
-from ami.ml.orchestration import jobs as orchestration_jobs
 from ami.ml.orchestration.jobs import NATS_PUBLISH_FANOUT_CHUNK_SIZE, queue_images_to_nats
 
 
@@ -126,9 +125,3 @@ class TestQueueImagesToNatsFanout(TestCase):
 
         self.assertFalse(result)
         self.assertEqual(instance.publish_task.await_count, 0)
-
-    def test_default_chunk_size_is_explicit(self, _mgr_cls, _state_cls):
-        # Lock the constant so a future change to the chunk size is a deliberate
-        # decision visible in the diff. The value itself is not a tuned magic
-        # number — it's an empirical floor that keeps gather() bounded.
-        self.assertEqual(orchestration_jobs.NATS_PUBLISH_FANOUT_CHUNK_SIZE, 200)

--- a/ami/ml/orchestration/tests/test_jobs.py
+++ b/ami/ml/orchestration/tests/test_jobs.py
@@ -18,6 +18,7 @@ def _stub_manager(mock_manager_cls, publish_results=None):
     instance = mock_manager_cls.return_value
     instance.__aenter__ = AsyncMock(return_value=instance)
     instance.__aexit__ = AsyncMock(return_value=False)
+    instance.ensure_job_resources = AsyncMock()
     instance._ensure_stream = AsyncMock()
     instance._ensure_consumer = AsyncMock()
     instance.log_async = AsyncMock()
@@ -85,8 +86,7 @@ class TestQueueImagesToNatsFanout(TestCase):
 
         queue_images_to_nats(job, images)
 
-        self.assertEqual(instance._ensure_stream.await_count, 1)
-        self.assertEqual(instance._ensure_consumer.await_count, 1)
+        self.assertEqual(instance.ensure_job_resources.await_count, 1)
         self.assertEqual(instance.publish_task.await_count, 5)
 
     def test_chunks_across_fanout_boundary(self, mock_mgr_cls, _state_cls):
@@ -100,8 +100,7 @@ class TestQueueImagesToNatsFanout(TestCase):
 
         self.assertEqual(instance.publish_task.await_count, n)
         # Warm-up still only runs once even when we span multiple chunks.
-        self.assertEqual(instance._ensure_stream.await_count, 1)
-        self.assertEqual(instance._ensure_consumer.await_count, 1)
+        self.assertEqual(instance.ensure_job_resources.await_count, 1)
 
     def test_partial_failure_counted_as_failed_not_raised(self, mock_mgr_cls, _state_cls):
         # 3 images, middle one fails. Method should return False (failure summary)
@@ -116,10 +115,10 @@ class TestQueueImagesToNatsFanout(TestCase):
         self.assertEqual(instance.publish_task.await_count, 3)
 
     def test_stream_setup_failure_short_circuits_publishing(self, mock_mgr_cls, _state_cls):
-        # If _ensure_stream raises, we should not attempt any publish_task calls —
-        # the whole batch is marked failed in one shot.
+        # If ensure_job_resources raises, we should not attempt any publish_task
+        # calls — the whole batch is marked failed in one shot.
         instance = _stub_manager(mock_mgr_cls)
-        instance._ensure_stream = AsyncMock(side_effect=RuntimeError("nats down"))
+        instance.ensure_job_resources = AsyncMock(side_effect=RuntimeError("nats down"))
         images = self._make_images(4)
         job = self._make_job()
 

--- a/ami/ml/orchestration/tests/test_jobs.py
+++ b/ami/ml/orchestration/tests/test_jobs.py
@@ -1,0 +1,135 @@
+from unittest.mock import AsyncMock, patch
+
+from django.test import TestCase
+
+from ami.jobs.models import Job, JobDispatchMode, MLJob
+from ami.main.models import Deployment, Project, S3StorageSource, SourceImage, SourceImageCollection
+from ami.ml.models import Pipeline
+from ami.ml.orchestration import jobs as orchestration_jobs
+from ami.ml.orchestration.jobs import NATS_PUBLISH_FANOUT_CHUNK_SIZE, queue_images_to_nats
+
+
+def _stub_manager(mock_manager_cls, publish_results=None):
+    """Return an AsyncMock TaskQueueManager instance with publish_task pre-stubbed.
+
+    publish_results is an optional iterable of bools matching publish_task call
+    order. Defaults to always-True.
+    """
+    instance = mock_manager_cls.return_value
+    instance.__aenter__ = AsyncMock(return_value=instance)
+    instance.__aexit__ = AsyncMock(return_value=False)
+    instance._ensure_stream = AsyncMock()
+    instance._ensure_consumer = AsyncMock()
+    instance.log_async = AsyncMock()
+    if publish_results is None:
+        instance.publish_task = AsyncMock(return_value=True)
+    else:
+        instance.publish_task = AsyncMock(side_effect=list(publish_results))
+    return instance
+
+
+@patch("ami.ml.orchestration.jobs.AsyncJobStateManager")
+@patch("ami.ml.orchestration.jobs.TaskQueueManager")
+class TestQueueImagesToNatsFanout(TestCase):
+    """Unit-test the chunk+gather behaviour of queue_images_to_nats.
+
+    The integration test in test_cleanup.py uses a real NATS server. These
+    tests instead mock TaskQueueManager so they run without infrastructure and
+    can assert on call counts.
+    """
+
+    def setUp(self):
+        self.project = Project.objects.create(name="fanout test")
+        self.data_source = S3StorageSource.objects.create(
+            name="ds",
+            bucket="b",
+            access_key="x",
+            secret_key="y",
+            public_base_url="https://example.invalid/",
+            project=self.project,
+        )
+        self.deployment = Deployment.objects.create(name="d", project=self.project, data_source=self.data_source)
+        self.pipeline = Pipeline.objects.create(name="p", slug="p", version="1")
+        self.collection = SourceImageCollection.objects.create(name="c", project=self.project)
+
+    def _make_images(self, n: int) -> list[SourceImage]:
+        # public_base_url is set so SourceImage.url() returns a truthy URL —
+        # otherwise queue_images_to_nats skips the image and the inner loop
+        # we're trying to test never runs.
+        rows = [
+            SourceImage(
+                path=f"fanout/{i}.jpg",
+                deployment=self.deployment,
+                project=self.project,
+                public_base_url="https://example.invalid/",
+            )
+            for i in range(n)
+        ]
+        SourceImage.objects.bulk_create(rows)
+        return list(SourceImage.objects.filter(project=self.project).order_by("pk"))
+
+    def _make_job(self) -> Job:
+        return Job.objects.create(
+            name="fanout",
+            job_type_key=MLJob.key,
+            project=self.project,
+            pipeline=self.pipeline,
+            source_image_collection=self.collection,
+            dispatch_mode=JobDispatchMode.ASYNC_API,
+        )
+
+    def test_warms_stream_and_consumer_once_before_publishing(self, mock_mgr_cls, _state_cls):
+        instance = _stub_manager(mock_mgr_cls)
+        images = self._make_images(5)
+        job = self._make_job()
+
+        queue_images_to_nats(job, images)
+
+        self.assertEqual(instance._ensure_stream.await_count, 1)
+        self.assertEqual(instance._ensure_consumer.await_count, 1)
+        self.assertEqual(instance.publish_task.await_count, 5)
+
+    def test_chunks_across_fanout_boundary(self, mock_mgr_cls, _state_cls):
+        instance = _stub_manager(mock_mgr_cls)
+        # One full chunk + one short chunk: forces the inner loop to iterate twice.
+        n = NATS_PUBLISH_FANOUT_CHUNK_SIZE + 7
+        images = self._make_images(n)
+        job = self._make_job()
+
+        queue_images_to_nats(job, images)
+
+        self.assertEqual(instance.publish_task.await_count, n)
+        # Warm-up still only runs once even when we span multiple chunks.
+        self.assertEqual(instance._ensure_stream.await_count, 1)
+        self.assertEqual(instance._ensure_consumer.await_count, 1)
+
+    def test_partial_failure_counted_as_failed_not_raised(self, mock_mgr_cls, _state_cls):
+        # 3 images, middle one fails. Method should return False (failure summary)
+        # but not raise — and the success count should reflect the two that worked.
+        instance = _stub_manager(mock_mgr_cls, publish_results=[True, False, True])
+        images = self._make_images(3)
+        job = self._make_job()
+
+        result = queue_images_to_nats(job, images)
+
+        self.assertFalse(result)
+        self.assertEqual(instance.publish_task.await_count, 3)
+
+    def test_stream_setup_failure_short_circuits_publishing(self, mock_mgr_cls, _state_cls):
+        # If _ensure_stream raises, we should not attempt any publish_task calls —
+        # the whole batch is marked failed in one shot.
+        instance = _stub_manager(mock_mgr_cls)
+        instance._ensure_stream = AsyncMock(side_effect=RuntimeError("nats down"))
+        images = self._make_images(4)
+        job = self._make_job()
+
+        result = queue_images_to_nats(job, images)
+
+        self.assertFalse(result)
+        self.assertEqual(instance.publish_task.await_count, 0)
+
+    def test_default_chunk_size_is_explicit(self, _mgr_cls, _state_cls):
+        # Lock the constant so a future change to the chunk size is a deliberate
+        # decision visible in the diff. The value itself is not a tuned magic
+        # number — it's an empirical floor that keeps gather() bounded.
+        self.assertEqual(orchestration_jobs.NATS_PUBLISH_FANOUT_CHUNK_SIZE, 200)

--- a/ami/ml/orchestration/tests/test_jobs.py
+++ b/ami/ml/orchestration/tests/test_jobs.py
@@ -44,7 +44,7 @@ class TestQueueImagesToNatsFanout(TestCase):
             name="ds",
             bucket="b",
             access_key="x",
-            secret_key="y",
+            secret_key="y",  # noqa: S106 - fixture value, never used as a real credential
             public_base_url="https://example.invalid/",
             project=self.project,
         )

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -566,7 +566,7 @@ class TestPipeline(TestCase):
             name="ds-prefetch-test",
             bucket="prefetch-bucket",
             access_key="x",
-            secret_key="y",
+            secret_key="y",  # noqa: S106 - fixture value, never used as a real credential
             public_base_url="https://example.invalid/",
             project=self.project,
         )
@@ -1129,8 +1129,9 @@ class TestPipeline(TestCase):
         for call in mock_save.call_args_list:
             self.assertEqual(
                 call.kwargs.get("update_fields"),
-                ["progress"],
-                "Throttled saves should write only the progress column",
+                ["progress", "updated_at"],
+                "Throttled saves must include `updated_at` so Django's auto_now fires "
+                "and the reaper's stale-job heuristic sees forward motion.",
             )
 
         # Final emitted fraction comes from the second save (batch 4): processed=10,

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -554,6 +554,43 @@ class TestPipeline(TestCase):
         images = list(collect_images(collection=self.image_collection, pipeline=self.pipeline))
         assert len(images) == 2
 
+    def test_collect_images_prefetches_deployment_and_data_source(self):
+        """
+        collect_images() must hand back SourceImage rows with deployment and
+        deployment.data_source already joined, so the downstream queue_images_to_nats
+        loop doesn't trigger N+1 FK lookups inside image.url() (see issue #1321).
+        """
+        from ami.main.models import S3StorageSource
+
+        data_source = S3StorageSource.objects.create(
+            name="ds-prefetch-test",
+            bucket="prefetch-bucket",
+            access_key="x",
+            secret_key="y",
+            public_base_url="https://example.invalid/",
+            project=self.project,
+        )
+        deployment = Deployment.objects.create(
+            name="prefetch-deployment", project=self.project, data_source=data_source
+        )
+        images = [
+            SourceImage.objects.create(path=f"prefetch-{i}.jpg", deployment=deployment, project=self.project)
+            for i in range(3)
+        ]
+        collection = SourceImageCollection.objects.create(project=self.project, name="prefetch-collection")
+        collection.images.set(images)
+
+        collected = list(collect_images(collection=collection, pipeline=self.pipeline))
+        self.assertEqual(len(collected), 3)
+
+        # Accessing deployment.data_source on the returned images should
+        # require zero extra queries because select_related joined both.
+        with self.assertNumQueries(0):
+            for image in collected:
+                self.assertEqual(image.deployment_id, deployment.pk)
+                self.assertEqual(image.deployment.data_source_id, data_source.pk)
+                self.assertEqual(image.deployment.data_source.public_base_url, "https://example.invalid/")
+
     def fake_pipeline_results(
         self,
         source_images: list[SourceImage],

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -1088,6 +1088,73 @@ class TestPipeline(TestCase):
         result = list(filter_processed_images(images, self.pipeline, batch_size=3))
         self.assertEqual(result, images)
 
+    def test_filter_processed_images_emits_throttled_collect_progress(self):
+        """
+        When `job` and `total` are passed, filter_processed_images should call
+        job.save(update_fields=["progress"]) at most once per
+        COLLECT_PROGRESS_SAVE_INTERVAL_SECONDS of wall time, capped at
+        COLLECT_PROGRESS_MAX_FRACTION. Keeps the reaper's "no forward progress"
+        heuristic happy on multi-minute Collect stages without hot-saving the
+        Job row on every chunk (issue #1321 follow-up).
+        """
+        from unittest.mock import patch
+
+        from ami.jobs.models import Job, MLJob
+        from ami.ml.models.pipeline import COLLECT_PROGRESS_MAX_FRACTION, filter_processed_images
+
+        job = Job.objects.create(
+            project=self.project,
+            name="collect progress cadence test",
+            pipeline=self.pipeline,
+            job_type_key=MLJob.key,
+        )
+        # First save triggered MLJob.setup → "collect" stage exists.
+        job.progress.get_stage("collect")
+
+        images = [SourceImage.objects.create(path=f"cadence-{i}.jpg") for i in range(10)]
+
+        # batch_size=3 over 10 images → 4 batches.
+        # Per-batch time.monotonic() return values:
+        #   init=0, after batch1=1 (gap 1, no save),
+        #   after batch2=6 (gap 6, SAVE → last=6),
+        #   after batch3=7 (gap 1, no save),
+        #   after batch4=12 (gap 6, SAVE → last=12).
+        # Expected: exactly 2 saves.
+        monotonic_values = iter([0.0, 1.0, 6.0, 7.0, 12.0])
+        with patch("ami.ml.models.pipeline.time.monotonic", side_effect=lambda: next(monotonic_values)):
+            with patch.object(Job, "save", autospec=True) as mock_save:
+                list(filter_processed_images(images, self.pipeline, batch_size=3, job=job, total=10))
+
+        self.assertEqual(mock_save.call_count, 2, "Expected throttle to allow exactly 2 saves")
+        for call in mock_save.call_args_list:
+            self.assertEqual(
+                call.kwargs.get("update_fields"),
+                ["progress"],
+                "Throttled saves should write only the progress column",
+            )
+
+        # Final emitted fraction comes from the second save (batch 4): processed=10,
+        # total=10 → raw 1.0, capped at COLLECT_PROGRESS_MAX_FRACTION.
+        collect_stage = job.progress.get_stage("collect")
+        self.assertEqual(collect_stage.progress, COLLECT_PROGRESS_MAX_FRACTION)
+
+    def test_filter_processed_images_skips_progress_emission_without_job(self):
+        """
+        Legacy callers that omit `job` (the only callers before this change)
+        should see zero job.save() calls — the throttle block is fully gated
+        on both `job` and `total` being passed.
+        """
+        from unittest.mock import patch
+
+        from ami.jobs.models import Job
+        from ami.ml.models.pipeline import filter_processed_images
+
+        images = [SourceImage.objects.create(path=f"nojob-{i}.jpg") for i in range(5)]
+        with patch.object(Job, "save", autospec=True) as mock_save:
+            list(filter_processed_images(images, self.pipeline, batch_size=2))
+
+        self.assertEqual(mock_save.call_count, 0)
+
     def test_null_detections_are_algorithm_specific(self):
         """
         Null detections from different pipelines/algorithms should not be shared.

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -962,6 +962,95 @@ class TestPipeline(TestCase):
         result = list(filter_processed_images([image], self.pipeline))
         self.assertEqual(result, [], "Fully classified image with null detection should be skipped")
 
+    def test_filter_processed_images_empty_input(self):
+        """An empty iterable should yield nothing and run no per-image queries."""
+        from ami.ml.models.pipeline import filter_processed_images
+
+        with self.assertNumQueries(1):  # one query: pipeline.algorithms.all()
+            result = list(filter_processed_images([], self.pipeline))
+        self.assertEqual(result, [])
+
+    def test_filter_processed_images_mixed_batch(self):
+        """
+        A mixed batch of images covering all five branches should yield only
+        the ones that need processing, in input order.
+        """
+        from ami.ml.models.pipeline import filter_processed_images
+
+        detector = self.algorithms["random-detector"]
+        binary = self.algorithms["random-binary-classifier"]
+        species = self.algorithms["random-species-classifier"]
+
+        unprocessed = SourceImage.objects.create(path="unprocessed.jpg")
+        null_only = SourceImage.objects.create(path="null_only.jpg")
+        unclassified = SourceImage.objects.create(path="unclassified.jpg")
+        fully_classified = SourceImage.objects.create(path="fully_classified.jpg")
+
+        Detection.objects.create(source_image=null_only, detection_algorithm=detector, bbox=None)
+
+        Detection.objects.create(source_image=unclassified, detection_algorithm=detector, bbox=[0.1, 0.2, 0.3, 0.4])
+
+        real_det = Detection.objects.create(
+            source_image=fully_classified, detection_algorithm=detector, bbox=[0.1, 0.2, 0.3, 0.4]
+        )
+        taxon = Taxon.objects.create(name="Test Mixed Batch Taxon")
+        Classification.objects.create(
+            detection=real_det, taxon=taxon, algorithm=binary, score=0.9, timestamp=datetime.datetime.now()
+        )
+        Classification.objects.create(
+            detection=real_det, taxon=taxon, algorithm=species, score=0.8, timestamp=datetime.datetime.now()
+        )
+
+        images = [unprocessed, null_only, unclassified, fully_classified]
+        result = list(filter_processed_images(images, self.pipeline))
+        self.assertEqual(result, [unprocessed, unclassified])
+
+    def test_filter_processed_images_query_count_is_bounded_per_batch(self):
+        """
+        With N images and batch_size=B, the query count should scale as
+        O(N / B), not O(N). Locks in the bulk-query rewrite from issue #1321.
+
+        Each batch issues at most:
+          - 1 Detection bulk select
+          - 1 Classification bulk select (only when real detections exist)
+        Plus one initial pipeline.algorithms.all() that's shared across batches.
+        """
+        from ami.ml.models.pipeline import filter_processed_images
+
+        detector = self.algorithms["random-detector"]
+        binary = self.algorithms["random-binary-classifier"]
+        species = self.algorithms["random-species-classifier"]
+        taxon = Taxon.objects.create(name="Bounded Query Test Taxon")
+
+        # 10 images. Batch 1: 5 fully-classified (triggers classification query).
+        # Batch 2: 5 unprocessed (no detections, classification query skipped).
+        images = [SourceImage.objects.create(path=f"bulk-{i}.jpg") for i in range(10)]
+        for image in images[:5]:
+            real_det = Detection.objects.create(
+                source_image=image, detection_algorithm=detector, bbox=[0.1, 0.2, 0.3, 0.4]
+            )
+            Classification.objects.create(
+                detection=real_det, taxon=taxon, algorithm=binary, score=0.9, timestamp=datetime.datetime.now()
+            )
+            Classification.objects.create(
+                detection=real_det, taxon=taxon, algorithm=species, score=0.8, timestamp=datetime.datetime.now()
+            )
+
+        # Expected: 1 (pipeline) + 2 (detection × 2 batches) + 1 (classification, batch 1 only) = 4.
+        with self.assertNumQueries(4):
+            result = list(filter_processed_images(images, self.pipeline, batch_size=5))
+
+        # First 5 fully classified → skipped. Last 5 fresh → yielded.
+        self.assertEqual(result, images[5:])
+
+    def test_filter_processed_images_preserves_input_order_across_batches(self):
+        """Output should preserve input ordering even when batched."""
+        from ami.ml.models.pipeline import filter_processed_images
+
+        images = [SourceImage.objects.create(path=f"order-{i}.jpg") for i in range(7)]
+        result = list(filter_processed_images(images, self.pipeline, batch_size=3))
+        self.assertEqual(result, images)
+
     def test_null_detections_are_algorithm_specific(self):
         """
         Null detections from different pipelines/algorithms should not be shared.

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -1080,14 +1080,6 @@ class TestPipeline(TestCase):
         # First 5 fully classified → skipped. Last 5 fresh → yielded.
         self.assertEqual(result, images[5:])
 
-    def test_filter_processed_images_preserves_input_order_across_batches(self):
-        """Output should preserve input ordering even when batched."""
-        from ami.ml.models.pipeline import filter_processed_images
-
-        images = [SourceImage.objects.create(path=f"order-{i}.jpg") for i in range(7)]
-        result = list(filter_processed_images(images, self.pipeline, batch_size=3))
-        self.assertEqual(result, images)
-
     def test_filter_processed_images_emits_throttled_collect_progress(self):
         """
         When `job` and `total` are passed, filter_processed_images should call
@@ -1113,15 +1105,23 @@ class TestPipeline(TestCase):
 
         images = [SourceImage.objects.create(path=f"cadence-{i}.jpg") for i in range(10)]
 
-        # batch_size=3 over 10 images → 4 batches.
-        # Per-batch time.monotonic() return values:
-        #   init=0, after batch1=1 (gap 1, no save),
-        #   after batch2=6 (gap 6, SAVE → last=6),
-        #   after batch3=7 (gap 1, no save),
-        #   after batch4=12 (gap 6, SAVE → last=12).
-        # Expected: exactly 2 saves.
-        monotonic_values = iter([0.0, 1.0, 6.0, 7.0, 12.0])
-        with patch("ami.ml.models.pipeline.time.monotonic", side_effect=lambda: next(monotonic_values)):
+        # batch_size=3 over 10 images → 4 batches. Each monotonic() call
+        # advances the clock by 3s. Expected sequence: init=0, batch1=3
+        # (gap 3, no save), batch2=6 (gap 6, SAVE → last=6), batch3=9
+        # (gap 3, no save), batch4=12 (gap 6, SAVE → last=12). Two saves.
+        #
+        # Counter-based stub (vs an iter/next sequence) means extra
+        # monotonic() calls added to filter_processed_images later will
+        # advance time faster and the assertion will fail with a clear
+        # cadence mismatch, not StopIteration.
+        clock = {"t": 0.0}
+
+        def fake_monotonic():
+            t = clock["t"]
+            clock["t"] += 3.0
+            return t
+
+        with patch("ami.ml.models.pipeline.time.monotonic", side_effect=fake_monotonic):
             with patch.object(Job, "save", autospec=True) as mock_save:
                 list(filter_processed_images(images, self.pipeline, batch_size=3, job=job, total=10))
 

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -1007,6 +1007,33 @@ class TestPipeline(TestCase):
             result = list(filter_processed_images([], self.pipeline))
         self.assertEqual(result, [])
 
+    def test_filter_processed_images_yields_all_when_pipeline_has_no_classifiers(self):
+        """
+        When a pipeline has no classifier algorithms registered, filter_processed_images
+        must yield every image (matching the "Will reprocess all images" warning).
+        Without the short-circuit, the empty `pipeline_classifier_ids` set makes
+        `set().issubset(observed) == True` and every image with existing detections
+        is silently skipped — directly contradicting the warning.
+        """
+        from ami.ml.models.pipeline import filter_processed_images
+
+        detector_only_pipeline = Pipeline.objects.create(name="Detector Only Pipeline")
+        detector_only_pipeline.algorithms.set([self.algorithms["random-detector"]])
+
+        # Image with a real, fully-processed-looking detection from the detector.
+        # Pre-short-circuit this would be skipped because the empty pipeline classifier
+        # set is vacuously a subset of any observed-classifier set.
+        image_with_detection = SourceImage.objects.create(path="no-classifier-with-det.jpg")
+        Detection.objects.create(
+            source_image=image_with_detection,
+            detection_algorithm=self.algorithms["random-detector"],
+            bbox=[0.1, 0.2, 0.3, 0.4],
+        )
+        image_unprocessed = SourceImage.objects.create(path="no-classifier-unprocessed.jpg")
+
+        result = list(filter_processed_images([image_with_detection, image_unprocessed], detector_only_pipeline))
+        self.assertEqual(result, [image_with_detection, image_unprocessed])
+
     def test_filter_processed_images_mixed_batch(self):
         """
         A mixed batch of images covering all five branches should yield only


### PR DESCRIPTION
Operators running ML jobs on large Capture Sets (`SourceImageCollection`) were seeing the job sit in `STARTED` for ~20 minutes, no Collect-stage progress, no errors in the log, and then flip to `REVOKED` once the reaper noticed no forward progress. From their side the platform looked like it had silently dropped the job. The Celery worker was actually still running — stuck in the Collect → queue path doing per-image SQL — but no `job.progress` updates were being saved, so the reaper's 10-minute "no forward progress" heuristic fired.

Three independent O(N)-per-image sites in that path were each big enough on their own to push past the 10-minute reaper threshold on collections in the ~100k-image range. This PR fixes all three.

Collect → queue → NATS-stream-created on a ~100k-image job that previously **hung for ~19 minutes and got reaped** now completes in **42 seconds end-to-end** (measured on the Serbia dev box on the same shape of collection, see numbers below). That's roughly a 20–25× drop in absolute wall time on the path that was getting killed; the per-image cost goes from ~7.7 ms (147k incident wall time ÷ image count) down to ~0.4 ms. Smaller jobs see the same shape but the absolute win is too small to notice.

Before (collecting images takes more than 15 minutes and gets revoked)
<img width="752" height="146" alt="image" src="https://github.com/user-attachments/assets/c28c9d7a-6ba7-4248-be6b-08d181fc80ff" />

After (collecting images takes 30 seconds or so)
<img width="653" height="166" alt="image" src="https://github.com/user-attachments/assets/f169ae3a-b09e-4da2-a047-6d93d9541733" />


## What this PR changes

- **Bulk-query `filter_processed_images`** (`ami/ml/models/pipeline.py`). Was 3–5 ORM round-trips per image; now chunks via `itertools.islice` at `batch_size=1000` and does at most 2 bulk queries per chunk. Semantics for all five processed/unprocessed branches preserved. 147k images → ~295 queries instead of ~500k. Measured: 9.4 s for 105k images, down from a reaper-killed run on 147k.
- **Prefetch `deployment__data_source` in `collect_images`** (`ami/ml/models/pipeline.py`). The two queryset branches (collection-backed and deployment-backed) now `.select_related("deployment__data_source")` so the FK chain rides along on the initial fetch. Saves a query per image on the downstream `image.url()` call in `queue_images_to_nats`.
- **Cache `image.url()` once per iteration in `queue_images_to_nats`** (`ami/ml/orchestration/jobs.py`). The pre-NATS prep loop called it twice — once in the truthy check, once for assignment — doubling the FK chain cost on every iteration. Now called once.
- **Fanout the NATS publish loop with `asyncio.gather`** (`ami/ml/orchestration/jobs.py`, new constant `NATS_PUBLISH_FANOUT_CHUNK_SIZE=200`). Sequential `await self.js.publish(...)` stacked the per-message JetStream ack round-trip (~1.3 ms each, including TCP) linearly. Chunked `gather` lets the NATS client pipeline acks back to us. `_ensure_stream` / `_ensure_consumer` are also pre-warmed once before the loop — they were already cache-noop after first call, but pre-warming prevents 200 concurrent coroutines from all trying to create the stream on the first chunk. Measured: 139 s → 15 s on 105k images (~9× speedup on the publish loop alone).
- **Extract `bbox_is_null()` helper** next to `NULL_DETECTIONS_FILTER` in `ami/main/models.py` so the SQL filter and the in-memory check share a single source of truth. Used inside the bulk filter.
- **Strip Detection's default `Meta.ordering`** on the bulk select via `.order_by()`. The rows land in a dict — no point sorting them in Postgres.
- **Rename per-batch dicts** in the bulk filter (`images_with_pipeline_detection`, `real_pipeline_detections_per_image`) so it's clear they only cover detections from *this* pipeline's algorithms.
- **Short-circuit the "no classifier" filter path** (`ami/ml/models/pipeline.py`). When a pipeline has no classifier algorithms registered, the empty classifier set made `set().issubset(observed)` vacuously true, so images with existing detections were silently skipped — contradicting the "Will reprocess all images" warning. Now yields all images and returns. This is a pre-existing bug surfaced during review; fixed here because the PR rewrote that exact code path.

## Tests

- Empty input → 1 query.
- Mixed batch across all five filter branches → correct subset yielded.
- Query-count assertion: 10 images at `batch_size=5` → 4 queries (1 pipeline + 2 detection batches + 1 classification batch). Locks in the O(batches) shape.
- No-classifier short-circuit: a pipeline with no classifier algorithms registered yields every image (matches the "Will reprocess all images" warning) — guards the empty-set `issubset` bug fixed in review.
- `collect_images` returns SourceImage rows with `deployment` + `deployment.data_source` joined — accessing them triggers 0 additional queries.
- NATS fanout (4 tests in `ami/ml/orchestration/tests/test_jobs.py`, mocking `TaskQueueManager`): warm-up runs exactly once, `publish_task` await count equals image count across a chunk boundary, partial-failure path returns `False` without raising, and a stream-setup exception short-circuits and yields zero publishes.

## Ordering note for the fanout change

JetStream still assigns `ack.seq` atomically on the server side as messages arrive, so the stream is still strictly ordered by arrival. What changes is the order *within* a 200-message gather chunk — two images dispatched in the same chunk can land in the stream in either order. Consumers fetch via `consumer.fetch` which yields in seq order, and the ADC worker processes each image-task independently with no cross-task ordering dependency, so this is safe. Globally the chunked order is still preserved: chunk N's messages all land in the stream before chunk N+1's.

## Performance — what each fix bought

The original incident on a 147k-image collection ran for ~19 minutes before the reaper killed it. The job never reached the NATS publish loop — it stalled inside `filter_processed_images` doing per-image SQL — so we have direct evidence for one fix (the filter rewrite) and arithmetic / measurement for the rest. Per-fix attribution on a 105k-image workload:

| Site / fix | Before this PR | After this PR | Source of the "before" number |
|---|---|---|---|
| `filter_processed_images` | ~13 min (105k images at the 7.7 ms/img incident rate) | **9 s measured** | 147k incident wall time ÷ image count, scaled |
| `image.url()` × 2 + uncached `deployment.data_source` FK chain in queue prep loop | ~9 ms × 2 × 105k ≈ 31 min if it had ever run | absorbed into the 15 s publish loop | Per-call cost measured on a real production SourceImage; never observed at scale because the filter stalled first |
| Sequential `await self.js.publish(...)` per image | 139 s on 105k (~15 min extrapolated on 700k) | **15 s measured** | Measured directly in run 1 of the A/B below |
| **Total job-prep wall time on ~100k-image collection** | **~19 min → reaper kill** | **42.1 s** | Incident timeline (before); Serbia run 2 (after) |

So the 20× headline isn't a single fix — the filter rewrite alone gets it under the reaper threshold, but the `url()` cache and the fanout each remove a stage that *would have* hit the threshold once the previous one stopped being the bottleneck. With only the filter fixed, the same job-prep on 700k images would have stalled inside the publish loop at ~15 minutes wall. With all three fixed, the publish loop scales to 700k in ~100 s.

The A/B below is the direct measurement that backs row 3 (sequential vs fanout publish) and shows what each stage contributes to the final 42 s.

## Measured end-to-end on the Serbia dev box (2026-05-27)

Re-ran the incident path against the closest-shape collection on hand: project 20, collection 165 ("All images"), 105,091 `SourceImage` rows, pipeline `quebec_vermont_moths_2023`, `dispatch_mode=async_api`. Stack was this branch on top of Postgres + Redis + JetStream as on a fresh deploy. Pipeline 3's algorithms have already classified ~6k of the 105k, so the filter does meaningful work (all 105,091 images returned as "to process" after dedup).

### Headline comparison

| State | Wall time on ~100k–150k images | Outcome |
|---|---|---|
| **Before this PR** (production code, observed in #1321 on a 147k-image collection) | **~19 minutes** (1140 s) | reaped at 19m18s, `REVOKED` |
| **After this PR** (measured on 105k-image collection) | **42.1 seconds** | `collect: SUCCESS`, `process` queued, no reaper firing |

That's the ~20× headline win that closes #1321. The per-image cost on the job-prep path drops from ~7.7 ms (incident wall time ÷ image count) to ~0.4 ms.

### Where the time went — A/B of the publish-loop change inside this PR

The performance work is a stack of 5 commits (`4c089c24`–`59d05619`). The first four fix the filter rewrite, the `select_related`, and the `url()` caching; the fifth adds the `asyncio.gather` fanout. (Later commits in the PR add the collect-progress emission, the review fixes, and tests — they don't change the perf path.) To check that the fanout commit specifically pulled its weight, I ran the same job *twice* — once with the first four commits applied (sequential publish loop still), once with all five (fanout publish loop):

| Stage | Run 1 — 4 commits, sequential publish (job 2544) | Run 2 — 5 commits, fanout publish (job 2545) |
|---|---|---|
| Celery pickup + `collect_images` | 13.8 s | 14.2 s |
| `filter_processed_images` (105,091 images) | **9.4 s** | **9.0 s** |
| `state_manager.initialize_job` (Redis SADD) | 4.1 s | 3.6 s |
| `queue_images_to_nats` publish loop | **139 s** (~1.3 ms/img) | **~15 s** (~0.14 ms/img amortised) |
| **Total `run_job`** | **166.9 s** (2.78 min) | **42.1 s** |

Both runs are on the same code stack as this PR for the *filter* changes — the 9 s filter is post-fix in both. The "before" 19-minute baseline above was never re-measured directly because the pre-fix code would have stalled the worker the same way it did in the incident. The 9 s filter and 7.7 ms → 0.4 ms per-image numbers are derived from the same 105k vs 147k extrapolation, which is the closest 1:1 comparison the dev box could give without rolling back to a known-broken state.

Throughput on the publish loop: 105,091 / 139 ≈ **755 msg/s sequential** vs 105,091 / 15 ≈ **7,000 msg/s with fanout**. The fanout rate was confirmed against NATS `/varz` samples taken during the run (in_msgs delta of ~45k over a 9 s window mid-publish, ~60k over the following 10 s window).

Extrapolating linearly at the measured fanout rate: a 700k-image job (the largest collection currently on Serbia) would spend ~100 s in the publish loop and ~60 s in the filter, totaling well under 5 minutes. Sequential publish on the same 700k collection would have taken ~15 minutes for the publish alone, so the fanout change is load-bearing for the largest collections, not just nice-to-have.

What the e2e proves: the job-prep path (Collect → filter → Redis init → NATS publish) on a real ~100k-image production-shape collection completes in 42 seconds and leaves the job in a healthy `STARTED` state with `collect: SUCCESS` and `process` queued. The 10-minute reaper threshold isn't approached at any stage.

### Downstream consumption confirmed (2026-05-28 re-run)

The 2026-05-27 runs above queued all 105,091 messages but could not confirm the ADC worker actually consumed them: the dev box's ADC worker was in HTTP-poll mode with a 401 auth issue, so the `process` stage stayed at 0% after queueing. That criterion was satisfied only by inference (queue-success log + Redis sets initialised + 105,091 JetStream messages in flight).

After the auth was fixed, a fresh job (2547, same project 20 / collection 165 / `quebec_vermont_moths_2023`) on the latest branch ran the full loop. `collect` reached `SUCCESS (1.0)`, then `process` advanced past 0 (`STARTED`, climbing) with `results` also moving, and `Job.updated_at` bumped steadily throughout (observed 00:03→00:06 and on), so the reaper never approached its threshold. This closes the one gap from the earlier runs: the full Collect → filter → publish → consume → results path is now observed working end-to-end, not inferred. Absolute process-stage throughput is bounded by ADC inference speed on 105k images, which is orthogonal to this PR.

## Collect-stage progress emission (also in this PR)

`filter_processed_images` now accepts optional `job` and `total` kwargs and emits a throttled fractional `collect` progress update at most once every 5 s of wall time (`COLLECT_PROGRESS_SAVE_INTERVAL_SECONDS`), capped at 0.99 (`COLLECT_PROGRESS_MAX_FRACTION`) so the caller's terminal `status=SUCCESS, progress=1` flip still owns the final value. `collect_images` wires both through. Legacy callers without `job` stay silent — the throttle block is fully gated on both new kwargs.

This makes the Collect stage tick `Job.save(update_fields=["progress", "updated_at"])` regularly, which keeps `Job.updated_at` fresh against the reaper at `ami/jobs/tasks.py:929-944` (cutoff `Job.STALLED_JOBS_MAX_MINUTES = 10`). `updated_at` is listed explicitly in `update_fields` because Django's `auto_now` only fires its `pre_save` hook for fields named in `update_fields`; omitting it (as an earlier revision of this PR did) would update the `progress` JSONB but leave `updated_at` stale, defeating the reaper-shielding entirely. The structural fix for the reaper false-positive lands here rather than in a follow-up because the wiring is cheap and there's no good reason to leave the gap open.

Two new tests in `ami/ml/tests.py`:
- `test_filter_processed_images_emits_throttled_collect_progress` — a counter-based clock stub verifies the ≥5 s gate fires exactly the expected number of saves across a multi-chunk run, all with `update_fields=["progress", "updated_at"]`, and that the final emitted fraction is capped at 0.99.
- `test_filter_processed_images_skips_progress_emission_without_job` — omitting `job` keeps the legacy code path silent (zero `Job.save()` calls).

Earlier follow-up note about "celery_state=PENDING" was misleading paraphrase: during the Collect stage Django `Job.status` is `STARTED` (set by `MLJob.run()` at `ami/jobs/models.py:462`) and Celery's `AsyncResult(task_id).state` is also `STARTED` — PENDING only applies between enqueue and pickup. The actual reaper trigger is `(status ∈ running_states) AND (updated_at < cutoff)`. STARTED is in `running_states()`. The 5 s throttle directly addresses the real trigger; nothing PENDING-specific remains to chase.

## Not in this PR (follow-ups)

- **Queue-stage progress emission.** `queue_images_to_nats` still has no incremental progress emission during the publish loop. The 42 s end-to-end wall time on 105k images measured above (and ~140 s extrapolated on 700k) is well under the 10-minute reaper cutoff, so this isn't load-bearing. Wiring it would require `sync_to_async`-bridged updates inside the `asyncio.gather` chunks and a careful pass on the `Job.progress` JSONB clobber race with the NATS result handler (`_update_job_progress` in `ami/jobs/tasks.py`).

Closes #1321.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized image processing pipeline with batch database queries to enhance throughput during large-scale operations.
  * Improved task publishing efficiency with chunked batching to reduce latency during queue operations.

* **Improvements**
  * Enhanced progress reporting during batch processing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RolnickLab/antenna/pull/1322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->