### PR TITLE
Avoid wide distinct scans for visible captures

### DIFF
--- a/ami/base/models.py
+++ b/ami/base/models.py
@@ -66,7 +66,8 @@ class BaseQuerySet(QuerySet):
             if not is_anonymous:
                 filter_condition |= Q(owner=user) | Q(members=user)
 
-            return self.filter(filter_condition).distinct()
+            visible_project_ids = self.filter(filter_condition).order_by().values_list("pk", flat=True)
+            return self.filter(pk__in=visible_project_ids)
 
         # For models related to Project
         project_accessor = model.get_project_accessor()
@@ -85,7 +86,8 @@ class BaseQuerySet(QuerySet):
         if not is_anonymous:
             filter_condition |= Q(**{f"{project_field}owner": user}) | Q(**{f"{project_field}members": user})
 
-        return self.filter(filter_condition).distinct()
+        visible_object_ids = self.filter(filter_condition).order_by().values_list("pk", flat=True)
+        return self.filter(pk__in=visible_object_ids)
 
 
 class BaseModel(models.Model):

--- a/ami/base/models.py
+++ b/ami/base/models.py
@@ -66,6 +66,9 @@ class BaseQuerySet(QuerySet):
             if not is_anonymous:
                 filter_condition |= Q(owner=user) | Q(members=user)
 
+            if is_anonymous:
+                return self.filter(filter_condition)
+
             visible_project_ids = self.filter(filter_condition).order_by().values_list("pk", flat=True)
             return self.filter(pk__in=visible_project_ids)
 

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -3233,9 +3233,12 @@ class TestDraftProjectPermissions(APITestCase):
         assert self.deployment.pk not in ids
 
     def test_visible_for_user_deduplicates_captures_in_a_primary_key_subquery(self):
-        queryset = SourceImage.objects.visible_for_user(self.member)
+        self.project.members.add(self.outsider)
+        queryset = SourceImage.objects.visible_for_user(self.owner)
 
         self.assertIn(self.deployment.captures.first(), queryset)
+        capture_ids = list(queryset.values_list("pk", flat=True))
+        self.assertEqual(len(capture_ids), len(set(capture_ids)))
         self.assertNotIn("SELECT DISTINCT", str(queryset.query))
 
     def test_visible_for_user_across_all_models(self):

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -3232,6 +3232,12 @@ class TestDraftProjectPermissions(APITestCase):
         ids = [d["id"] for d in response.data["results"]]
         assert self.deployment.pk not in ids
 
+    def test_visible_for_user_deduplicates_captures_in_a_primary_key_subquery(self):
+        queryset = SourceImage.objects.visible_for_user(self.member)
+
+        self.assertIn(self.deployment.captures.first(), queryset)
+        self.assertNotIn("SELECT DISTINCT", str(queryset.query))
+
     def test_visible_for_user_across_all_models(self):
         all_users = {
             "superuser": self.superuser,


### PR DESCRIPTION
# Avoid wide distinct scans for visible captures

## Summary

Capture-list visibility filtering previously used a full-row `DISTINCT` after the project-membership join, which can cause PostgreSQL to sort wide capture rows and spill large temporary files. This change filters the outer queryset by a narrow primary-key subquery instead, preserving the visibility rules while avoiding the wide-row distinct operation.

### List of Changes

1. Preserve project and project-related visibility filtering through a primary-key subquery rather than `SELECT DISTINCT` across full model rows.
2. Add a regression test that verifies the capture visibility queryset contains the expected capture without generating `SELECT DISTINCT`.

### Related Issues

Fixes #1370

## Detailed Description

The owner-or-member visibility condition can join project memberships and multiply result rows. The inner queryset now selects only matching primary keys with default ordering removed; the outer queryset applies `pk__in` and remains available for callers to order, annotate, paginate, and select the full capture rows normally.

This is autonomous AI-agent work that @Dodothereal operates, monitors, and is accountable for.

### How to Test the Changes

Run in the required sandbox:

- `sandbox-run "python -m py_compile ami/base/models.py ami/main/tests.py"` — passed.
- `sandbox-run "pip install Django==4.2.10 && python - <<'PY' ..."` — passed an isolated Django ORM check confirming the primary-key subquery preserves ordered results and emits no `DISTINCT`.
- `sandbox-run "python manage.py test ami.main.tests.TestDraftProjectPermissions --keepdb"` — could not start because the sandbox had no Django installed.
- `sandbox-run "pip install -r requirements/base.txt && python manage.py test ami.main.tests.TestDraftProjectPermissions --keepdb"` — blocked during dependency resolution because the repository pins `psycopg[binary]==3.1.9`, for which no package is available on the sandbox's Python 3.12 platform.
- `sandbox-run "docker compose -f docker-compose.ci.yml run --rm django python manage.py test ami.main.tests.TestDraftProjectPermissions --keepdb"` — unavailable because Docker is not installed in the sandbox.

## Deployment Notes

No migration or configuration change is required.

## Checklist

- [x] I have tested these changes appropriately within the available sandbox environment.
- [x] I have added and/or modified relevant tests.
- [ ] I updated relevant documentation or comments.
- [x] I have verified that this PR follows the project's coding standards.
- [x] Any dependent changes have already been merged to main.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility filtering for project-related content to return accurate, duplicate-free results.
  * Ensured draft-project deployments’ first captures are included in eligible views.
* **Tests**
  * Added regression coverage to confirm visibility filtering includes the expected captures and avoids duplicate capture entries in results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->