### PR TITLE
Stop the stale-job reaper from revoking jobs that are created but not yet started

### DIFF
--- a/ami/jobs/models.py
+++ b/ami/jobs/models.py
@@ -79,10 +79,8 @@ class JobState(str, OrderedEnum):
 
     @classmethod
     def running_states(cls):
-        # CREATED is excluded: a created-but-not-enqueued job has no Celery task
-        # and no async resources, so it must never be reaped or reconciled. Jobs
-        # can be pre-configured and started later, and they wait in CREATED until
-        # a user enqueues them (which flips them to PENDING). See #1354.
+        # Dispatched states the reapers/reconcilers select from. CREATED is not
+        # here: a not-yet-enqueued job has no Celery task to reap. See #1354.
         return [cls.PENDING, cls.STARTED, cls.RETRY, cls.CANCELING, cls.UNKNOWN]
 
     @classmethod
@@ -100,8 +98,9 @@ class JobState(str, OrderedEnum):
 
     @classmethod
     def finalizable_states(cls):
-        # running_states() minus CANCELING (don't resurrect a cancel in progress)
-        # and UNKNOWN (never served; shouldn't auto-finalize). See #1337.
+        # States a job may auto-finalize from. Excludes CANCELING (don't resurrect
+        # a cancel in progress) and UNKNOWN (never served; shouldn't auto-finalize).
+        # See #1337.
         return [cls.CREATED, cls.PENDING, cls.STARTED, cls.RETRY]
 
 

--- a/ami/jobs/models.py
+++ b/ami/jobs/models.py
@@ -79,7 +79,11 @@ class JobState(str, OrderedEnum):
 
     @classmethod
     def running_states(cls):
-        return [cls.CREATED, cls.PENDING, cls.STARTED, cls.RETRY, cls.CANCELING, cls.UNKNOWN]
+        # CREATED is excluded: a created-but-not-enqueued job has no Celery task
+        # and no async resources, so it must never be reaped or reconciled. Jobs
+        # can be pre-configured and started later, and they wait in CREATED until
+        # a user enqueues them (which flips them to PENDING). See #1354.
+        return [cls.PENDING, cls.STARTED, cls.RETRY, cls.CANCELING, cls.UNKNOWN]
 
     @classmethod
     def final_states(cls):

--- a/ami/jobs/tests/test_update_stale_jobs.py
+++ b/ami/jobs/tests/test_update_stale_jobs.py
@@ -121,3 +121,21 @@ class CheckStaleJobsTest(TestCase):
 
         self.assertEqual(results, [])
         mock_cleanup.assert_not_called()
+
+    @patch("ami.jobs.tasks.cleanup_async_job_if_needed")
+    def test_skips_created_but_unstarted_jobs(self, mock_cleanup):
+        """A job created but never enqueued is left alone regardless of age.
+
+        Jobs can be pre-configured and started later, so a CREATED job has no
+        Celery task and no async resources to reconcile. The staleness cutoff
+        (measured against ``updated_at``) does not apply to it — it waits in
+        CREATED until a user starts it. See #1354.
+        """
+        job = self._create_job(status=JobState.CREATED, minutes_ago=300)
+
+        results = check_stale_jobs()
+
+        self.assertEqual(results, [])
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobState.CREATED.value)
+        mock_cleanup.assert_not_called()


### PR DESCRIPTION
## Summary

Jobs can be created without starting them immediately — for example, to pre-configure several jobs and launch them at a later time. A job created this way waits in the `CREATED` state until someone starts it. A periodic background task revokes jobs that look stale or hung, and it was also revoking these created-but-unstarted jobs, so a pre-configured job would be cancelled before it ever ran. This change leaves `CREATED` jobs alone, so they wait to be started instead of being reaped.

Closes #1354

### List of Changes

| Change (user-facing effect) | How (implementation) |
|----|----|
| A job that is created but not yet started is no longer revoked by the stale-job reaper, regardless of how long it waits. | Removed `CREATED` from `JobState.running_states()`, the set the reaper and reconcilers select jobs from. |
| Added a regression test pinning that a `CREATED` job past the staleness cutoff is left untouched. | New `test_skips_created_but_unstarted_jobs` in `ami/jobs/tests/test_update_stale_jobs.py`. |

## Detailed Description

The stale-job reaper (`check_stale_jobs` in `ami/jobs/tasks.py`) finds jobs that are still in a running state and whose `updated_at` is older than `Job.STALLED_JOBS_MAX_MINUTES` (10 minutes), then revokes them. It selected candidates via `JobState.running_states()`, which included `CREATED`. A job that was pre-configured and left for later therefore qualified once it was older than the cutoff, and was revoked.

A `CREATED` job has no Celery task and no async (NATS/Redis) resources, so there is nothing to reap or reconcile. `Job.enqueue()` flips a job to `PENDING` the moment it is dispatched, and a job that gets stuck mid-dispatch is already `PENDING` — so genuinely stuck jobs are still caught. Removing `CREATED` from `running_states()` also keeps the lost-images reconciler and the async snapshot check (the other callers of `running_states()`) from touching jobs that have not started.

`finalizable_states()` is intentionally left unchanged — it keeps `CREATED` because a synchronous job can legitimately transition `CREATED → SUCCESS` through the normal completion path; that is separate from time-based reaping.

The full stale-job test suite passes (7/7).


## Out-of-scope observations (left for follow-up)

While sweeping for code that depends on `running_states()`, I found a few pre-existing places in the frontend that classify the `CREATED` state independently of the backend. They are not consumers of `running_states()` (which is Python-only), so this change does not affect them, and they are not modified here. Noting them for a later pass:

- `ui/src/data-services/models/capture-set.ts` and `ui/src/data-services/models/capture-details.ts` — `hasJobInProgress` counts a `CREATED` job as "in progress". A created-but-unstarted job has not been dispatched yet, so this may overstate activity. It could also be intentional (signalling that a job is already set up for the capture set, to avoid duplicates) — worth a deliberate decision rather than a silent change.
- `ui/src/data-services/models/job.ts` — `canCancel` only allows `STARTED`/`PENDING`, but the backend's `finalizable_states()` permits cancelling a `CREATED` job too. The result is a harmless asymmetry: the cancel button is hidden for `CREATED` jobs even though the backend would accept the request.

These are flagged only; no behavior change is intended in this PR.
