### PR TITLE
Allow the UI to be served on custom hosts (reverse proxy / Tailscale)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,10 +62,11 @@ services:
       - django
     environment:
       - API_PROXY_TARGET=http://django:8000
-      # Hostnames allowed by `vite preview` when serving the built UI behind a
-      # reverse proxy on a non-localhost host (comma-separated). Unset = Vite's
-      # localhost-only default.
-      # - PREVIEW_ALLOWED_HOSTS=preview.example.com
+      # Hostnames the Vite server accepts when the UI is reached on a
+      # non-localhost host (reverse proxy / Tailscale name), comma-separated.
+      # Covers both `vite preview` (this service) and `yarn start` (ui-dev).
+      # Unset = Vite's localhost-only default.
+      # - UI_ALLOWED_HOSTS=ui.example.com
 
   ui-dev:
     profiles:
@@ -89,10 +90,9 @@ services:
     environment:
       - API_PROXY_TARGET=http://django:8000
       - CHOKIDAR_USEPOLLING=true
-      # Hostnames allowed by the `vite`/`yarn start` dev server when accessing
-      # it on a non-localhost host, e.g. a Tailscale name (comma-separated).
-      # Unset = Vite's localhost-only default.
-      # - DEV_ALLOWED_HOSTS=my-machine.tailnet.ts.net
+      # See UI_ALLOWED_HOSTS note on the `ui` service above. Set this when
+      # reaching the dev server on a non-localhost host (e.g. a Tailscale name).
+      # - UI_ALLOWED_HOSTS=my-machine.tailnet.ts.net
 
   redis:
     image: redis:6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,11 +62,6 @@ services:
       - django
     environment:
       - API_PROXY_TARGET=http://django:8000
-      # Hostnames the Vite server accepts when the UI is reached on a
-      # non-localhost host (reverse proxy / Tailscale name), comma-separated.
-      # Covers both `vite preview` (this service) and `yarn start` (ui-dev).
-      # Unset = Vite's localhost-only default.
-      # - UI_ALLOWED_HOSTS=ui.example.com
 
   ui-dev:
     profiles:
@@ -90,9 +85,6 @@ services:
     environment:
       - API_PROXY_TARGET=http://django:8000
       - CHOKIDAR_USEPOLLING=true
-      # See UI_ALLOWED_HOSTS note on the `ui` service above. Set this when
-      # reaching the dev server on a non-localhost host (e.g. a Tailscale name).
-      # - UI_ALLOWED_HOSTS=my-machine.tailnet.ts.net
 
   redis:
     image: redis:6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,10 @@ services:
       - django
     environment:
       - API_PROXY_TARGET=http://django:8000
+      # Hostnames allowed by `vite preview` when serving the built UI behind a
+      # reverse proxy on a non-localhost host (comma-separated). Unset = Vite's
+      # localhost-only default.
+      # - PREVIEW_ALLOWED_HOSTS=preview.example.com
 
   ui-dev:
     profiles:
@@ -85,6 +89,10 @@ services:
     environment:
       - API_PROXY_TARGET=http://django:8000
       - CHOKIDAR_USEPOLLING=true
+      # Hostnames allowed by the `vite`/`yarn start` dev server when accessing
+      # it on a non-localhost host, e.g. a Tailscale name (comma-separated).
+      # Unset = Vite's localhost-only default.
+      # - DEV_ALLOWED_HOSTS=my-machine.tailnet.ts.net
 
   redis:
     image: redis:6

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,0 +1,13 @@
+# Example environment configuration for the UI (Vite).
+# Copy to `.env.local` (gitignored) and adjust for your setup.
+# See ui/README.md "Configuration" for details.
+
+# Backend the dev server proxies /api and /media to.
+# API_PROXY_TARGET=http://localhost:8000
+
+# Hostnames the Vite server accepts when the UI is reached on a non-localhost
+# host (a reverse proxy, or a Tailscale name). Comma-separated; a leading-dot
+# entry like `.example.com` matches all subdomains. Applies to both the dev
+# server (`yarn start`) and the preview server (`yarn preview`).
+# Unset = Vite's localhost-only default.
+# UI_ALLOWED_HOSTS=ui.example.com

--- a/ui/README.md
+++ b/ui/README.md
@@ -52,6 +52,15 @@ Now you can navigate to the following URL: http://localhost:3000
 
 By default the app will try to connect to http://localhost:8000 for the backend API. Use the env var `API_PROXY_TARGET` to change this. You can create multiple `.env` files in the `ui/` directory for different environments or configurations. For example, use `yarn start --mode staging` to load `.env.staging` and point the `API_PROXY_TARGET` to a remote backend.
 
