### PR TITLE
Log premature-terminal and missing-state job failures (observability for #1337)

### DIFF
--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -437,51 +437,38 @@ def _fail_job(job_id: int, reason: str) -> None:
 
 
 def _log_missing_state_context(job_id: int, stage: str) -> None:
-    """Log context when a result arrives but the job's Redis state is absent.
-
-    A missing total-images key is treated as fatal by the result handler, but it
-    conflates three cases: genuinely cleaned up (end of life), never seeded yet
-    (startup race), and wiped by a duplicate/redelivered run_job re-running
-    initialize_job. Record the job's age and status so we can tell which one is
-    actually happening before adding grace logic. Observation only; see #1337.
-    """
+    # Diagnostic for a missing progress-state key. Status + age separate the two
+    # cases: a terminal job means a late result arriving after the job finished
+    # (benign — e.g. a cancel already cleaned up the state); a still-running job
+    # with no state is the one worth investigating (state never seeded, or wiped
+    # by a re-dispatched run). Observation only; the fix is planned in #1337.
     from django.utils import timezone
 
     from ami.jobs.models import Job, JobState  # avoid circular import
 
     try:
-        row = Job.objects.values("status", "dispatch_mode", "created_at").get(pk=job_id)
+        row = Job.objects.values("status", "created_at").get(pk=job_id)
     except Job.DoesNotExist:
-        logger.warning("Missing Redis state for job %s (stage=%s) and the job row is gone. See #1337.", job_id, stage)
+        logger.warning("Job %s: progress state missing and the job no longer exists (stage=%s).", job_id, stage)
         return
 
     age = (timezone.now() - row["created_at"]).total_seconds() if row["created_at"] else None
     age_s = round(age, 1) if age is not None else None
 
     if row["status"] in JobState.final_states():
-        # Expected: an in-flight result arriving after the job already finished
-        # (e.g. a cancel deleted the Redis state). The _fail_job call below no-ops
-        # on a terminal job, so this is normal post-terminal cleanup, not an
-        # anomaly — info, not warning.
         logger.info(
-            "Ignoring in-flight result for already-terminal job %s (stage=%s, status=%s, age_s=%s). See #1337.",
+            "Job %s: result arrived after the job already finished (status=%s, stage=%s); ignoring.",
             job_id,
-            stage,
             row["status"],
-            age_s,
+            stage,
         )
     else:
-        # The job is NOT terminal but its state is gone — this is the case worth
-        # investigating. A small age points to a not-yet-seeded or redispatch
-        # race rather than genuine cleanup.
         logger.warning(
-            "Missing Redis state for non-terminal job %s (stage=%s): status=%s dispatch=%s age_s=%s. "
-            "Failing job. A small age points to a not-yet-seeded or redispatch race rather than genuine cleanup. "
-            "See #1337.",
+            "Job %s: progress state missing while the job is still running "
+            "(status=%s, stage=%s, age=%ss); marking it failed.",
             job_id,
-            stage,
             row["status"],
-            row["dispatch_mode"],
+            stage,
             age_s,
         )
 
@@ -706,19 +693,13 @@ def _update_job_progress(
                 # already-terminal job's JSONB would disagree with its column.
                 job.progress.summary.status = complete_state
             else:
-                # The work completed but the guard found the job already terminal/
-                # CANCELING, so the completion was not applied. Often legitimate (a
-                # user cancel or the reaper genuinely won the race), but a frequent
-                # occurrence signals a PREMATURE terminal verdict — e.g. the reaper
-                # revoked a slow-but-alive job and its results then landed. Logged so
-                # these false-positive terminals are visible instead of silently
-                # swallowed by the guard. Observation only; see #1337.
-                current = Job.objects.filter(pk=job_id).values_list("status", flat=True).first()
+                # Work completed but the guard found the job already terminal/CANCELING,
+                # so the completion was not applied. Usually legitimate (a cancel or the
+                # reaper won the race); if frequent it points to a premature terminal
+                # verdict. Observation only; see #1337.
                 logger.warning(
-                    "Job %s completed work after it was already terminal (status=%s); "
-                    "completion not applied. If frequent, the terminal verdict may be premature. See #1337.",
+                    "Job %s: work completed but the job was already in a terminal state; completion not applied.",
                     job_id,
-                    current,
                 )
 
         # status/finished_at are deliberately NOT in this save() — only the

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -447,19 +447,22 @@ def _log_missing_state_context(job_id: int, stage: str) -> None:
     from ami.jobs.models import Job, JobState  # avoid circular import
 
     try:
-        row = Job.objects.values("status", "created_at").get(pk=job_id)
+        job_values = Job.objects.values("status", "created_at").get(pk=job_id)
     except Job.DoesNotExist:
         logger.warning("Job %s: progress state missing and the job no longer exists (stage=%s).", job_id, stage)
         return
 
-    age = (timezone.now() - row["created_at"]).total_seconds() if row["created_at"] else None
+    age = (timezone.now() - job_values["created_at"]).total_seconds() if job_values["created_at"] else None
     age_s = round(age, 1) if age is not None else None
 
-    if row["status"] in JobState.final_states():
+    # Mirror _fail_job's no-op set: a job that is already terminal OR cancelling
+    # will not actually be failed, so a late result for it is expected cleanup,
+    # not an anomaly.
+    if job_values["status"] in {JobState.CANCELING, *JobState.final_states()}:
         logger.info(
             "Job %s: result arrived after the job already finished (status=%s, stage=%s); ignoring.",
             job_id,
-            row["status"],
+            job_values["status"],
             stage,
         )
     else:
@@ -467,7 +470,7 @@ def _log_missing_state_context(job_id: int, stage: str) -> None:
             "Job %s: progress state missing while the job is still running "
             "(status=%s, stage=%s, age=%ss); marking it failed.",
             job_id,
-            row["status"],
+            job_values["status"],
             stage,
             age_s,
         )
@@ -697,9 +700,10 @@ def _update_job_progress(
                 # so the completion was not applied. Usually legitimate (a cancel or the
                 # reaper won the race); if frequent it points to a premature terminal
                 # verdict. Observation only; see #1337.
-                logger.warning(
-                    "Job %s: work completed but the job was already in a terminal state; completion not applied.",
-                    job_id,
+                job.logger.warning(
+                    "Stage '%s' completed but the job was already in a terminal state; not applying %s.",
+                    stage,
+                    complete_state,
                 )
 
         # status/finished_at are deliberately NOT in this save() — only the

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -282,6 +282,7 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
         # State keys genuinely missing (the total-images key returned None).
         # Ack so NATS stops redelivering and fail the job — there's no state
         # left to reconcile against.
+        _log_missing_state_context(job_id, "process")
         _ack_task_via_nats(reply_subject, logger)
         _fail_job(job_id, "Job state keys not found in Redis (likely cleaned up concurrently)")
         return
@@ -364,6 +365,7 @@ def process_nats_pipeline_result(self, job_id: int, result_data: dict, reply_sub
             # State keys genuinely missing (total-images key returned None). Ack
             # first so NATS stops redelivering a message whose state is gone,
             # then fail the job. Mirrors the stage=process missing-state path.
+            _log_missing_state_context(job_id, "results")
             _ack_task_via_nats(reply_subject, job.logger)
             _fail_job(job_id, "Job state keys not found in Redis (likely cleaned up concurrently)")
             return
@@ -432,6 +434,35 @@ def _fail_job(job_id: int, reason: str) -> None:
     except Job.DoesNotExist:
         logger.error(f"Cannot fail job {job_id}: not found")
         cleanup_async_job_resources(job_id)
+
+
+def _log_missing_state_context(job_id: int, stage: str) -> None:
+    """Log context when a result arrives but the job's Redis state is absent.
+
+    A missing total-images key is treated as fatal by the result handler, but it
+    conflates three cases: genuinely cleaned up (end of life), never seeded yet
+    (startup race), and wiped by a duplicate/redelivered run_job re-running
+    initialize_job. Record the job's age and status so we can tell which one is
+    actually happening before adding grace logic. Observation only; see #1337.
+    """
+    from django.utils import timezone
+
+    from ami.jobs.models import Job  # avoid circular import
+
+    try:
+        row = Job.objects.values("status", "dispatch_mode", "created_at").get(pk=job_id)
+        age = (timezone.now() - row["created_at"]).total_seconds() if row["created_at"] else None
+        logger.warning(
+            "Missing Redis state for job %s (stage=%s): status=%s dispatch=%s age_s=%s. Failing job. "
+            "A small age points to a not-yet-seeded or redispatch race rather than genuine cleanup. See #1337.",
+            job_id,
+            stage,
+            row["status"],
+            row["dispatch_mode"],
+            round(age, 1) if age is not None else None,
+        )
+    except Job.DoesNotExist:
+        logger.warning("Missing Redis state for job %s (stage=%s) and the job row is gone. See #1337.", job_id, stage)
 
 
 def _ack_task_via_nats(reply_subject: str, job_logger: logging.Logger) -> bool:
@@ -653,6 +684,21 @@ def _update_job_progress(
                 # Advance summary.status only when the transition fired, else an
                 # already-terminal job's JSONB would disagree with its column.
                 job.progress.summary.status = complete_state
+            else:
+                # The work completed but the guard found the job already terminal/
+                # CANCELING, so the completion was not applied. Often legitimate (a
+                # user cancel or the reaper genuinely won the race), but a frequent
+                # occurrence signals a PREMATURE terminal verdict — e.g. the reaper
+                # revoked a slow-but-alive job and its results then landed. Logged so
+                # these false-positive terminals are visible instead of silently
+                # swallowed by the guard. Observation only; see #1337.
+                current = Job.objects.filter(pk=job_id).values_list("status", flat=True).first()
+                logger.warning(
+                    "Job %s completed work after it was already terminal (status=%s); "
+                    "completion not applied. If frequent, the terminal verdict may be premature. See #1337.",
+                    job_id,
+                    current,
+                )
 
         # status/finished_at are deliberately NOT in this save() — only the
         # guarded UPDATE above writes them. Folding them back in reopens #1337.

--- a/ami/jobs/tasks.py
+++ b/ami/jobs/tasks.py
@@ -447,22 +447,43 @@ def _log_missing_state_context(job_id: int, stage: str) -> None:
     """
     from django.utils import timezone
 
-    from ami.jobs.models import Job  # avoid circular import
+    from ami.jobs.models import Job, JobState  # avoid circular import
 
     try:
         row = Job.objects.values("status", "dispatch_mode", "created_at").get(pk=job_id)
-        age = (timezone.now() - row["created_at"]).total_seconds() if row["created_at"] else None
+    except Job.DoesNotExist:
+        logger.warning("Missing Redis state for job %s (stage=%s) and the job row is gone. See #1337.", job_id, stage)
+        return
+
+    age = (timezone.now() - row["created_at"]).total_seconds() if row["created_at"] else None
+    age_s = round(age, 1) if age is not None else None
+
+    if row["status"] in JobState.final_states():
+        # Expected: an in-flight result arriving after the job already finished
+        # (e.g. a cancel deleted the Redis state). The _fail_job call below no-ops
+        # on a terminal job, so this is normal post-terminal cleanup, not an
+        # anomaly — info, not warning.
+        logger.info(
+            "Ignoring in-flight result for already-terminal job %s (stage=%s, status=%s, age_s=%s). See #1337.",
+            job_id,
+            stage,
+            row["status"],
+            age_s,
+        )
+    else:
+        # The job is NOT terminal but its state is gone — this is the case worth
+        # investigating. A small age points to a not-yet-seeded or redispatch
+        # race rather than genuine cleanup.
         logger.warning(
-            "Missing Redis state for job %s (stage=%s): status=%s dispatch=%s age_s=%s. Failing job. "
-            "A small age points to a not-yet-seeded or redispatch race rather than genuine cleanup. See #1337.",
+            "Missing Redis state for non-terminal job %s (stage=%s): status=%s dispatch=%s age_s=%s. "
+            "Failing job. A small age points to a not-yet-seeded or redispatch race rather than genuine cleanup. "
+            "See #1337.",
             job_id,
             stage,
             row["status"],
             row["dispatch_mode"],
-            round(age, 1) if age is not None else None,
+            age_s,
         )
-    except Job.DoesNotExist:
-        logger.warning("Missing Redis state for job %s (stage=%s) and the job row is gone. See #1337.", job_id, stage)
 
 
 def _ack_task_via_nats(reply_subject: str, job_logger: logging.Logger) -> bool:


### PR DESCRIPTION
## Summary

This is an observability-only change (no behaviour change) that makes two classes of "the job ended up in a terminal state" event visible in the logs, so we can tell *legitimate* terminal verdicts from *premature* ones before adding any corrective logic.

It follows #1338 (now merged), which made the result handler's terminal status transition atomic and non-regressing (the companion #1342 extends the same guard to the cancel and signal-handler writers). A side effect of that hardening is that a terminal verdict is now irreversible: a late-arriving completion can no longer pull a job back out of REVOKED/FAILURE. That is correct when the terminal verdict was right (a user cancel, a real crash), but it cements the verdict when it was *wrong* (for example, the stale-job reaper revoked a slow-but-alive job and its results then landed, or a result arrived while the job's Redis state was momentarily absent). These logs surface those cases instead of letting them disappear silently.

### List of Changes

1. **Log when work completes for a job that is already terminal.** In `_update_job_progress` (`ami/jobs/tasks.py`), when the guarded terminal transition does *not* fire because the job is already terminal/CANCELING, emit a warning via the per-job log, naming the stage and the terminal state that was not applied. This is often legitimate (a cancel or the reaper genuinely won the race), but a frequent occurrence is the signal of a premature terminal verdict. *Observation only — the guard behaviour is unchanged.*
2. **Log context when a result arrives for missing Redis state.** The result handler treats a missing total-images key as fatal (ack + `_fail_job`). That single condition conflates three very different situations: state genuinely cleaned up (end of life), state never seeded yet (startup race), and state wiped by a duplicate/redelivered `run_job` re-running `initialize_job`. A new `_log_missing_state_context` helper records the job's age and status at both missing-state branches and splits the log by job state: a terminal/CANCELING job logs an **info** line (a late result after the job already finished — benign, e.g. cancel cleanup, which `_fail_job` no-ops on anyway), while a still-running job with missing state logs a **warning** (the case worth investigating). *Behaviour unchanged — the job is still failed where it was before; we just log why first, at the right severity.*

The log messages are plain operational statements (no ticket numbers or internal jargon in the runtime strings); the rationale and issue reference live in code comments.

## Why observation before correction

We have a report of Redis state appearing "missing for a moment at the beginning" of jobs, and the result handler currently fails a job on the first missing-state read with no second chance. Before adding grace/retry logic we want to confirm the actual trigger (a small `age` in the new log, on a still-running job, would point to a not-yet-seeded or redispatch race rather than genuine cleanup). Instrument, confirm, then fix.

## Follow-up (NOT in this PR — proposed)

Once the logs confirm the trigger, the corrective changes to make are:

1. **Grace on missing-state in the result handler.** If state is missing but the job is young / not yet `STARTED` / recently dispatched, do **not** ack-and-fail; re-raise so NATS redelivers and the brief gap self-heals, and only fail after a grace window. Today it fails immediately on the first read.
2. **Make `initialize_job` non-clobbering / idempotent.** It currently `delete`s the pending sets before re-adding, so a second `run_job` (a re-run, or an `acks_late` redelivery) wipes a job's live in-flight state. Refuse or no-op re-initialization of a job that already has pending state unless it's an explicit reset. **This is a prerequisite for #1324's `acks_late` redelivery**, which can re-trigger `run_job`.

## How to Test the Changes

- Full `ami/jobs/tests/test_tasks.py` and `ami/jobs/tests/test_jobs.py` pass locally (no behaviour change).
- The new log lines sit on the existing missing-state and already-terminal code paths; no new branches in control flow.
- Verified live on a dev deployment: cancelling a job mid-process produces the expected info line ("result arrived after the job already finished, status=REVOKED ... ignoring") for each in-flight result, rather than a misleading failure warning.

## Checklist

- [x] I have tested these changes appropriately.
- [x] I have added and/or modified relevant tests.
- [ ] I updated relevant documentation or comments.
- [x] I have verified that this PR follows the project's coding standards.
- [x] Any dependent changes have already been merged to main.

Builds on #1338 (merged). Sibling fast-follow of #1342 (not a dependency). Refs #1337, #1219, #1324.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging for job processing to improve visibility into edge cases, including better detection of missing state conditions and unexpected job state transitions for troubleshooting purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
