### PR TITLE
Improve celery task dispatch and cancellation to prevent stuck jobs

### DIFF
--- a/ami/jobs/models.py
+++ b/ami/jobs/models.py
@@ -1067,25 +1067,39 @@ class Job(BaseModel):
 
     def cancel(self):
         """
-        Cancel a job. For async_api jobs, clean up NATS/Redis resources
-        and transition through CANCELING → REVOKED. For other jobs,
-        revoke the Celery task.
+        Cancel a job.
+
+        For ASYNC_API jobs the long-running work is on remote ADC workers via
+        NATS, not in the local ``run_job`` celery task — by the time the user
+        clicks cancel, ``run_job`` has usually already finished
+        ``queue_images_to_nats`` and returned. Tearing down the NATS stream +
+        Redis state (``cleanup_async_job_if_needed``) is what actually stops
+        further work: ADC stops being delivered tasks, and any in-flight
+        result handlers see no Redis state and fast-fail. Calling
+        ``revoke(terminate=True)`` on the (likely-done) run_job would SIGTERM
+        the worker child if it happens to still be inside the bootstrap (e.g.
+        a slow ``filter_processed_images`` for a huge collection), which
+        prior to ``acks_late`` was an unrecoverable message loss. We revoke
+        without terminate so a not-yet-started copy is dropped without
+        killing in-flight bootstrap; the in-flight copy then notices
+        ``status == CANCELING`` via the early-guard in ``run_job`` next time
+        it's invoked (e.g. on redelivery) and bails out cleanly.
+
+        For INTERNAL / SYNC_API jobs the celery task body owns the entire
+        job lifecycle, so terminating it remains the only way to stop
+        active work.
         """
         self.status = JobState.CANCELING
         self.save()
 
+        is_async_api = self.dispatch_mode == JobDispatchMode.ASYNC_API
         if self.task_id:
             task = run_job.AsyncResult(self.task_id)
             if task:
-                task.revoke(terminate=True)
-            if self.dispatch_mode == JobDispatchMode.ASYNC_API:
-                # For async jobs we need to set the status to revoked here since the task already
-                # finished (it only queues the images).
-                self.status = JobState.REVOKED
-                self.save()
-        else:
-            self.status = JobState.REVOKED
-            self.save()
+                task.revoke(terminate=not is_async_api)
+
+        self.status = JobState.REVOKED
+        self.save()
 
         cleanup_async_job_if_needed(self)
 

--- a/ami/jobs/models.py
+++ b/ami/jobs/models.py
@@ -529,6 +529,28 @@ class MLJob(JobType):
             progress=1,
         )
 
+        # Mid-bootstrap cancel guard. ``collect_images`` above can run for many
+        # minutes on large collections (S3 list + DB joins), and the user may
+        # cancel during that window. ``Job.cancel()`` for ASYNC_API does
+        # ``revoke(terminate=False)`` to avoid SIGKILL'ing this worker, then
+        # writes REVOKED + tears down the NATS stream / Redis state. Without
+        # this check we would (a) clobber the cancel's REVOKED via the next
+        # full ``job.save()`` and (b) proceed to ``queue_images_to_nats``,
+        # recreating the stream the cancel just deleted and dispatching real
+        # GPU work to ADC for a revoked job. Refresh is read-only against the
+        # ``status`` column; the in-memory ``progress`` mutations from the
+        # collect stage are intentionally dropped on the bail path because the
+        # job is settled — no further progress writes make sense. Covers
+        # ASYNC_API (NATS dispatch) and SYNC paths (Celery sub-tasks in
+        # ``process_images``); INTERNAL jobs benefit too. See
+        # RolnickLab/antenna#1323.
+        db_status = Job.objects.values_list("status", flat=True).get(pk=job.pk)
+        if db_status in JobState.final_states() or db_status == JobState.CANCELING:
+            job.logger.info(
+                f"Job {job.pk} settled to {db_status} during bootstrap; " f"skipping dispatch of {len(images)} images"
+            )
+            return
+
         # End image collection stage
         job.save()
 
