### PR TITLE
Stop sending admin emails on every HTTP 500 in production

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -177,6 +177,17 @@ LOGGING = {
     },
 }
 
+# Django's default mail_admins handler sends email synchronously, blocking a worker
+# thread per HTTP 500; other (async/queued) handlers are recommended. Disabled by
+# default and gated behind an env var; errors are already captured by Sentry.
+ADMIN_ERROR_EMAILS = env.bool("DJANGO_ADMIN_ERROR_EMAILS", default=False)
+if not ADMIN_ERROR_EMAILS:
+    LOGGING["loggers"]["django"] = {
+        "level": "INFO",
+        "handlers": ["console"],
+        "propagate": False,
+    }
+
 # Sentry
 # ------------------------------------------------------------------------------
 SENTRY_DSN = env("SENTRY_DSN")

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -187,6 +187,11 @@ if not ADMIN_ERROR_EMAILS:
         "handlers": ["console"],
         "propagate": False,
     }
+else:
+    # Nothing to wire here: Django's DEFAULT_LOGGING attaches the mail_admins handler
+    # to the "django" logger before this module's LOGGING is applied. Explicit branch
+    # so the "on" path is visible here instead of hidden in Django's defaults. See #1356.
+    pass
 
 # Sentry
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

In production, every uncaught HTTP 500 triggers Django's default admin-error email, sent synchronously inside the request — one outbound email per error, each holding a worker thread for the duration of the send. During an error storm this becomes an email storm that ties up the worker pool and makes an incident worse. Sentry already captures every error independently, so these emails add no observability. This change disables that handler by default in deployed environments and puts it behind an environment variable, so it can be re-enabled per environment if a non-blocking (async/queued) handler is configured later.

### List of Changes

1. Admin error emails are no longer sent on production 500s by default. Operator-facing effect: an error spike can no longer snowball into a synchronous outbound-email storm that starves the worker pool. (Implementation: gate Django's default `mail_admins` `AdminEmailHandler` behind `DJANGO_ADMIN_ERROR_EMAILS`, default `False`; when off, the `django` logger routes to console only at `INFO` so 4xx/5xx request lines still reach stdout, and no longer propagates to the handler.)
2. Configurable per environment: set `DJANGO_ADMIN_ERROR_EMAILS=True` to re-enable admin error email where wanted. Covers production, demo, and staging (same settings module).

### Notes

- Sentry error capture is unaffected — it hooks the logging system via `LoggingIntegration`, independent of the `LOGGING` handlers list.
- Surfaced during a production incident where the synchronous admin-email path amplified a 500 storm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated production error logging behavior to better control when Django errors are sent to admin email alerts.
  * Added a new production toggle to route Django logs to the console at info level when admin error emails are disabled, helping keep logging behavior consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->