### PR TITLE
Speed up the occurrence list on large projects

### DIFF
--- a/ami/main/migrations/0093_occurrence_project_score_index.py
+++ b/ami/main/migrations/0093_occurrence_project_score_index.py
@@ -1,0 +1,47 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Add the index backing the default occurrence list sort.
+
+    The occurrence list endpoint is scoped to a project and ordered by
+    ``-determination_score`` (the model default ``Meta.ordering``). Without a
+    matching index the planner sorts the whole project's occurrences on every
+    page request, which becomes an on-disk merge sort on large projects.
+
+    Occurrence is large in production (over a million rows), so the index is
+    built CONCURRENTLY to avoid taking a write lock during deploy, which
+    requires a non-atomic migration. See 0086 for the same pattern and the
+    reason the statement timeout is cleared and restored around the build.
+
+    The column order is ``DESC`` (Postgres ``NULLS FIRST``) to match the SQL the
+    ORM emits for ``ORDER BY determination_score DESC`` exactly; a ``NULLS LAST``
+    index would not serve that ordering when the result set contains rows with a
+    null ``determination_score``.
+    """
+
+    atomic = False
+
+    dependencies = [
+        ("main", "0092_alter_sourceimage_checksum_and_more"),
+    ]
+
+    operations = [
+        # Runtime SET overrides the startup "-c statement_timeout" option and
+        # persists for the rest of this (non-atomic) migration's connection.
+        migrations.RunSQL(
+            sql="SET statement_timeout = 0;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        AddIndexConcurrently(
+            model_name="occurrence",
+            index=models.Index(fields=["project", "-determination_score"], name="occur_proj_score_desc_idx"),
+        ),
+        # Restore the session default so the disabled timeout does not leak into
+        # later migrations executed on the same (non-atomic) connection.
+        migrations.RunSQL(
+            sql="RESET statement_timeout;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -3780,6 +3780,11 @@ class Occurrence(BaseModel):
             # Supports sorting projects by their most recently updated occurrence
             # (see ProjectViewSet ordering "last_occurrence_updated_at").
             models.Index(fields=["project", "-updated_at"], name="occur_proj_updated_desc_idx"),
+            # Backs the default occurrence list sort: per-project, ordered by
+            # determination_score DESC (Meta.ordering). Without it the planner
+            # sorts the whole project's occurrences per page (on-disk merge sort
+            # on large projects). DESC = NULLS FIRST to match the ORM's ORDER BY.
+            models.Index(fields=["project", "-determination_score"], name="occur_proj_score_desc_idx"),
         ]
 
 


### PR DESCRIPTION
## Summary

The occurrence list is one of the main views people use to explore a project's results, and on large projects it has been slow to load. The list is always scoped to a project and sorted by determination score (highest-confidence identifications first), but the database had no index matching that access pattern — so every page load made Postgres sort the project's entire set of occurrences from scratch, spilling to an on-disk merge sort once the set got large. This change adds the one composite index that backs that sort, so the database can read the page straight from the index instead of sorting.

This came out of a measurement pass on the broader "slow list / slow counts" work (#928). On a production-snapshot dataset the occurrence list page went from an external-merge sort to a plain index scan — roughly 150× faster on the isolated query — and, importantly, it held up under concurrent load: at concurrency 8 the indexed page stayed in the low single-digit milliseconds, where the un-indexed sort degraded sharply as parallel requests piled onto the same sort. None of the three existing occurrence indexes help here; they all lead with `determination_id` and serve the per-taxon queries, not the project-wide score sort.

### List of Changes

| # | Change (user-facing effect) | How (implementation) |
|---|---|---|
| 1 | The occurrence list page loads quickly on large projects, and stays fast when many people load it at once. | Add a composite index `occur_proj_score_desc_idx` on `Occurrence(project, -determination_score)` — the exact shape of the default project-scoped, score-ordered list query. |
| 2 | No write-lock stall during deploy. | The index is built `CONCURRENTLY` in a non-atomic migration (0093), mirroring the existing pattern in migration 0086, including clearing and restoring `statement_timeout` around the build. |

## Detailed Description

The default occurrence ordering is the model's `Meta.ordering = ["-determination_score"]`, and `OccurrenceViewSet` scopes every list query to the active project. That produces `... WHERE project_id = ? AND <valid filters> ORDER BY determination_score DESC`. The new index matches both the equality column (`project`) and the sort column/direction (`determination_score DESC`).

The column direction is `DESC`, which in Postgres means `NULLS FIRST` — this matches the SQL the ORM emits for `ORDER BY determination_score DESC` exactly. A `NULLS LAST` index would not serve that ordering when the result set contains rows whose `determination_score` is null (a real edge case: `Occurrence.valid()` requires a determination but the score can still be null when `get_determination_score()` returns nothing), so `DESC`/`NULLS FIRST` is the correct, exact-match choice.

### Measurement notes

- Numbers above are from `EXPLAIN (ANALYZE, BUFFERS)` and a small concurrency sweep on a production-snapshot dataset (a dev bench restored from a production backup), not from the small development database. The plan change (external-merge sort → index scan) is the load-bearing result; the absolute page-load baseline still wants confirmation from production APM.
- The concurrency sweep ran at client concurrency 1/4/8; the indexed page's p99 stayed in the low single-digit milliseconds across all three.

Part of #928.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new database index to improve sorting and loading of occurrence lists filtered by project.
  * Enhanced support for ordering occurrences by score in descending order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->