+#### Allowed hosts
+
+Recent versions of Vite reject requests whose `Host` header isn't `localhost`, which breaks serving the UI on a custom hostname (a reverse proxy, or a Tailscale name). When you need to reach the UI on such a host, declare the allowed hostnames (comma-separated; a leading-dot entry like `.example.com` matches all subdomains):
+
+- `DEV_ALLOWED_HOSTS` — for the dev server (`yarn start` / `vite`).
+- `PREVIEW_ALLOWED_HOSTS` — for the production preview server (`yarn preview` / `vite preview`).
+
+Both are unset by default, preserving Vite's localhost-only behaviour for local development.
+
 ## Nova UI Kit
 
 This is our design system. This code is centralized in the `src/nova-ui-kit` directory and defines the visual language used across the application. It includes colors, typography, responsive breakpoints, and reusable UI primitives.

--- a/ui/README.md
+++ b/ui/README.md
@@ -54,12 +54,9 @@ By default the app will try to connect to http://localhost:8000 for the backend 
 
 #### Allowed hosts
 
-Recent versions of Vite reject requests whose `Host` header isn't `localhost`, which breaks serving the UI on a custom hostname (a reverse proxy, or a Tailscale name). When you need to reach the UI on such a host, declare the allowed hostnames (comma-separated; a leading-dot entry like `.example.com` matches all subdomains):
+Recent versions of Vite reject requests whose `Host` header isn't `localhost`, which breaks serving the UI on a custom hostname (a reverse proxy, or a Tailscale name). When you need to reach the UI on such a host, set `UI_ALLOWED_HOSTS` to the allowed hostnames (comma-separated; a leading-dot entry like `.example.com` matches all subdomains).
 
