### PR TITLE
Fix misplaced bounding boxes on portrait captures and add large image thumbnail size

### DIFF
--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -2519,11 +2519,8 @@ class SourceImage(BaseModel):
             img.thumbnail(new_size)
 
             buffer = BytesIO()
-            # EXIF must NOT be copied to the output (no ``exif=`` argument): the UI
-            # overlays detection boxes, which are stored in raw pixel coordinates, on
-            # these thumbnails. An EXIF Orientation tag would make browsers rotate the
-            # rendered pixels out of that coordinate space. Pinned by
-            # test_thumbnail_strips_exif_orientation.
+            # No ``exif=`` argument: detection boxes are overlaid on thumbnails in raw
+            # pixel coordinates, so the EXIF Orientation tag must not propagate.
             img.save(buffer, format="JPEG", progressive=True, optimize=True, quality=82)
             contents = buffer.getvalue()
             file_size = len(contents)

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -2519,6 +2519,11 @@ class SourceImage(BaseModel):
             img.thumbnail(new_size)
 
             buffer = BytesIO()
+            # EXIF must NOT be copied to the output (no ``exif=`` argument): the UI
+            # overlays detection boxes, which are stored in raw pixel coordinates, on
+            # these thumbnails. An EXIF Orientation tag would make browsers rotate the
+            # rendered pixels out of that coordinate space. Pinned by
+            # test_thumbnail_strips_exif_orientation.
             img.save(buffer, format="JPEG", progressive=True, optimize=True, quality=82)
             contents = buffer.getvalue()
             file_size = len(contents)

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -262,6 +262,51 @@ class TestImageThumbnailViews(TestCase):
         self.assertEqual(thumb.height, 768)
         self.assertEqual(response.headers["Location"], f"/media/{thumb.path}")
 
+    def test_thumbnail_new_with_large_size(self):
+        response = self.client.get(f"/api/v2/captures/thumbnails/{self.first_capture.pk}/?label=large")
+        self.assertEqual(response.status_code, 302)
+        thumb = self.first_capture.thumbnails.get(label="large")
+        # ``width`` stores the requested spec width for the regen gate, not the
+        # encoder output. The test fixture is 1024px wide and PIL's thumbnail()
+        # never upscales, so the stored file keeps its original dimensions.
+        self.assertEqual(thumb.width, 2560)
+        self.assertEqual(thumb.height, 768)
+        self.assertEqual(response.headers["Location"], f"/media/{thumb.path}")
+
+    def test_thumbnail_strips_exif_orientation(self):
+        """Thumbnails must stay in the source file's raw pixel space so detection
+        bounding boxes (stored in raw coordinates) align when overlaid in the UI.
+
+        A photo shot in portrait is typically stored as landscape pixels plus an
+        EXIF Orientation tag, and browsers force-apply that rotation to
+        cross-origin images. The thumbnail pipeline must neither rotate the
+        pixels nor propagate the tag to the output file, otherwise the session
+        detail view renders boxes 90° out of place (the pre-thumbnail behavior).
+        """
+        from django.core.files.storage import default_storage
+
+        from ami.utils import s3
+
+        ORIENTATION_TAG = 274  # EXIF tag id for Orientation
+        source = Image.new("RGB", (320, 240), (10, 120, 30))
+        exif = source.getexif()
+        exif[ORIENTATION_TAG] = 6  # stored landscape, rotate 90° CW to view
+        buffer = BytesIO()
+        source.save(buffer, format="JPEG", exif=exif)
+
+        assert self.deployment.data_source is not None
+        s3.write_file(self.deployment.data_source.config, self.first_capture.path, buffer.getvalue())
+
+        thumb = self.first_capture.find_or_generate_thumbnail_for_label("large")
+
+        with default_storage.open(thumb.path) as f:
+            output = Image.open(f)
+            output.load()
+
+        # Pixels stay in raw (landscape) space and the orientation tag is gone.
+        self.assertEqual(output.size, (320, 240))
+        self.assertIsNone(output.getexif().get(ORIENTATION_TAG))
+
     def test_thumbnail_blank_path_row_regenerates(self):
         """A row with an empty ``path`` (failed or interrupted generation) must
         trigger regeneration, not redirect to the storage root.

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -275,13 +275,8 @@ class TestImageThumbnailViews(TestCase):
 
     def test_thumbnail_strips_exif_orientation(self):
         """Thumbnails must stay in the source file's raw pixel space so detection
