### PR TITLE
Disable thumbnailing in private/draft projects for the time being

### DIFF
--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -79,11 +79,8 @@ class SourceImageThumbnailSerializer(DefaultSerializer):
         self.fields["thumbnails"] = serializers.SerializerMethodField()
 
     def get_thumbnails(self, obj: SourceImage) -> dict | None:
-        # Projects that aren't anonymously readable (draft) get no thumbnail-endpoint
-        # URLs, so the frontend falls back to the capture's presigned source URL. The
-        # endpoint is auth-gated and the frontend loads it via an anonymous <img> tag
-        # that can't send an Authorization header, so it would otherwise 401. Interim
-        # fix; serving thumbnails for private projects is tracked in #1341.
+        # No thumbnail-endpoint URLs for projects that don't allow them (see
+        # Project.thumbnails_enabled); the frontend falls back to the presigned source URL.
         if obj.project is None or not obj.project.thumbnails_enabled:
             return None
         return {

--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -79,20 +79,12 @@ class SourceImageThumbnailSerializer(DefaultSerializer):
         self.fields["thumbnails"] = serializers.SerializerMethodField()
 
     def get_thumbnails(self, obj: SourceImage) -> dict | None:
-        # Draft (non-public) projects: omit the thumbnail-endpoint URLs so the
-        # frontend falls back to the capture's presigned source URL (the
-        # pre-thumbnail-layer behavior), which authenticates via its own signature
-        # and stays private. The endpoint is auth-gated, but the frontend loads
-        # thumbnails via an anonymous <img> tag that cannot send an Authorization
-        # header, so a draft project's thumbnails would otherwise return 401 and
-        # render broken.
-        #
-        # Note: this only stops the UI from generating/serving thumbnails for draft
-        # projects; the endpoint itself is unchanged, so an authenticated caller can
-        # still trigger generation into public default storage. Enforcing that at the
-        # endpoint (and moving thumbnails to per-project storage) is the follow-up.
-        # See PR #1306.
-        if self._project_is_draft(obj.project_id):
+        # Projects that aren't anonymously readable (draft) get no thumbnail-endpoint
+        # URLs, so the frontend falls back to the capture's presigned source URL. The
+        # endpoint is auth-gated and the frontend loads it via an anonymous <img> tag
+        # that can't send an Authorization header, so it would otherwise 401. Interim
+        # fix; serving thumbnails for private projects is tracked in #1341.
+        if obj.project is None or not obj.project.thumbnails_enabled:
             return None
         return {
             label: reverse_with_params(
@@ -103,20 +95,6 @@ class SourceImageThumbnailSerializer(DefaultSerializer):
             )
             for label in settings.THUMBNAILS["SIZES"]
         }
-
-    def _project_is_draft(self, project_id: int | None) -> bool:
-        # Memoize per distinct project on this serializer instance: a list of N
-        # captures sharing one project costs one query, not N (the captures
-        # queryset does not select_related the SourceImage.project FK).
-        if project_id is None:
-            return False
-        cache = getattr(self, "_draft_project_cache", None)
-        if cache is None:
-            cache = {}
-            self._draft_project_cache = cache
-        if project_id not in cache:
-            cache[project_id] = Project.objects.filter(pk=project_id, draft=True).exists()
-        return cache[project_id]
 
 
 class SourceImageNestedSerializer(DefaultSerializer):

--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -79,8 +79,6 @@ class SourceImageThumbnailSerializer(DefaultSerializer):
         self.fields["thumbnails"] = serializers.SerializerMethodField()
 
     def get_thumbnails(self, obj: SourceImage) -> dict | None:
-        # No thumbnail-endpoint URLs for projects that don't allow them (see
-        # Project.thumbnails_enabled); the frontend falls back to the presigned source URL.
         if obj.project is None or not obj.project.thumbnails_enabled:
             return None
         return {

--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -79,6 +79,17 @@ class SourceImageThumbnailSerializer(DefaultSerializer):
         self.fields["thumbnails"] = serializers.SerializerMethodField()
 
     def get_thumbnails(self, obj: SourceImage) -> dict | None:
+        # Draft (non-public) projects are not routed through the thumbnail endpoint.
+        # The endpoint is auth-gated, but the frontend loads thumbnails via an
+        # anonymous <img> tag, which cannot send an Authorization header, so a draft
+        # project's thumbnails would return 401 and render broken. Returning None
+        # makes the frontend fall back to the capture's presigned source URL (the
+        # pre-thumbnail-layer behavior), which authenticates via its own signature
+        # and stays private. Generated thumbnails are also written to public default
+        # storage, so they must not be produced for non-public projects until
+        # per-project thumbnail storage exists. See PR #1306.
+        if self._project_is_draft(obj.project_id):
+            return None
         return {
             label: reverse_with_params(
                 "sourceimagethumbnail-detail",
@@ -88,6 +99,20 @@ class SourceImageThumbnailSerializer(DefaultSerializer):
             )
             for label in settings.THUMBNAILS["SIZES"]
         }
+
+    def _project_is_draft(self, project_id: int | None) -> bool:
+        # Memoize per distinct project on this serializer instance: a list of N
+        # captures sharing one project costs one query, not N (the captures
+        # queryset does not select_related the SourceImage.project FK).
+        if project_id is None:
+            return False
+        cache = getattr(self, "_draft_project_cache", None)
+        if cache is None:
+            cache = {}
+            self._draft_project_cache = cache
+        if project_id not in cache:
+            cache[project_id] = Project.objects.filter(pk=project_id, draft=True).exists()
+        return cache[project_id]
 
 
 class SourceImageNestedSerializer(DefaultSerializer):

--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -79,15 +79,19 @@ class SourceImageThumbnailSerializer(DefaultSerializer):
         self.fields["thumbnails"] = serializers.SerializerMethodField()
 
     def get_thumbnails(self, obj: SourceImage) -> dict | None:
-        # Draft (non-public) projects are not routed through the thumbnail endpoint.
-        # The endpoint is auth-gated, but the frontend loads thumbnails via an
-        # anonymous <img> tag, which cannot send an Authorization header, so a draft
-        # project's thumbnails would return 401 and render broken. Returning None
-        # makes the frontend fall back to the capture's presigned source URL (the
+        # Draft (non-public) projects: omit the thumbnail-endpoint URLs so the
+        # frontend falls back to the capture's presigned source URL (the
         # pre-thumbnail-layer behavior), which authenticates via its own signature
-        # and stays private. Generated thumbnails are also written to public default
-        # storage, so they must not be produced for non-public projects until
-        # per-project thumbnail storage exists. See PR #1306.
+        # and stays private. The endpoint is auth-gated, but the frontend loads
+        # thumbnails via an anonymous <img> tag that cannot send an Authorization
+        # header, so a draft project's thumbnails would otherwise return 401 and
+        # render broken.
+        #
+        # Note: this only stops the UI from generating/serving thumbnails for draft
+        # projects; the endpoint itself is unchanged, so an authenticated caller can
+        # still trigger generation into public default storage. Enforcing that at the
+        # endpoint (and moving thumbnails to per-project storage) is the follow-up.
+        # See PR #1306.
         if self._project_is_draft(obj.project_id):
             return None
         return {

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -636,6 +636,7 @@ class SourceImageViewSet(DefaultViewSet, ProjectMixin):
             "event",
             "deployment",
             "deployment__data_source",
+            "project",  # thumbnails serializer reads project.thumbnails_enabled per row
         ).order_by("timestamp")
 
         if self.action == "list":

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -319,6 +319,17 @@ class Project(ProjectSettingsMixin, BaseModel):
         if self.owner and not self.members.filter(id=self.owner.pk).exists():
             self.members.add(self.owner)
 
+    @property
+    def thumbnails_enabled(self) -> bool:
+        """Whether captures in this project should expose server-generated thumbnail URLs.
+
+        Draft projects aren't anonymously readable, and the thumbnail endpoint is loaded
+        via an anonymous <img> tag that can't authenticate, so it would 401. Proxy for
+        "anonymous can retrieve captures"; revisit if visibility decouples from `draft`.
+        Serving thumbnails for private projects is tracked in #1341.
+        """
+        return not self.draft
+
     def deployments_count(self) -> int:
         return self.deployments.count()
 

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -526,8 +526,8 @@ class TestThumbnailDraftProjectVisibility(APITestCase):
     The frontend loads thumbnails via an anonymous ``<img>`` tag, which cannot send
     an Authorization header, so a draft project's gated thumbnail endpoint returns
     401 and the image renders broken. The serializer omits thumbnail URLs for draft
-    projects so the frontend falls back to the capture's presigned source URL (the
-    pre-thumbnail-layer behavior). Public projects keep server-generated thumbnails.
+    projects so the frontend falls back to the capture's source URL (``capture.url``,
+    the pre-thumbnail-layer behavior). Public projects keep server-generated thumbnails.
     """
 
     def setUp(self) -> None:
@@ -558,9 +558,9 @@ class TestThumbnailDraftProjectVisibility(APITestCase):
         response = self.client.get(f"/api/v2/captures/{captures[0].pk}/?project_id={project.pk}")
         self.assertEqual(response.status_code, 200)
         rec = response.json()
-        # No thumbnail endpoint URLs -> frontend falls back to the presigned source URL.
+        # No thumbnail endpoint URLs -> frontend falls back to the capture's source URL.
         self.assertIsNone(rec["thumbnails"])
-        self.assertTrue(rec["url"], "presigned source URL must still be provided for fallback")
+        self.assertTrue(rec["url"], "source URL must still be provided for fallback")
 
     @override_settings(CACHALOT_ENABLED=False)
     def test_thumbnails_check_does_not_fetch_project_per_capture(self):

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -563,41 +563,37 @@ class TestThumbnailDraftProjectVisibility(APITestCase):
         self.assertTrue(rec["url"], "presigned source URL must still be provided for fallback")
 
     @override_settings(CACHALOT_ENABLED=False)
-    def test_draft_check_is_memoized_not_per_capture(self):
-        """The draft lookup must run exactly once per project, not once per capture row.
+    def test_thumbnails_check_does_not_fetch_project_per_capture(self):
+        """Reading ``project.thumbnails_enabled`` per capture must not trigger a query.
 
-        Without memoization the serializer would issue one ``draft`` lookup per
-        capture (an N+1). Query caching is disabled here so the count reflects real
-        DB hits rather than a warmed cache (otherwise a true N+1 could be masked by
-        cachalot serving the repeated lookup from cache).
+        The list queryset ``select_related("project")`` so the FK is populated via the
+        main JOIN. Without it the serializer would lazy-load ``obj.project`` once per
+        capture row — an N+1. We assert no standalone per-row fetch of the project
+        table occurs. Query caching is disabled so the count reflects real DB hits.
         """
