### PR TITLE
Make the async processing service (psv2) the default and update all existing projects

### DIFF
--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -1215,7 +1215,10 @@ class TestJobDispatchModeFiltering(APITestCase):
 
     def test_ml_job_dispatch_mode_set_on_creation(self):
         """Test that ML jobs get dispatch_mode set based on project feature flags at creation time."""
-        # Without async flag, ML job should default to sync_api
+        # With the async flag disabled, an ML job is dispatched via sync_api.
+        self.project.feature_flags.async_pipeline_workers = False
+        self.project.save()
+
         sync_job = Job.objects.create(
             job_type_key=MLJob.key,
             project=self.project,

--- a/ami/main/migrations/0094_enable_async_pipeline_workers.py
+++ b/ami/main/migrations/0094_enable_async_pipeline_workers.py
@@ -1,0 +1,47 @@
+"""
+Turn on the ``async_pipeline_workers`` feature flag for every existing project.
+
+This rolls out async ML processing (workers that pull tasks from the NATS queue
+instead of the synchronous push API) to all projects at once. New projects keep
+the model default of ``False`` until they are opted in separately; this migration
+only updates rows that exist at deploy time.
+
+The flag lives inside the ``feature_flags`` JSONB column (a ``ProjectFeatureFlags``
+pydantic model). We read each project's flags through the historical model, set the
+one boolean, and write it back. The reverse flips the flag back off for every
+project — a blanket disable. It does not restore per-project values from before the
+rollout, because the field default is ``False`` and this is the first global enable,
+so no project is expected to have been ``True`` beforehand.
+"""
+
+from django.db import migrations
+
+
+def enable_async_pipeline_workers(apps, schema_editor):
+    Project = apps.get_model("main", "Project")
+    for project in Project.objects.all():
+        flags = project.feature_flags
+        if not flags.async_pipeline_workers:
+            flags.async_pipeline_workers = True
+            project.feature_flags = flags
+            project.save(update_fields=["feature_flags"])
+
+
+def disable_async_pipeline_workers(apps, schema_editor):
+    Project = apps.get_model("main", "Project")
+    for project in Project.objects.all():
+        flags = project.feature_flags
+        if flags.async_pipeline_workers:
+            flags.async_pipeline_workers = False
+            project.feature_flags = flags
+            project.save(update_fields=["feature_flags"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("main", "0093_occurrence_project_score_index"),
+    ]
+
+    operations = [
+        migrations.RunPython(enable_async_pipeline_workers, disable_async_pipeline_workers),
+    ]

--- a/ami/main/migrations/0094_enable_async_pipeline_workers.py
+++ b/ami/main/migrations/0094_enable_async_pipeline_workers.py
@@ -3,38 +3,49 @@ Turn on the ``async_pipeline_workers`` feature flag for every existing project.
 
 This rolls out async ML processing (workers that pull tasks from the NATS queue
 instead of the synchronous push API) to all projects at once. New projects keep
-the model default of ``False`` until they are opted in separately; this migration
-only updates rows that exist at deploy time.
+whatever the model default is at creation time; this migration only updates rows
+that exist at deploy time.
 
 The flag lives inside the ``feature_flags`` JSONB column (a ``ProjectFeatureFlags``
-pydantic model). We read each project's flags through the historical model, set the
-one boolean, and write it back. The reverse flips the flag back off for every
-project — a blanket disable. It does not restore per-project values from before the
-rollout, because the field default is ``False`` and this is the first global enable,
-so no project is expected to have been ``True`` beforehand.
+pydantic model). The update toggles only the one key server-side with ``jsonb_set``
+rather than reading each project's JSON into Python, mutating it, and writing the
+whole value back. Doing it in place leaves the other feature flags untouched even
+if another process changes one of them during the deploy, and it runs as a single
+statement instead of one save per row. The reverse flips the flag back off for
+every project — a blanket disable. It does not restore per-project values from
+before the rollout, because the field default is ``False`` and this is the first
+global enable, so no project is expected to have been ``True`` beforehand.
 """
 
 from django.db import migrations
 
 
-def enable_async_pipeline_workers(apps, schema_editor):
+def _set_async_pipeline_workers(apps, schema_editor, *, enabled):
     Project = apps.get_model("main", "Project")
-    for project in Project.objects.all():
-        flags = project.feature_flags
-        if not flags.async_pipeline_workers:
-            flags.async_pipeline_workers = True
-            project.feature_flags = flags
-            project.save(update_fields=["feature_flags"])
+    table = schema_editor.connection.ops.quote_name(Project._meta.db_table)
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            UPDATE {table}
+            SET feature_flags = jsonb_set(
+                COALESCE(feature_flags, '{{}}'::jsonb),
+                '{{async_pipeline_workers}}',
+                to_jsonb(%s::boolean),
+                true
+            )
+            WHERE COALESCE((feature_flags ->> 'async_pipeline_workers')::boolean, false)
+                  IS DISTINCT FROM %s
+            """,
+            [enabled, enabled],
+        )
+
+
+def enable_async_pipeline_workers(apps, schema_editor):
+    _set_async_pipeline_workers(apps, schema_editor, enabled=True)
 
 
 def disable_async_pipeline_workers(apps, schema_editor):