-        bounding boxes (stored in raw coordinates) align when overlaid in the UI.
-
-        A photo shot in portrait is typically stored as landscape pixels plus an
-        EXIF Orientation tag, and browsers force-apply that rotation to
-        cross-origin images. The thumbnail pipeline must neither rotate the
-        pixels nor propagate the tag to the output file, otherwise the session
-        detail view renders boxes 90° out of place (the pre-thumbnail behavior).
+        boxes (stored in raw coordinates) align when overlaid in the UI: neither
+        rotate the pixels nor propagate the EXIF Orientation tag to the output.
         """
         from django.core.files.storage import default_storage
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -589,5 +589,10 @@ DEFAULT_EXCLUDE_TAXA = env.list("DEFAULT_EXCLUDE_TAXA", default=[])  # type: ign
 JOB_LOG_PERSIST_ENABLED = env.bool("JOB_LOG_PERSIST_ENABLED", default=True)  # type: ignore[no-untyped-call]
 
 
-# Sizes for Source Image Thumbnails
-THUMBNAILS = {"STORAGE_PREFIX": "thumbnails/", "SIZES": {"small": {"width": 240}, "medium": {"width": 1024}}}
+# Sizes for Source Image Thumbnails. The "large" size backs the zoomable session
+# detail view; thumbnails are re-encoded without EXIF metadata, so they render in
+# the same pixel space as detection bounding boxes (EXIF-rotated originals do not).
+THUMBNAILS = {
+    "STORAGE_PREFIX": "thumbnails/",
+    "SIZES": {"small": {"width": 240}, "medium": {"width": 1024}, "large": {"width": 2560}},
+}

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -589,9 +589,7 @@ DEFAULT_EXCLUDE_TAXA = env.list("DEFAULT_EXCLUDE_TAXA", default=[])  # type: ign
 JOB_LOG_PERSIST_ENABLED = env.bool("JOB_LOG_PERSIST_ENABLED", default=True)  # type: ignore[no-untyped-call]
 
 
-# Sizes for Source Image Thumbnails. The "large" size backs the zoomable session
-# detail view; thumbnails are re-encoded without EXIF metadata, so they render in
-# the same pixel space as detection bounding boxes (EXIF-rotated originals do not).
+# Sizes for Source Image Thumbnails ("large" backs the zoomable session detail view)
 THUMBNAILS = {
     "STORAGE_PREFIX": "thumbnails/",
     "SIZES": {"small": {"width": 240}, "medium": {"width": 1024}, "large": {"width": 2560}},

--- a/ui/src/data-services/models/capture.ts
+++ b/ui/src/data-services/models/capture.ts
@@ -183,10 +183,8 @@ export class Capture {
     return this._capture.url
   }
 
-  // Preferred source for the zoomable session detail view: large thumbnails are
-  // re-encoded without EXIF metadata, so they render in the same pixel space as
-  // detection bounding boxes. The raw original may carry an EXIF rotation that
-  // browsers force-apply to cross-origin images, misplacing the boxes.
+  // EXIF-free large thumbnail for the zoomable session detail view; detection
+  // boxes align with its pixels, unlike the EXIF-rotated original file.
   get thumbnailLarge(): string {
     if (this._capture.thumbnails?.large) {
       return this._capture.thumbnails.large

--- a/ui/src/data-services/models/capture.ts
+++ b/ui/src/data-services/models/capture.ts
@@ -183,6 +183,18 @@ export class Capture {
     return this._capture.url
   }
 
+  // Preferred source for the zoomable session detail view: large thumbnails are
+  // re-encoded without EXIF metadata, so they render in the same pixel space as
+  // detection bounding boxes. The raw original may carry an EXIF rotation that
+  // browsers force-apply to cross-origin images, misplacing the boxes.
+  get thumbnailLarge(): string {
+    if (this._capture.thumbnails?.large) {
+      return this._capture.thumbnails.large
+    }
+
+    return this._capture.url
+  }
+
   get src(): string {
     return this._capture.url
   }

--- a/ui/src/pages/session-details/capture/capture.tsx
+++ b/ui/src/pages/session-details/capture/capture.tsx
@@ -93,11 +93,8 @@ export const Capture = ({
         const boxWidth = boxRight - boxLeft
         const boxHeight = boxBottom - boxTop
 
-        // Box coordinates are in the original image's pixel space, so they can
-        // only be scaled against the capture's stored dimensions. The rendered
-        // image may be a downscaled thumbnail, so its natural size is not a
-        // valid substitute — without stored dimensions, skip drawing boxes
-        // rather than drawing them at the wrong scale.
+        // Boxes are in the original image's pixel space and the rendered image
+        // may be a downscaled thumbnail, so only stored dimensions can scale them.
         if (!width || !height) {
           return result
         }

--- a/ui/src/pages/session-details/capture/capture.tsx
+++ b/ui/src/pages/session-details/capture/capture.tsx
@@ -93,23 +93,25 @@ export const Capture = ({
         const boxWidth = boxRight - boxLeft
         const boxHeight = boxBottom - boxTop
 
-        const _width = width ?? naturalSize?.width
-        const _height = height ?? naturalSize?.height
-
-        if (!_width || !_height) {
+        // Box coordinates are in the original image's pixel space, so they can
+        // only be scaled against the capture's stored dimensions. The rendered
+        // image may be a downscaled thumbnail, so its natural size is not a
+        // valid substitute — without stored dimensions, skip drawing boxes
+        // rather than drawing them at the wrong scale.
+        if (!width || !height) {
           return result
         }
 
         result[detection.id] = {
-          width: `${(boxWidth / _width) * 100}%`,
-          height: `${(boxHeight / _height) * 100}%`,
-          top: `${(boxTop / _height) * 100}%`,
-          left: `${(boxLeft / _width) * 100}%`,
+          width: `${(boxWidth / width) * 100}%`,
+          height: `${(boxHeight / height) * 100}%`,
+          top: `${(boxTop / height) * 100}%`,
+          left: `${(boxLeft / width) * 100}%`,
         }
 
         return result
       }, {}),
-    [width, height, naturalSize, detections]
+    [width, height, detections]
   )
 
   const ratio = useMemo(() => {

--- a/ui/src/pages/session-details/session-details.tsx
+++ b/ui/src/pages/session-details/session-details.tsx
@@ -169,7 +169,7 @@ const Content = ({ session }: { session: SessionDetails }) => {
               detections={activeCapture?.detections ?? []}
               height={activeCapture?.height ?? session.firstCapture.height}
               showDetections={settings.showDetections}
-              src={activeCapture?.url}
+              src={activeCapture?.thumbnailLarge}
               transformRef={transformRef}
               width={activeCapture?.width ?? session.firstCapture.width}
             />


### PR DESCRIPTION
## Summary

Captures taken in portrait orientation (for example from a phone-based station) showed their detection bounding boxes in the wrong place in the session detail view — shifted and rotated 90° relative to the insects they belong to. This PR makes the session detail view render captures from a generated thumbnail instead of the original file. What users get today: correctly placed boxes on portrait captures, and faster capture browsing than scrubbing through full-size originals. A new 2560px "large" thumbnail size keeps zooming reasonably sharp.

| Before (production) | After (this branch, same image and detections) |
|---|---|
| ![Boxes misplaced on a portrait capture](https://object-arbutus.cloud.computecanada.ca/ami-media-staging/uploads/screenshots/pr-1374/before-portrait-boxes-misplaced.png) | ![Boxes aligned on the insects](https://object-arbutus.cloud.computecanada.ca/ami-media-staging/uploads/screenshots/pr-1374/after-boxes-aligned-local.png) |

### List of Changes

1. Bounding boxes now line up correctly on portrait captures in the session detail view — the view renders a generated "large" thumbnail instead of the original image file.
2. A new "large" (2560px wide) thumbnail size is available from the thumbnails API for every capture, generated lazily on first request like the existing sizes.
3. Browsing captures in the detail view is lighter once thumbnails are warm — the browser fetches the 2560px derivative instead of a multi-megabyte original. The "view source file" link still opens the full-resolution original.
4. Captures with no stored width/height no longer risk wrongly scaled boxes: the overlay is skipped instead of scaled against the rendered image's dimensions.
5. Two new backend tests pin the behavior: thumbnails must strip EXIF metadata and keep the source's raw pixel dimensions, and the "large" label must generate and redirect like the existing sizes.

## Detailed Description

Photos shot in portrait are typically stored as landscape pixels plus an EXIF Orientation tag. Everything in our pipeline — detection coordinates, stored image dimensions, crops — lives in that raw (unrotated) pixel space and is mutually consistent. Browsers, however, force-apply the EXIF rotation when displaying the original file, and for cross-origin images they ignore the `image-orientation: none` CSS override unless the storage bucket serves CORS headers (verified empirically). So the detail view displayed a rotated image while the box overlay math worked in raw space.

This regressed in #1339, which switched the view's image source from the medium thumbnail to the original URL to improve zoom quality. Generated thumbnails are re-encoded without EXIF metadata, so they always render in the same pixel space as the boxes — a new test makes that invariant explicit instead of a side effect, and a comment in the generator guards against a future "preserve metadata" change silently breaking every overlay.

All thumbnail plumbing (viewset label validation, `thumbnail_urls()`, serializers) iterates `settings.THUMBNAILS["SIZES"]` dynamically, so adding the "large" size required no code changes beyond the setting itself. PIL's `thumbnail()` never upscales: sources narrower than 2560px get an original-resolution re-encode, which is still EXIF-stripped and therefore still correct.

### What happens to captures that already have thumbnails

Adding a size is purely additive. There is nothing to invalidate, backfill, or migrate before or after deploying this.

Thumbnails are stored as one row per capture and label (`SourceImageThumbnail`, with a unique constraint on that pair), so each size is independent of the others. This change only adds a `large` entry; the `small` (240px) and `medium` (1024px) specs are untouched. `thumbnail_is_valid()` compares a stored row's width against the configured spec width, so existing rows remain valid and are never re-encoded.

For an existing capture there is simply no `large` row yet, which reads as invalid. `thumbnail_urls()` therefore emits the route URL (`/captures/thumbnails/<pk>/?label=large`) for that label rather than a direct storage URL, and the first request generates the derivative lazily: fetch the original, encode a 2560px JPEG, store it, write the row, then redirect to storage. Every later request for that capture is warm and served straight from storage, with the backend out of the loop.

The same mechanism covers invalidation in general. Because the stored width is the *requested* spec width, changing an existing size in settings (for example `medium` from 1024 to 1200) makes every row for that label read as invalid and regenerate on next request; a modified source image is handled the same way through `last_modified`. There is no cache-busting step to run and no management command to schedule — thumbnail generation only ever happens lazily, through the thumbnail viewset.

## Known caveats

- **Zoom sharpness is capped at 2560px for all captures**, portrait or not. #1339 introduced full-resolution zoom; this PR trades that for correctness and lighter loading. #1373 proposes restoring full resolution progressively at high zoom levels.
- **Cold generation shifts load to the backend.** The first view of each capture at the new size makes Django fetch the original and encode a 2560px JPEG in-request; rapidly scrubbing through a large uncached session concentrates that work on web workers (same pattern discussed in #1346). Once generated, the serializer emits direct storage URLs and the backend is not involved. This exposure is considerably smaller once the progressive loader in #1375 is in place: that change starts the view on the medium thumbnail and only requests `large` when someone actually zooms in, so the 2560px derivative gets generated for captures people inspect rather than every capture they scroll past. The two are intended to merge and deploy together for that reason. Pre-generating thumbnails per session is still a possible follow-up if it bites in practice.
- **Each capture gains one more stored derivative.** A 2560px JPEG is added to storage the first time a capture is viewed at that size. It is materially smaller than the original it derives from, but it is worth being aware of for large projects.
- **The portrait situation itself is unchanged elsewhere**: detection crops and any future view that overlays coordinates on the original file are still in raw pixel space. This PR fixes the session detail view; the platform-wide orientation question (normalize at ingest vs. expose orientation metadata) remains open.

## Follow-ups

- #1373 is implemented in #1375, which stacks on this branch: it progressively loads sharper tiers as you zoom (blurry-first with a loading indicator) and returns the default weight of this view to a smaller thumbnail. The plan is to merge and deploy the two together, so the resolution cap noted above is lifted and the cold-generation exposure is narrowed at the same time.

## How to test

1. Open a session with portrait captures (reproduction case: [session 12918 in the Ogden St. project](https://antenna.insectai.org/projects/86/sessions/12918?capture=50039437) shows the misplaced boxes on the current deployment).
2. With this branch, the same view shows boxes aligned with the insects, and the image request goes through `/captures/thumbnails/<id>/?label=large` on first load (direct storage URL once warm). Verified end-to-end on a local stack with the production portrait image and its nine real detections — screenshots above.
3. Backend: `python manage.py test ami.main.tests.TestImageThumbnailViews` (29 tests, includes the two new ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