@@ -1040,6 +1062,21 @@ class Job(BaseModel):
 
         if save:
             self.save()
+
+    def is_settled(self) -> bool:
+        """Return True when the job is in a terminal state or being cancelled.
+
+        Used by every code path that must not start (or continue) work for a
+        job whose lifecycle has effectively ended: the ``run_job`` early-guard
+        (after acks_late redelivery), the ``MLJob.run`` mid-bootstrap cancel
+        check (before ``queue_images_to_nats`` dispatches GPU work to ADC),
+        the prerun signal handler (so a redelivered or canceled message does
+        not get its status reset to PENDING), and ``_fail_job``. Centralized
+        so the predicate stays in one place — adding a new "do not resume"
+        status only requires touching :meth:`JobState.final_states` or this
+        method.
+        """
+        return self.status in JobState.final_states() or self.status == JobState.CANCELING
 
     def run(self):
         """

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -150,7 +150,7 @@ def update_async_services_seen_for_project(project_id: int) -> None:
     reject_on_worker_lost=True,
 )
 def run_job(self, job_id: int) -> None:
-    from ami.jobs.models import Job, JobState
+    from ami.jobs.models import Job
 
     try:
         job = Job.objects.get(pk=job_id)
@@ -161,8 +161,10 @@ def run_job(self, job_id: int) -> None:
     # Early-guard: under acks_late, the broker may redeliver this message after a
     # worker SIGKILL/OOM, and Job.cancel() may also flip status to CANCELING /
     # REVOKED while the message sits in the prefetch buffer. Don't re-run a job
-    # that's already settled or being torn down.
-    if job.status in JobState.final_states() or job.status == JobState.CANCELING:
+    # that's already settled or being torn down. The companion guard in
+    # pre_update_job_status above prevents the task_prerun signal from
+    # overwriting that status with PENDING before we get here.
+    if job.is_settled():
         job.logger.info(
             f"Skipping run_job for job {job.pk}: already in status {job.status} "
             f"(redelivery or cancellation in flight)"
@@ -444,7 +446,7 @@ def _fail_job(job_id: int, reason: str) -> None:
     try:
         with transaction.atomic():
             job = Job.objects.select_for_update().get(pk=job_id)
-            if job.status in (JobState.CANCELING, *JobState.final_states()):
+            if job.is_settled():
                 return
             job.update_status(JobState.FAILURE, save=False)
             job.finished_at = datetime.datetime.now()
@@ -1327,7 +1329,34 @@ def cleanup_async_job_if_needed(job) -> None:
 
 @task_prerun.connect(sender=run_job)
 def pre_update_job_status(sender, task_id, task, **kwargs):
-    # in the prerun signal, set the job status to PENDING
+    """Bump the job to PENDING when a worker picks the message up.
+
+    Skipped when the job is already settled (terminal state) or being
+    cancelled. Without that guard, a broker redelivery (acks_late + worker
+    crash) or a cancel that arrived while the message was still in the
+    prefetch buffer would have its REVOKED/CANCELING status silently
+    overwritten with PENDING here, and the ``run_job`` early-guard
+    (which reads ``Job.status`` after this signal fires) would then fail
+    to short-circuit and re-run the job. See RolnickLab/antenna#1323.
+    """
+    from ami.jobs.models import Job
+
+    job_id = task.request.kwargs.get("job_id") if task.request.kwargs else None
+    if job_id is None and task.request.args:
+        job_id = task.request.args[0]
+    if job_id is not None:
+        try:
+            job = Job.objects.only("status").get(pk=job_id)
+        except Job.DoesNotExist:
+            pass
+        else:
+            if job.is_settled():
+                logger.info(
+                    "task_prerun: skipping PENDING write for job %s in status %s " "(redelivery or cancel in flight)",
+                    job_id,
+                    job.status,
+                )
+                return
     update_job_status(sender, task_id, task, "PENDING", **kwargs)
 
 

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -136,30 +136,53 @@ def update_async_services_seen_for_project(project_id: int) -> None:
     )
 
 
-@celery_app.task(bind=True, soft_time_limit=default_soft_time_limit, time_limit=default_time_limit)
+# acks_late + reject_on_worker_lost so a worker SIGKILL/OOM mid-task does not
+# silently drop the job: the broker holds the message until the task body
+# either completes successfully or raises, and redelivers if the worker dies.
+# Pairs with the early-guard below — a redelivered run_job that finds the job
+# already in a terminal state (or mid-cancellation) returns cleanly instead of
+# re-running side effects. See RolnickLab/antenna#1323.
+@celery_app.task(
+    bind=True,
+    soft_time_limit=default_soft_time_limit,
+    time_limit=default_time_limit,
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
 def run_job(self, job_id: int) -> None:
-    from ami.jobs.models import Job
+    from ami.jobs.models import Job, JobState
 
     try:
         job = Job.objects.get(pk=job_id)
     except Job.DoesNotExist as e:
         raise e
         # self.retry(exc=e, countdown=1, max_retries=1)
-    else:
-        job.logger.info(f"Running job {job}")
-        try:
-            job.run()
-        except Exception as e:
-            job.logger.error(f'Job #{job.pk} "{job.name}" failed: {e}')
-            raise
-        else:
-            from ami.jobs.models import JobDispatchMode
 
-            job.refresh_from_db()
-            if job.dispatch_mode == JobDispatchMode.ASYNC_API and not job.progress.is_complete():
-                _log_worker_availability(job)
-            else:
-                job.logger.info(f"Finished job {job}")
+    # Early-guard: under acks_late, the broker may redeliver this message after a
+    # worker SIGKILL/OOM, and Job.cancel() may also flip status to CANCELING /
+    # REVOKED while the message sits in the prefetch buffer. Don't re-run a job
+    # that's already settled or being torn down.
+    if job.status in JobState.final_states() or job.status == JobState.CANCELING:
+        job.logger.info(
+            f"Skipping run_job for job {job.pk}: already in status {job.status} "
+            f"(redelivery or cancellation in flight)"
+        )
+        return
+
+    job.logger.info(f"Running job {job}")
+    try:
+        job.run()
+    except Exception as e:
+        job.logger.error(f'Job #{job.pk} "{job.name}" failed: {e}')
+        raise
+    else:
+        from ami.jobs.models import JobDispatchMode
+
+        job.refresh_from_db()
+        if job.dispatch_mode == JobDispatchMode.ASYNC_API and not job.progress.is_complete():
+            _log_worker_availability(job)
+        else:
+            job.logger.info(f"Finished job {job}")
 
 
 def _log_worker_availability(job) -> None:

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -439,6 +439,50 @@ class TestJobView(APITestCase):
         job.refresh_from_db()
         self.assertEqual(job.status, JobState.REVOKED)
 
+    def test_mljob_run_bails_when_cancelled_during_bootstrap(self):
+        """Regression for the cancel-during-bootstrap race in ASYNC_API jobs.
+
+        ``Job.cancel()`` revokes without terminate=True (so the local worker is
+        not SIGTERM'd), marks the row REVOKED, and tears down NATS/Redis state.
+        If the worker is still inside ``MLJob.run`` (typically blocked in the
+        slow ``collect_images`` step), it must refresh the row and bail BEFORE
+        calling ``queue_images_to_nats`` — otherwise it would recreate the
+        stream and dispatch real GPU work to ADC for a revoked job.
+        """
+        from unittest.mock import patch
+
+        from ami.jobs.models import MLJob
+
+        pipeline = Pipeline.objects.create(name="Cancel-race pipeline", slug="cancel-race-pipeline")
+        pipeline.projects.add(self.project)
+        collection = SourceImageCollection.objects.create(name="Cancel-race collection", project=self.project)
+        job = Job.objects.create(
+            project=self.project,
+            name="Cancel-race",
+            pipeline=pipeline,
+            source_image_collection=collection,
+            status=JobState.STARTED,
+            dispatch_mode=JobDispatchMode.ASYNC_API,
+        )
+        job.setup()
+
+        def cancel_mid_collect(*_args, **_kwargs):
+            # Simulate the user clicking cancel while collect_images is still
+            # running: rewrite the DB row out from under this in-flight task.
+            Job.objects.filter(pk=job.pk).update(status=JobState.REVOKED)
+            return []
+
+        with patch.object(
+            pipeline,
+            "collect_images",
+            side_effect=cancel_mid_collect,
+        ), patch("ami.ml.orchestration.jobs.queue_images_to_nats") as mock_queue:
+            MLJob.run(job)
+
+        mock_queue.assert_not_called()
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobState.REVOKED)
+
     def test_cancel_job_without_task_id_still_revokes(self):
         """A job that never made it to enqueue (no task_id) still transitions
         to REVOKED and triggers async-cleanup (a no-op for non-ASYNC_API)."""

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -375,10 +375,92 @@ class TestJobView(APITestCase):
         # Accept either 401 (TokenAuthentication) or 403 (SessionAuthentication with AnonymousUser)
         self.assertIn(resp.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
 
-    def test_cancel_job(self):
-        # This cannot be tested until we have a way to cancel jobs
-        # and a way to run async tasks in tests.
-        pass
+    def test_cancel_async_api_job_does_not_terminate_celery_task(self):
+        """ASYNC_API cancel must revoke without terminate=True.
+
+        The remote ADC worker is doing the actual work via NATS — terminating
+        the (likely-done) local ``run_job`` bootstrap doesn't stop them, and
+        SIGTERM'ing a still-bootstrapping child loses the message under the
+        broker's early-ack default. Cleanup of NATS/Redis state is what
+        actually stops further work.
+        """
+        from unittest.mock import MagicMock, patch
+
+        job = Job.objects.create(
+            project=self.project,
+            name="Cancel async_api",
+            task_id="fake-async-task-id",
+            status=JobState.STARTED,
+            dispatch_mode=JobDispatchMode.ASYNC_API,
+        )
+
+        with patch("ami.jobs.models.run_job") as mock_run_job, patch(
+            "ami.jobs.models.cleanup_async_job_if_needed"
+        ) as mock_cleanup:
+            mock_task = MagicMock()
+            mock_run_job.AsyncResult.return_value = mock_task
+
+            job.cancel()
+
+            mock_run_job.AsyncResult.assert_called_once_with("fake-async-task-id")
+            mock_task.revoke.assert_called_once_with(terminate=False)
+            mock_cleanup.assert_called_once_with(job)
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobState.REVOKED)
+
+    def test_cancel_sync_api_job_terminates_celery_task(self):
+        """SYNC_API / INTERNAL cancel must keep terminate=True.
+
+        Their celery task body owns the entire job lifecycle, so terminating
+        the task is the only way to stop active work.
+        """
+        from unittest.mock import MagicMock, patch
+
+        job = Job.objects.create(
+            project=self.project,
+            name="Cancel sync_api",
+            task_id="fake-sync-task-id",
+            status=JobState.STARTED,
+            dispatch_mode=JobDispatchMode.SYNC_API,
+        )
+
+        with patch("ami.jobs.models.run_job") as mock_run_job, patch(
+            "ami.jobs.models.cleanup_async_job_if_needed"
+        ) as mock_cleanup:
+            mock_task = MagicMock()
+            mock_run_job.AsyncResult.return_value = mock_task
+
+            job.cancel()
+
+            mock_task.revoke.assert_called_once_with(terminate=True)
+            mock_cleanup.assert_called_once_with(job)
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobState.REVOKED)
+
+    def test_cancel_job_without_task_id_still_revokes(self):
+        """A job that never made it to enqueue (no task_id) still transitions
+        to REVOKED and triggers async-cleanup (a no-op for non-ASYNC_API)."""
+        from unittest.mock import patch
+
+        job = Job.objects.create(
+            project=self.project,
+            name="Cancel never-enqueued",
+            task_id="",
+            status=JobState.PENDING,
+            dispatch_mode=JobDispatchMode.INTERNAL,
+        )
+
+        with patch("ami.jobs.models.run_job") as mock_run_job, patch(
+            "ami.jobs.models.cleanup_async_job_if_needed"
+        ) as mock_cleanup:
+            job.cancel()
+            mock_run_job.AsyncResult.assert_not_called()
+            mock_cleanup.assert_called_once_with(job)
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobState.REVOKED)
 
     def test_list_jobs_with_ids_only(self):
         """Test the ids_only parameter returns only job IDs."""

--- a/ami/jobs/tests/test_tasks.py
+++ b/ami/jobs/tests/test_tasks.py
@@ -667,7 +667,7 @@ class TestRunJobEarlyGuard(TransactionTestCase):
         job = self._make_job(JobState.REVOKED)
 
         with patch.object(Job, "run") as mock_run:
-            result = run_job.apply(args=[job.pk])
+            result = run_job.apply(kwargs={"job_id": job.pk})
 
         self.assertTrue(result.successful(), msg=f"task should succeed, got {result.state}: {result.traceback}")
         mock_run.assert_not_called()
@@ -679,7 +679,7 @@ class TestRunJobEarlyGuard(TransactionTestCase):
         job = self._make_job(JobState.CANCELING)
 
         with patch.object(Job, "run") as mock_run:
-            result = run_job.apply(args=[job.pk])
+            result = run_job.apply(kwargs={"job_id": job.pk})
 
         self.assertTrue(result.successful(), msg=f"task should succeed, got {result.state}: {result.traceback}")
         mock_run.assert_not_called()
@@ -691,7 +691,7 @@ class TestRunJobEarlyGuard(TransactionTestCase):
         job = self._make_job(JobState.SUCCESS)
 
         with patch.object(Job, "run") as mock_run:
-            result = run_job.apply(args=[job.pk])
+            result = run_job.apply(kwargs={"job_id": job.pk})
 
         self.assertTrue(result.successful(), msg=f"task should succeed, got {result.state}: {result.traceback}")
         mock_run.assert_not_called()
@@ -703,9 +703,28 @@ class TestRunJobEarlyGuard(TransactionTestCase):
         job = self._make_job(JobState.PENDING)
 
         with patch.object(Job, "run") as mock_run:
-            run_job.apply(args=[job.pk])
+            run_job.apply(kwargs={"job_id": job.pk})
 
         mock_run.assert_called_once()
+
+    def test_prerun_signal_does_not_clobber_revoked_status(self):
+        """
+        Regression: the ``task_prerun`` signal would otherwise call
+        ``update_job_status(state="PENDING")`` and overwrite a REVOKED/CANCELING
+        status before the ``run_job`` early-guard reads it. With the prerun
+        guard in place, the status survives the signal, the early-guard fires,
+        and ``Job.run()`` is not called.
+        """
+        from ami.jobs.tasks import run_job
+
+        job = self._make_job(JobState.REVOKED)
+
+        with patch.object(Job, "run") as mock_run:
+            run_job.apply(kwargs={"job_id": job.pk})
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobState.REVOKED)
+        mock_run.assert_not_called()
 
 
 class TestResultEndpointWithError(APITestCase):

--- a/ami/jobs/tests/test_tasks.py
+++ b/ami/jobs/tests/test_tasks.py
@@ -626,6 +626,88 @@ class TestTaskFailureGuard(TransactionTestCase):
         mock_cleanup.assert_called_once()
 
 
+class TestRunJobEarlyGuard(TransactionTestCase):
+    """
+    run_job early-guard regression tests.
+
+    With ``acks_late=True`` and ``reject_on_worker_lost=True`` on the task,
+    the broker will redeliver a run_job message if a worker dies mid-task
+    (SIGKILL, OOM, deploy roll). The early-guard at the top of ``run_job``
+    short-circuits when the Job is already in a terminal state or being
+    cancelled, so a redelivery — or a cancel-and-retry race — does not
+    re-run side effects. See RolnickLab/antenna#1323.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.project = Project.objects.create(name="run_job guard project")
+        self.pipeline = Pipeline.objects.create(name="run_job guard pipeline", slug="run-job-guard-pipeline")
+        self.pipeline.projects.add(self.project)
+        self.collection = SourceImageCollection.objects.create(name="run_job guard collection", project=self.project)
+
+    def tearDown(self):
+        cache.clear()
+
+    def _make_job(self, status: JobState) -> Job:
+        job = Job.objects.create(
+            job_type_key=MLJob.key,
+            project=self.project,
+            name=f"run_job guard {status}",
+            pipeline=self.pipeline,
+            source_image_collection=self.collection,
+        )
+        job.status = status
+        job.save()
+        return job
+
+    def test_skips_when_job_already_revoked(self):
+        """Redelivery after the user cancelled and the job settled to REVOKED."""
+        from ami.jobs.tasks import run_job
+
+        job = self._make_job(JobState.REVOKED)
+
+        with patch.object(Job, "run") as mock_run:
+            result = run_job.apply(args=[job.pk])
+
+        self.assertTrue(result.successful(), msg=f"task should succeed, got {result.state}: {result.traceback}")
+        mock_run.assert_not_called()
+
+    def test_skips_when_job_canceling(self):
+        """Cancel arrived after the message was already in the prefetch buffer."""
+        from ami.jobs.tasks import run_job
+
+        job = self._make_job(JobState.CANCELING)
+
+        with patch.object(Job, "run") as mock_run:
+            result = run_job.apply(args=[job.pk])
+
+        self.assertTrue(result.successful(), msg=f"task should succeed, got {result.state}: {result.traceback}")
+        mock_run.assert_not_called()
+
+    def test_skips_when_job_already_success(self):
+        """Redelivery after the job actually completed (e.g. ack lost in transit)."""
+        from ami.jobs.tasks import run_job
+
+        job = self._make_job(JobState.SUCCESS)
+
+        with patch.object(Job, "run") as mock_run:
+            result = run_job.apply(args=[job.pk])
+
+        self.assertTrue(result.successful(), msg=f"task should succeed, got {result.state}: {result.traceback}")
+        mock_run.assert_not_called()
+
+    def test_runs_when_job_pending(self):
+        """Contract pair: a healthy first-delivery still calls Job.run()."""
+        from ami.jobs.tasks import run_job
+
+        job = self._make_job(JobState.PENDING)
+
+        with patch.object(Job, "run") as mock_run:
+            run_job.apply(args=[job.pk])
+
+        mock_run.assert_called_once()
+
+
 class TestResultEndpointWithError(APITestCase):
     """Integration test for the result API endpoint with error results."""
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -429,6 +429,18 @@ CELERY_REDIS_BACKEND_HEALTH_CHECK_INTERVAL = 30  # Check health every 30s
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 CELERY_WORKER_ENABLE_PREFETCH_COUNT_REDUCTION = True
 
+# Fair scheduling for the prefork pool.
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-pool-optimization
+# Under the default scheduler the master process pre-assigns prefetched
+# messages to specific prefork children at delivery time, so a long task
+# pinned to one child causes head-of-line blocking even when sibling
+# children are idle. Fair mode holds prefetched messages in a shared buffer
+# and hands one to a child only when that child is genuinely idle, which
+# matters for queues that mix heterogeneous-duration tasks (notably ``jobs``,
+# where ``run_job`` can sit inside ``filter_processed_images`` for minutes).
+# See RolnickLab/antenna#1323.
+CELERY_WORKER_POOL_OPTIMIZATION = "fair"
+
 # Split Celery work across three queues so one class of task can't starve
 # another. Staging/production/worker compose files each run a dedicated
 # worker service per queue; local/CI use a single worker consuming all queues.

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -51,6 +51,16 @@ services:
     command: /start-celeryworker
     environment:
       CELERY_QUEUES: "jobs"
+      # TODO(#1323): consider overriding CELERY_WORKER_CONCURRENCY to ~4 here.
+      # Counter-intuitive but: per-container prefetch = concurrency × prefetch_multiplier(=1),
+      # so a 16-wide jobs container reserves up to 16 messages on a single broker channel.
+      # When one run_job sits idle inside filter_processed_images for minutes, the other 15
+      # reserved slots block sibling jobs from being offered to an idle peer container.
+      # Lowering to 4 shrinks the reservation window so the broker spills aggressively to
+      # peers. Acceptable for jobs queue because run_job spends most of its time waiting on
+      # NATS results rather than CPU. Other queues (ml_results, antenna) want the larger
+      # pool — they're DB/Redis-bound and benefit from oversubscription.
+      # CELERY_WORKER_CONCURRENCY: "4"
     restart: always
 
   celeryworker_ml:


### PR DESCRIPTION
Closes #1323.

Last week we hit the symptom Issue #1323 describes: a `run_job` was sitting inside `filter_processed_images()` for ~9 minutes against a huge collection, and a fresh `run_job` queued behind it sat in `RESERVED` on the same worker container the entire time — even though 15 of 16 children on that container were idle and the entire sibling container was idle. `SIGKILL`'ing the blocker let the queued job start in the same second. The job that finally ran was almost certainly fine, but it wasted nine minutes of wall clock for no good reason, and any user clicking "run" during that window saw nothing happen.

This PR fixes the three reinforcing causes the issue identified, plus an orthogonal cancel-path bug I noticed while reading the code paths. Each one is a small config or decorator change; the value is in stacking them.

## What changes for users

- **Stuck `run_job` no longer blocks other jobs in the queue.** A slow first job releases the worker slot for the next one as soon as a sibling child is idle, rather than holding 15 idle slots hostage.
- **A worker crash mid-job no longer silently drops the job.** Before: the celery message was already acked at delivery, so a SIGKILL/OOM/deploy roll meant the job stayed in `STARTED` forever until the reaper found it. After: broker holds the message, redelivers it when a worker comes back. The job either resumes or — if it had already settled — exits cleanly.
- **Cancelling an async ML job actually cancels.** Today's `Job.cancel` calls `revoke(terminate=True)` on the local `run_job` task. For ASYNC_API that task has almost always already finished (`queue_images_to_nats` returns fast) — terminating it does nothing about the actual work running on the remote ADC worker, and on the rare occasion the bootstrap is still running, the SIGTERM kills it without redelivery. The real cancel mechanism for async is tearing down the NATS stream + Redis state, which `cleanup_async_job_if_needed` already does. We now skip terminate for ASYNC_API.

## Plain-language summary

| Behavior | Before | After |
|---|---|---|
| Long `run_job` blocking sibling jobs on same container | Yes — pre-assignment pins messages to busy child | No — fair scheduler hands messages only to idle children |
| Long `run_job` blocking sibling jobs on sibling container | Sometimes — broker spills late | Reduced — pairs naturally with smaller per-container reservation window (see below) |
| Worker SIGKILL/OOM mid-`run_job` | Message lost; job stranded in STARTED | Broker redelivers; early-guard handles redelivery cleanly |
| Cancel of ASYNC_API job | Terminates local bootstrap (mostly a no-op, occasionally a SIGTERM mid-flight); remote workers keep going | Tears down NATS stream + Redis state; remote work stops naturally |
| Cancel of SYNC_API / INTERNAL job | Terminates celery task | Unchanged — terminate is still the only way |

## What's in this PR

1. **`config/settings/base.py`** — `CELERY_WORKER_POOL_OPTIMIZATION = "fair"`. One line. Applies to all queues; the value is largely on `jobs`.
2. **`ami/jobs/tasks.py`** — `acks_late=True, reject_on_worker_lost=True` on `run_job`, plus an early-guard at the top of the task body that returns cleanly when `job.status` is in `final_states()` or `CANCELING`. The guard is what makes redelivery and cancel-race safe.
3. **`ami/jobs/models.py`** — `Job.cancel` no longer passes `terminate=True` when `dispatch_mode == ASYNC_API`. For other dispatch modes, behavior is unchanged.
4. **`docker-compose.worker.yml`** — added a commented-out `CELERY_WORKER_CONCURRENCY: "4"` on `celeryworker_jobs` with a TODO referencing this issue, in case we want to enable cause C later.

## A note on the counter-intuitive concurrency knob

The issue suggests *lowering* per-container concurrency on the jobs queue as a third fix. I've left this commented out for now (just a discoverability hint in `docker-compose.worker.yml`) because it reads as backwards and I'd rather watch the first two fixes in production before pulling this lever too.

The reasoning, briefly: celery's prefetch reserves `concurrency × prefetch_multiplier(=1)` messages per container at the broker level. With concurrency=16, that's 16 messages held in the container's local buffer. When one of those messages is a stuck task, the container still tells the broker "I have 15 free slots" — and the broker keeps offering new messages to that container instead of spilling to a fully-idle sibling. Lowering concurrency to 4 shrinks the reservation window so the broker spills sooner.

The reason this isn't a meaningful capacity cut: `run_job` spends nearly all its time waiting on NATS results to come back, not burning CPU. The 16 was originally raised (#1228) for `ml_results` and `antenna`, which are DB/Redis-bound and benefit from oversubscription. The `jobs` queue inherited the high number incidentally.

## What the three fixes are actually doing

There are three different head-of-line problems, with three different mechanisms:

- **Inside a child** (one slow task blocks its own pipe): can't be fixed, that's just how prefork works.
- **Inside a container, across children** (default pre-assignment scheduler pins messages to specific child pipes regardless of which child becomes idle first): fixed by `-O fair`.
- **Across containers** (broker prefetch reservation: a 1-task container still looks like it has 15 free slots): mitigated by lower per-container concurrency (the deferred knob).

`acks_late` is orthogonal to all three — it's about surviving worker death, not about scheduling. But it's a precondition for both the cancel fix to be safe (cancellation can now terminate a worker without losing the redelivered message that the early-guard will short-circuit) and for the deferred concurrency change to be safe (smaller pools mean each child handles more tasks, and a single SIGKILL hurts more).

## What's verified

- New unit tests on `Job.cancel` for ASYNC_API / SYNC_API / no-task-id paths.
- New tests on the `run_job` early-guard covering `REVOKED`, `CANCELING`, `SUCCESS`, and the contract pair (`PENDING` still runs).
- Full `ami.jobs.tests` (118 tests) and `ami.ml.tests` + `ami.ml.orchestration.tests` (81 tests) green.

## What still needs verifying in staging/prod

From the issue's "what we still need to verify" section, two of three are now testable:

1. **Re-running the symptom against a real `-O fair` worker** — confirm `RESERVED → ACTIVE` happens immediately when a sibling child is idle. I'd want to do this on dev box (queue two long `run_job`s back-to-back, sleep one).
2. **`-O fair` interaction with `max-tasks-per-child=100`** — should be fine but worth watching for the first day after deploy.
3. **`acks_late` redelivery in practice** — the early-guard makes a redelivered `run_job` a no-op when the job is already settled, so this is covered by the tests, but worth eyeballing the celery logs after deploy for unexpected `Skipping run_job` messages.

The cancel fix is the one I'd most like a second pair of eyes on — the docstring is the long version, but the gist is "for ASYNC_API the celery task isn't where the work is, so terminating it doesn't cancel; cleanup does."

## Related

- #1323 — this issue.
- #1321 — `filter_processed_images` slowness, the upstream cause of the long `run_job` that exposed this. Fixing #1321 reduces the *frequency* of stuck jobs; this PR reduces the *blast radius* when they happen.
- #1228 — the PR that raised `CELERY_WORKER_CONCURRENCY` to 16 for ml/antenna queues. Context for why the jobs queue inherited the same number.
- #1234 / #1235 — the prior async-job fix pair (ACK/SREM ordering, Bug C guard, stale-job cutoff). The cancel fix here is in similar territory.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job cancellation now handles different job types more reliably, ensuring consistent state transitions and proper cleanup.
  * Task execution is more resilient when workers are unexpectedly lost, with automatic re-delivery of in-flight tasks to maintain reliability.

* **Chores**
  * Optimized worker pool scheduling configuration to enable fair task distribution and reduce processing delays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RolnickLab/antenna/pull/1324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->