-    Project = apps.get_model("main", "Project")
-    for project in Project.objects.all():
-        flags = project.feature_flags
-        if flags.async_pipeline_workers:
-            flags.async_pipeline_workers = False
-            project.feature_flags = flags
-            project.save(update_fields=["feature_flags"])
+    _set_async_pipeline_workers(apps, schema_editor, enabled=False)
 
 
 class Migration(migrations.Migration):

--- a/ami/main/migrations/0094_enable_async_pipeline_workers.py
+++ b/ami/main/migrations/0094_enable_async_pipeline_workers.py
@@ -13,8 +13,9 @@ whole value back. Doing it in place leaves the other feature flags untouched eve
 if another process changes one of them during the deploy, and it runs as a single
 statement instead of one save per row. The reverse flips the flag back off for
 every project — a blanket disable. It does not restore per-project values from
-before the rollout, because the field default is ``False`` and this is the first
-global enable, so no project is expected to have been ``True`` beforehand.
+before the rollout: some projects may have had the flag enabled individually
+beforehand, so the reverse returns every project to the off state rather than to
+its prior value.
 """
 
 from django.db import migrations

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -278,7 +278,7 @@ class ProjectFeatureFlags(pydantic.BaseModel):
     default_filters: bool = False  # Whether to show default filters form in UI
     # Feature flag for jobs to reprocess all images in the project, even if already processed
     reprocess_all_images: bool = False
-    async_pipeline_workers: bool = False  # Whether to use async pipeline workers that pull tasks from a queue
+    async_pipeline_workers: bool = True  # Whether to use async pipeline workers that pull tasks from a queue
 
 
 def get_default_feature_flags() -> ProjectFeatureFlags:


### PR DESCRIPTION
## Summary

This flips the switch on the new async processing service (psv2) platform-wide. It does two things together: every project that already exists is switched over, and every project created from now on uses psv2 by default. Concretely, the `async_pipeline_workers` feature flag drives whether a project's ML jobs run on workers that pull tasks from the NATS queue (psv2) instead of the synchronous push API; this PR makes that the default and rolls it out to the back-catalogue so operators don't have to opt each project in by hand.

We are flipping the default now because psv2 has proven substantially more reliable and much faster than the synchronous service in operator testing — on the order of two orders of magnitude higher throughput on large capture sets (an operational observation on production data, not a controlled benchmark). The remaining psv2 work is tracked but none of it blocks turning psv2 on by default; the open items are refinements, hardening, and follow-ups rather than correctness gates for the common path.

> Operational precondition: this routes every project's ML jobs through async (NATS) workers. Each deployment it runs against must have psv2 workers live and consuming the queue. Stranded async jobs are caught by the stale-job reaper rather than hanging indefinitely.

### List of Changes

| Change (user/operator effect) | How (implementation) |
|----|----|
| New projects use the async processing service (psv2) by default. | `ProjectFeatureFlags.async_pipeline_workers` default changed from `False` to `True` in `ami/main/models.py`. No migration is needed: the `feature_flags` field deconstructs by its `schema=` class reference and default-factory reference, neither of which changes when a default inside the pydantic model changes — `makemigrations --check` confirms no model migration. |
| Every project that already exists is switched over to psv2, without an operator flipping each one by hand. | New data migration `0094_enable_async_pipeline_workers` runs a single DB-side `UPDATE ... jsonb_set(...)` that toggles only the `async_pipeline_workers` key in place for every existing `Project`, with a `WHERE ... IS DISTINCT FROM` guard so rows already at the target are skipped. Updating the one key server-side (rather than reading the whole JSON into Python and writing it back) leaves the other feature flags untouched even under a concurrent change, and runs as one statement instead of one save per row. |
| The existing-project rollout can be undone in one step. | The data migration's reverse flips the flag back to `False` for every project (a blanket disable). It does not restore per-project values from before the rollout — some projects may have been opted in individually beforehand, so the reverse returns every project to the off state. The reverse does not change the new model default; that is a code change, reverted by reverting the commit. |

### Notes

- The default change and the data migration are complementary: the default only affects rows created after deploy, so the data migration is still required to cover projects that already exist.
- Validated on a fresh test database and end-to-end on a dev box: the data migration enables the flag for all projects and the reverse clears it, while an unrelated flag set on a project is preserved through both directions. The factory that backs new-project creation now returns `async_pipeline_workers = True` with the other defaults unchanged.

## Known follow-ups (PSv2) — none blocking this change

psv2 is the new async/distributed ML backend tracked under the umbrella issue **#515** and the **PSv2** label. The items below are known and open at the time of this change. None of them block making psv2 the default — they are hardening, performance, and feature-completeness follow-ups. Full lists: [Antenna PSv2 issues](https://github.com/RolnickLab/antenna/issues?q=is%3Aopen+label%3APSv2) · [Antenna PSv2 PRs](https://github.com/RolnickLab/antenna/pulls?q=is%3Aopen+label%3APSv2) · [ADC (ami-data-companion) PRs](https://github.com/RolnickLab/ami-data-companion/pulls).

**Reliability / job-state correctness (Antenna)**
- #1354 — Jobs that are created but not started get revoked.
- #1337 / #1285 — Concurrent job-progress saves cause incorrect job statuses; broader review of how job state and progress are tracked.
- #1283 / #1282 — Clean up the task queue on revoke/restart (duplicate tasks); CANCELLED jobs leak through the `/next` filter and starve newer jobs.
- #1247 — A few images are regularly stranded after long-running jobs.
- #1168 — Async jobs can hang forever when NATS tasks exhaust `max_deliver` without posting results (mitigated by the stale-job reaper).
- #1123 — Tasks are queued and the worker sees the job, but no tasks are handed out.
- #1061 — Handle `Job.DoesNotExist` properly in `process_source_images_async`.

**Performance / scaling (Antenna)**
- #1288 — Defer the aggregate count refresh in `process_nats_pipeline_result` (expected 5–10× on the result path).
- #1256 — Refactor job logging so it isn't a bottleneck.
- #1173 — Update progress while queuing NATS tasks (currently blocks).

**Auth & permissions (Antenna + ADC)**
- #1263 / #964 / #1153 / #1182 — Processing-service user permissions, the auth workflow for psv2, worker (re)authentication with an application token, and the ML Data Manager role not being able to fetch job tasks.
- In flight: Antenna #1194 / #1201 (API-key auth + key management UI for processing services); ADC #136 (switch ADC workers to API-key auth).

**Pipeline config & result contract (in flight)**
- #1275 + Antenna PR #1279 with ADC PR #146 — propagate `PipelineRequestConfigParameters` through pull-mode (NATS) tasks so workers honor per-request config.
- ADC #149 — split oversized result uploads so wide-taxonomy batches aren't rejected.
- ADC #148 / #139 — DataLoader hardening (forkserver context, timeouts, teardown) and making the tuning knobs env-configurable.

**Docs, templates, and infra (in flight)**
- Antenna PR #1137 (async backend docs + diagram), #1011 (processing-service templates consume from pipeline queues), #1154 (push-mode worker template), #1130 (NATS connection pooling + retries), #972 (update AWS deployment for psv2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Async pipeline workers are now enabled by default for new projects.
  * Existing projects have been updated to use the new default setting automatically.

* **Bug Fixes**
  * Improved consistency in job dispatch behavior by making related tests set the project flag explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->