-        from django.core.cache import cache
         from django.db import connection
         from django.test.utils import CaptureQueriesContext
 
         project, _, captures = self._make_project_with_captures(draft=True)
         self.assertGreater(len(captures), 1, "need a multi-row fixture to detect an N+1")
 
-        cache.clear()
         url = f"/api/v2/captures/?project_id={project.pk}"
         with CaptureQueriesContext(connection) as ctx:
             response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertGreater(len(response.json()["results"]), 1, "need >1 result row to detect an N+1")
 
-        # Target the memoized `Project.objects.filter(pk=..., draft=True).exists()`
-        # specifically: an existence probe (``LIMIT 1``) against the project table
-        # filtering on ``draft``. Match case-insensitively and without quoted
-        # identifiers so the predicate is not tied to one DB backend's SQL dialect.
-        draft_lookups = [
-            q
-            for q in ctx.captured_queries
-            if "main_project" in q["sql"].lower() and "draft" in q["sql"].lower() and "limit 1" in q["sql"].lower()
+        # A lazy-load of ``obj.project`` reads the project table as the primary FROM
+        # (``SELECT ... FROM main_project WHERE id = ?``); the JOINed list query does
+        # not. Match without quoted identifiers so it is not tied to one DB backend.
+        per_row_project_fetches = [
+            q for q in ctx.captured_queries if "from main_project" in q["sql"].lower().replace('"', "")
         ]
         self.assertEqual(
-            len(draft_lookups),
-            1,
-            f"draft lookup ran {len(draft_lookups)} times across {len(captures)} captures (expected memoized to 1)",
+            len(per_row_project_fetches),
+            0,
+            f"project table fetched {len(per_row_project_fetches)} times across "
+            f"{len(captures)} captures (expected 0 via select_related)",
         )
 
 

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -519,6 +519,69 @@ class TestImageThumbnailViews(TestCase):
         self.assertFalse(default_storage.exists(path), "pre_delete signal must clean the storage blob")
 
 
+class TestThumbnailDraftProjectVisibility(APITestCase):
+    """PR #1306 follow-up: draft (non-public) projects must not route thumbnails
+    through the auth-gated thumbnail endpoint.
+
+    The frontend loads thumbnails via an anonymous ``<img>`` tag, which cannot send
+    an Authorization header, so a draft project's gated thumbnail endpoint returns
+    401 and the image renders broken. The serializer omits thumbnail URLs for draft
+    projects so the frontend falls back to the capture's presigned source URL (the
+    pre-thumbnail-layer behavior). Public projects keep server-generated thumbnails.
+    """
+
+    def setUp(self) -> None:
+        self.superuser = User.objects.create_superuser(email="thumb-draft-admin@insectai.org", password="secret")
+        # Superuser can view captures of a draft project; we assert on the serialized
+        # ``thumbnails`` field, which is independent of who is viewing.
+        self.client.force_authenticate(self.superuser)
+        return super().setUp()
+
+    def _make_project_with_captures(self, draft: bool):
+        project, deployment = setup_test_project(reuse=False)
+        if draft:
+            project.draft = True
+            project.save(update_fields=["draft"])
+        captures = create_captures_from_files(deployment=deployment)
+        return project, deployment, [c[0] for c in captures]
+
+    def test_public_project_returns_thumbnail_urls(self):
+        project, _, captures = self._make_project_with_captures(draft=False)
+        response = self.client.get(f"/api/v2/captures/{captures[0].pk}/?project_id={project.pk}")
+        self.assertEqual(response.status_code, 200)
+        thumbnails = response.json()["thumbnails"]
+        self.assertIsNotNone(thumbnails)
+        self.assertIn("small", thumbnails)
+
+    def test_draft_project_omits_thumbnail_urls(self):
+        project, _, captures = self._make_project_with_captures(draft=True)
+        response = self.client.get(f"/api/v2/captures/{captures[0].pk}/?project_id={project.pk}")
+        self.assertEqual(response.status_code, 200)
+        rec = response.json()
+        # No thumbnail endpoint URLs -> frontend falls back to the presigned source URL.
+        self.assertIsNone(rec["thumbnails"])
+        self.assertTrue(rec["url"], "presigned source URL must still be provided for fallback")
+
+    def test_draft_check_is_memoized_not_per_capture(self):
+        """The draft lookup must run at most once per project, not once per capture row."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        project, _, captures = self._make_project_with_captures(draft=True)
+        self.assertGreater(len(captures), 1, "need a multi-row fixture to detect an N+1")
+
+        url = f"/api/v2/captures/?project_id={project.pk}"
+        self.client.get(url)  # warm content-type / cachalot caches
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertGreater(len(response.json()["results"]), 1)
+
+        draft_queries = [q for q in ctx.captured_queries if '"main_project"' in q["sql"] and "draft" in q["sql"]]
+        self.assertLessEqual(len(draft_queries), 1, f"draft lookup ran {len(draft_queries)} times (N+1)")
+
+
 class TestImageGrouping(TestCase):
     def setUp(self) -> None:
         print(f"Currently active database: {connection.settings_dict}")

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -531,11 +531,11 @@ class TestThumbnailDraftProjectVisibility(APITestCase):
     """
 
     def setUp(self) -> None:
+        super().setUp()
         self.superuser = User.objects.create_superuser(email="thumb-draft-admin@insectai.org", password="secret")
         # Superuser can view captures of a draft project; we assert on the serialized
         # ``thumbnails`` field, which is independent of who is viewing.
         self.client.force_authenticate(self.superuser)
-        return super().setUp()
 
     def _make_project_with_captures(self, draft: bool):
         project, deployment = setup_test_project(reuse=False)
@@ -562,24 +562,43 @@ class TestThumbnailDraftProjectVisibility(APITestCase):
         self.assertIsNone(rec["thumbnails"])
         self.assertTrue(rec["url"], "presigned source URL must still be provided for fallback")
 
+    @override_settings(CACHALOT_ENABLED=False)
     def test_draft_check_is_memoized_not_per_capture(self):
-        """The draft lookup must run at most once per project, not once per capture row."""
+        """The draft lookup must run exactly once per project, not once per capture row.
+
+        Without memoization the serializer would issue one ``draft`` lookup per
+        capture (an N+1). Query caching is disabled here so the count reflects real
+        DB hits rather than a warmed cache (otherwise a true N+1 could be masked by
+        cachalot serving the repeated lookup from cache).
+        """
+        from django.core.cache import cache
         from django.db import connection
         from django.test.utils import CaptureQueriesContext
 
         project, _, captures = self._make_project_with_captures(draft=True)
         self.assertGreater(len(captures), 1, "need a multi-row fixture to detect an N+1")
 
+        cache.clear()
         url = f"/api/v2/captures/?project_id={project.pk}"
-        self.client.get(url)  # warm content-type / cachalot caches
-
         with CaptureQueriesContext(connection) as ctx:
             response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertGreater(len(response.json()["results"]), 1)
+        self.assertGreater(len(response.json()["results"]), 1, "need >1 result row to detect an N+1")
 
-        draft_queries = [q for q in ctx.captured_queries if '"main_project"' in q["sql"] and "draft" in q["sql"]]
-        self.assertLessEqual(len(draft_queries), 1, f"draft lookup ran {len(draft_queries)} times (N+1)")
+        # Target the memoized `Project.objects.filter(pk=..., draft=True).exists()`
+        # specifically: an existence probe (``LIMIT 1``) against the project table
+        # filtering on ``draft``. Match case-insensitively and without quoted
+        # identifiers so the predicate is not tied to one DB backend's SQL dialect.
+        draft_lookups = [
+            q
+            for q in ctx.captured_queries
+            if "main_project" in q["sql"].lower() and "draft" in q["sql"].lower() and "limit 1" in q["sql"].lower()
+        ]
+        self.assertEqual(
+            len(draft_lookups),
+            1,
+            f"draft lookup ran {len(draft_lookups)} times across {len(captures)} captures (expected memoized to 1)",
+        )
 
 
 class TestImageGrouping(TestCase):


### PR DESCRIPTION
## Summary

Images in draft (non-public) projects have been rendering broken since the server-side thumbnail layer (#1306) shipped. This restores them.

The thumbnail endpoint is authentication-gated, but the frontend loads thumbnails through an anonymous `<img>` tag, which cannot send an Authorization header. For a draft project the anonymous request is denied (401), so every capture image appears broken. Public projects were unaffected, because anonymous read passes their permission check.

The fix is deliberately small and safe: for draft projects the API no longer hands back thumbnail-endpoint URLs, so the frontend falls back to the capture's source URL (`capture.url`) — exactly how images were served before the thumbnail layer, bypassing the auth-gated endpoint. Public projects keep server-generated thumbnails and their performance benefit.

(Note: project visibility is independent of storage. Whether the source URL is presigned depends on the capture's bucket, not on whether the project is draft — a draft project may live on a public bucket and a public project on a private one. The determinant here is the `draft` flag / anonymous-retrieve permission, not bucket type.)

This is an interim fix. The longer-term plan (self-authenticating signed-token thumbnail URLs, or writing thumbnails to each project's own object store) lets draft/private projects benefit from thumbnails too; it is tracked in **#1341**. We chose not to simply open the endpoint to anonymous access, because generated thumbnails are written to public default storage where they would be world-readable and enumerable by capture id — a privacy regression for restricted imagery.

### List of Changes

| # | Change (user-facing effect) | How (implementation) |
|---|------------------------------|----------------------|
| 1 | Draft-project capture images render again instead of showing broken thumbnails. | New `Project.thumbnails_enabled` property (`= not draft`) names the policy on the model; `SourceImageThumbnailSerializer.get_thumbnails` returns `None` when it is false, and the frontend already falls back to the source URL when no thumbnails are present (`ui/.../capture.ts`). |
| 2 | No new per-row database load from the draft check on capture lists. | The captures list queryset `select_related("project")`, so the serializer reads `obj.project.thumbnails_enabled` straight off the main JOIN — one query for the whole page, no per-instance memoization. |
| 3 | Regression coverage for the bug class that slipped through. | `TestThumbnailDraftProjectVisibility`: public project returns thumbnail URLs; draft project omits them (and still returns the source `url` for fallback); and a query-capture test proves the list path does no standalone per-row project fetch (the `select_related` guarantee). The existing thumbnail tests only covered a public project, which is why this regressed silently. |

## Detailed Description

Root cause, empirical confirmation, the `<img>`-cannot-authenticate constraint, and the longer-term options are tracked in **#1341**. Context also posted on #1306.

Follow-up to #1306; interacts with #1331 (direct thumbnail URLs), which does not on its own fix draft projects. The durable fix is tracked in #1341.