-- `DEV_ALLOWED_HOSTS` — for the dev server (`yarn start` / `vite`).
-- `PREVIEW_ALLOWED_HOSTS` — for the production preview server (`yarn preview` / `vite preview`).
-
-Both are unset by default, preserving Vite's localhost-only behaviour for local development.
+The same variable covers both Vite servers — the dev server (`yarn start` / `vite`) and the production preview server (`yarn preview` / `vite preview`) — so it works regardless of which one a given container runs. It is unset by default, preserving Vite's localhost-only behaviour for local development.
 
 ## Nova UI Kit
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -23,6 +23,18 @@ export default defineConfig(({ mode }) => {
   // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
   const env = loadEnv(mode, process.cwd(), '')
 
+  // Parse a comma-separated list of hostnames into the array Vite expects for
+  // `allowedHosts`. Empty/whitespace entries (e.g. a trailing comma) are
+  // dropped. Returns undefined when nothing is configured so Vite keeps its
+  // default localhost-only behaviour.
+  const parseAllowedHosts = (value?: string) => {
+    const hosts = value
+      ?.split(',')
+      .map((host) => host.trim())
+      .filter(Boolean)
+    return hosts && hosts.length > 0 ? hosts : undefined
+  }
+
   return {
     assetsInclude: ['**/*.md'],
     base: '/',
@@ -49,6 +61,10 @@ export default defineConfig(({ mode }) => {
     server: {
       open: true,
       port: 3000,
+      // Hosts allowed when serving the dev server (`vite` / `yarn start`)
+      // behind a reverse proxy or on a non-localhost hostname (e.g. a
+      // Tailscale name). Comma-separated; unset keeps Vite's localhost default.
+      allowedHosts: parseAllowedHosts(env.DEV_ALLOWED_HOSTS),
       proxy: {
         '/api': {
           target: env.API_PROXY_TARGET || 'http://localhost:8000',
@@ -65,9 +81,7 @@ export default defineConfig(({ mode }) => {
       // reverse proxy (e.g. a hosted preview deployment). Comma-separated.
       // When unset, Vite's default localhost-only behaviour is preserved, so
       // local development is unaffected.
-      allowedHosts: env.PREVIEW_ALLOWED_HOSTS
-        ? env.PREVIEW_ALLOWED_HOSTS.split(',').map((host) => host.trim())
-        : undefined,
+      allowedHosts: parseAllowedHosts(env.PREVIEW_ALLOWED_HOSTS),
     },
   }
 })

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -60,5 +60,14 @@ export default defineConfig(({ mode }) => {
         },
       },
     },
+    preview: {
+      // Hosts allowed when serving the built app with `vite preview` behind a
+      // reverse proxy (e.g. a hosted preview deployment). Comma-separated.
+      // When unset, Vite's default localhost-only behaviour is preserved, so
+      // local development is unaffected.
+      allowedHosts: env.PREVIEW_ALLOWED_HOSTS
+        ? env.PREVIEW_ALLOWED_HOSTS.split(',').map((host) => host.trim())
+        : undefined,
+    },
   }
 })

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -23,10 +23,15 @@ export default defineConfig(({ mode }) => {
   // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
   const env = loadEnv(mode, process.cwd(), '')
 
-  // Parse a comma-separated list of hostnames into the array Vite expects for
-  // `allowedHosts`. Empty/whitespace entries (e.g. a trailing comma) are
-  // dropped. Returns undefined when nothing is configured so Vite keeps its
-  // default localhost-only behaviour.
+  // UI_ALLOWED_HOSTS declares the hostnames both Vite servers accept when the
+  // app is reached on a non-localhost host (a reverse proxy, or a Tailscale
+  // name): the dev server (`vite` / `yarn start`, via `server.allowedHosts`)
+  // and the preview server (`vite preview`, via `preview.allowedHosts`). A
+  // container only runs one of those, so a single variable covers both.
+  //
+  // Parse a comma-separated list into the array Vite expects. Empty/whitespace
+  // entries (e.g. a trailing comma) are dropped. Returns undefined when nothing
+  // is configured so Vite keeps its default localhost-only behaviour.
   const parseAllowedHosts = (value?: string) => {
     const hosts = value
       ?.split(',')
@@ -61,10 +66,7 @@ export default defineConfig(({ mode }) => {
     server: {
       open: true,
       port: 3000,
-      // Hosts allowed when serving the dev server (`vite` / `yarn start`)
-      // behind a reverse proxy or on a non-localhost hostname (e.g. a
-      // Tailscale name). Comma-separated; unset keeps Vite's localhost default.
-      allowedHosts: parseAllowedHosts(env.DEV_ALLOWED_HOSTS),
+      allowedHosts: parseAllowedHosts(env.UI_ALLOWED_HOSTS),
       proxy: {
         '/api': {
           target: env.API_PROXY_TARGET || 'http://localhost:8000',
@@ -77,11 +79,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     preview: {
-      // Hosts allowed when serving the built app with `vite preview` behind a
-      // reverse proxy (e.g. a hosted preview deployment). Comma-separated.
-      // When unset, Vite's default localhost-only behaviour is preserved, so
-      // local development is unaffected.
-      allowedHosts: parseAllowedHosts(env.PREVIEW_ALLOWED_HOSTS),
+      allowedHosts: parseAllowedHosts(env.UI_ALLOWED_HOSTS),
     },
   }
 })


### PR DESCRIPTION
## Summary

A recent Vite upgrade (pulled in with the dependency update) tightened both Vite servers so they reject any request whose `Host` header isn't `localhost`. That's a reasonable default, but it breaks any setup that reaches the UI through a reverse proxy on a real hostname (a hosted preview/dev deployment, a Tailscale name, etc.): instead of the app, the browser gets a plain-text page saying *"This host is not allowed."*

This adds an opt-in way to declare which hostnames the UI's Vite server should accept, through a single `UI_ALLOWED_HOSTS` environment variable. It covers both servers the `ui` container can run — the dev server (`yarn start` / `vite`, port 3000) and the preview server (`yarn preview` / `vite preview`) — since a container only runs one of them, one variable is enough. Local development is unchanged: when the variable is unset, Vite keeps its localhost-only default, so contributors running the app locally see no difference.

This is the frontend counterpart to the backend's existing host allowlist. Django already controls which hosts its API endpoints and admin will answer to via `DJANGO_ALLOWED_HOSTS` (read into Django's `ALLOWED_HOSTS` in `config/settings/`). A proxied deployment now sets both: `DJANGO_ALLOWED_HOSTS` for the backend, `UI_ALLOWED_HOSTS` for the UI.

### List of Changes

1. **Operators can serve the UI behind a reverse proxy on a named host.** Set `UI_ALLOWED_HOSTS` to a comma-separated list of hostnames (a leading-dot entry like `.example.com` matches all subdomains) and the Vite dev/preview server accepts those requests instead of returning "host not allowed". *Technical: a `parseAllowedHosts` helper in `ui/vite.config.ts` reads `UI_ALLOWED_HOSTS` via the existing `loadEnv` call, splits on commas, trims, drops empty entries, and returns `undefined` when nothing is set so Vite's default is preserved. Wired into both `server.allowedHosts` and `preview.allowedHosts`.*
2. **Documented the new variable** in `ui/.env.example` (new file) and `ui/README.md` so the option is discoverable.

## Detailed Description

The UI container runs either `vite` (dev) or `vite preview` (serving the production build), depending on the compose service. Newer Vite versions added a Host-header allowlist to both as an SSRF/DNS-rebinding mitigation, defaulting to localhost only. Deployments that put either server behind a proxy on a custom domain therefore need to declare the allowed hostnames explicitly. Rather than hardcode any specific domain, this reads the list from the environment so each deployment supplies its own — mirroring how `DJANGO_ALLOWED_HOSTS` already works on the backend.

### How to Test the Changes

1. Build the UI (`yarn build`), then serve it with the variable set:
   `UI_ALLOWED_HOSTS=ui.example.com yarn preview --host 0.0.0.0 --port 4000`
   (or run the dev server: `UI_ALLOWED_HOSTS=ui.example.com yarn start`, which listens on port 3000).
2. `curl -H 'Host: ui.example.com' http://localhost:4000/` (port 3000 for the dev server) → returns the app (HTTP 200), not the "host not allowed" page.
3. Re-run with the variable unset → behaviour is Vite's localhost-only default, unchanged from today.

## Deployment Notes

Set `UI_ALLOWED_HOSTS` in the `ui` service's environment for any proxied deployment (comma-separated hostnames, or a leading-dot wildcard to cover subdomains). No effect if left unset. This is the UI-side analogue of `DJANGO_ALLOWED_HOSTS` on the backend.
