### PR TITLE
Stop large class masking jobs from being cancelled before they report any progress

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -69,6 +69,13 @@ A confident but wrong comment is worse than no comment — future developers and
 - **Keep the load-bearing fact; cut unverified mechanism.** A reader changing a constant should not have to trust a paragraph of speculation. State what the code does and the one reason that matters.
 - **Label guesses as guesses.** Use "best-guess", "not measured", "appears to" for anything you have not tested or profiled. Never state a hunch in the authoritative voice.
 - **Short, then link.** Point to the PR or issue for the long reasoning (`See #1231`) instead of embedding it as truth. A PR thread is dated and discussable; an inline comment reads as eternal fact.
+- **Keep comments to a few lines; put the investigation in the PR.** A rationale comment states the rule a future editor must not break, the one reason it exists, and a `See #NNNN` link — normally two or three lines, rarely more than four. Benchmark tables, before/after measurements, the history of what was tried, and anything a reviewer would want to argue with belong in the PR description, where they are dated and can be replied to. The same limit applies to docstrings on tests and helpers: say what the test protects, then link out for why it matters. Long explanatory blocks also age badly, because the next person to change the code updates the line and leaves the essay.
+
+  ```python
+  # Do not add .distinct(): neither scope can duplicate a row, and de-duplicating
+  # sorts the logits and scores arrays — 208s versus 0.5s on a 55,530-row scope.
+  # See #1376.
+  ```
 - **In PR descriptions, distinguish measured from inferred.** Numbers from a profiler, logs, or `ps` are measurements; numbers from reading code are estimates. Say which.
 
 ## Project Overview

--- a/ami/jobs/models.py
+++ b/ami/jobs/models.py
@@ -897,6 +897,10 @@ class PostProcessingJob(JobType):
         job.progress.add_stage(cls.name, key=cls.key)
         job.update_status(JobState.STARTED)
         job.started_at = datetime.datetime.now()
+        # Mark the stage started before the task runs, as the other job types do.
+        # A stage left at CREATED reads as "Waiting to start" however long the task
+        # takes, and a task's first progress report can be minutes in. See #1376.
+        job.progress.update_stage(cls.key, status=JobState.STARTED, progress=0)
         job.save()
 
         params = job.params or {}

--- a/ami/ml/management/commands/run_class_masking.py
+++ b/ami/ml/management/commands/run_class_masking.py
@@ -46,17 +46,18 @@ class Command(BaseCommand):
 
         from ami.main.models import Classification
 
-        classification_count = (
-            Classification.objects.filter(
-                detection__source_image__collections=collection,
-                terminal=True,
-                algorithm=algorithm,
-                scores__isnull=False,
-                logits__isnull=False,
-            )
-            .distinct()
-            .count()
-        )
+        # Mirrors ClassMaskingTask._scoped_classifications, including its reason for
+        # not de-duplicating rows: collection membership holds one row per
+        # (capture, collection) pair, so this cannot double-count, and de-duplicating
+        # rows that carry the logits and scores arrays is expensive enough to dominate
+        # the command's runtime.
+        classification_count = Classification.objects.filter(
+            detection__source_image__collections=collection,
+            terminal=True,
+            algorithm=algorithm,
+            scores__isnull=False,
+            logits__isnull=False,
+        ).count()
 
         taxa_count = taxa_list.taxa.count()
 

--- a/ami/ml/management/commands/run_class_masking.py
+++ b/ami/ml/management/commands/run_class_masking.py
@@ -46,11 +46,8 @@ class Command(BaseCommand):
 
         from ami.main.models import Classification
 
-        # Mirrors ClassMaskingTask._scoped_classifications, including its reason for
-        # not de-duplicating rows: collection membership holds one row per
-        # (capture, collection) pair, so this cannot double-count, and de-duplicating
-        # rows that carry the logits and scores arrays is expensive enough to dominate
-        # the command's runtime.
+        # Mirrors ClassMaskingTask._scoped_classifications; do not add .distinct(),
+        # see #1376.
         classification_count = Classification.objects.filter(
             detection__source_image__collections=collection,
             terminal=True,

--- a/ami/ml/post_processing/base.py
+++ b/ami/ml/post_processing/base.py
@@ -74,7 +74,15 @@ class BasePostProcessingTask(abc.ABC):
         """
 
         if self.job:
-            self.job.progress.update_stage(self.job.job_type_key, progress=progress)
+            # Imported here because ami.jobs.models imports the post-processing
+            # registry, so a module-level import would be circular.
+            from ami.jobs.models import JobState
+
+            # The stage is marked STARTED here because nothing else does it: the job
+            # wrapper creates the stage and later marks it SUCCESS, so a stage
+            # reporting progress would otherwise still be labelled "Waiting to
+            # start" for the whole run. See #1376.
+            self.job.progress.update_stage(self.job.job_type_key, status=JobState.STARTED, progress=progress)
             # Bump updated_at alongside progress: the stale-job reaper
             # (check_stale_jobs) revokes running jobs whose updated_at is older
             # than STALLED_JOBS_MAX_MINUTES. A long post-processing run that only

--- a/ami/ml/post_processing/base.py
+++ b/ami/ml/post_processing/base.py
@@ -74,18 +74,7 @@ class BasePostProcessingTask(abc.ABC):
         """
 
         if self.job:
-            # Imported here because ami.jobs.models imports the post-processing
-            # registry, so a module-level import would be circular.
-            from ami.jobs.models import JobState
-
-            # Job.update_progress only promotes a stage out of CREATED once its
-            # progress exceeds zero, so a stage reporting exactly 0% stays labelled
-            # "Waiting to start". Promote it here, and only from CREATED, so a
-            # heartbeat can never pull a finished or cancelled stage backwards.
-            # See #1376.
-            stage = self.job.progress.get_stage(self.job.job_type_key)
-            status = {"status": JobState.STARTED} if stage.status == JobState.CREATED else {}
-            self.job.progress.update_stage(self.job.job_type_key, progress=progress, **status)
+            self.job.progress.update_stage(self.job.job_type_key, progress=progress)
             # Bump updated_at alongside progress: the stale-job reaper
             # (check_stale_jobs) revokes running jobs whose updated_at is older
             # than STALLED_JOBS_MAX_MINUTES. A long post-processing run that only

--- a/ami/ml/post_processing/base.py
+++ b/ami/ml/post_processing/base.py
@@ -78,11 +78,14 @@ class BasePostProcessingTask(abc.ABC):
             # registry, so a module-level import would be circular.
             from ami.jobs.models import JobState
 
-            # The stage is marked STARTED here because nothing else does it: the job
-            # wrapper creates the stage and later marks it SUCCESS, so a stage
-            # reporting progress would otherwise still be labelled "Waiting to
-            # start" for the whole run. See #1376.
-            self.job.progress.update_stage(self.job.job_type_key, status=JobState.STARTED, progress=progress)
+            # Job.update_progress only promotes a stage out of CREATED once its
+            # progress exceeds zero, so a stage reporting exactly 0% stays labelled
+            # "Waiting to start". Promote it here, and only from CREATED, so a
+            # heartbeat can never pull a finished or cancelled stage backwards.
+            # See #1376.
+            stage = self.job.progress.get_stage(self.job.job_type_key)
+            status = {"status": JobState.STARTED} if stage.status == JobState.CREATED else {}
+            self.job.progress.update_stage(self.job.job_type_key, progress=progress, **status)
             # Bump updated_at alongside progress: the stale-job reaper
             # (check_stale_jobs) revokes running jobs whose updated_at is older
             # than STALLED_JOBS_MAX_MINUTES. A long post-processing run that only

--- a/ami/ml/post_processing/class_masking.py
+++ b/ami/ml/post_processing/class_masking.py
@@ -68,10 +68,8 @@ def make_classifications_filtered_by_taxa_list(
     ``{"classifications_checked": i, "classifications_total": total,
        "classifications_masked": masked_count, "occurrences_updated": n_changed}``.
 
-    ``on_setup`` is called once with the number of classifications in scope, after
-    the scope has been sized and the category map expanded but before the first row
-    is processed. It gives an operator the size of the run up front and marks the
-    job as alive before any masking work begins.
+    ``on_setup`` is called once with the number of classifications in scope, before
+    the first row is processed, so a long run reports what it found up front.
 
     ``occurrences_updated`` counts only occurrences whose determination actually
     changed (not just any occurrence touched), matching the size-filter convention.
@@ -119,9 +117,8 @@ def make_classifications_filtered_by_taxa_list(
     timestamp = timezone.now()
     masked_count = 0
 
-    # Report the size of the run before touching a row: sizing the scope and
-    # expanding the category map both take time on a large classifier, and until
-    # this fires the job looks untouched.
+    # Sizing the scope and expanding the category map both take time on a large
+    # classifier, so report before touching a row.
     if on_setup is not None:
         on_setup(total)
 
@@ -282,17 +279,9 @@ class ClassMaskingTask(BasePostProcessingTask):
         ``config_schema`` guarantees exactly one scope id is set, so the single
         ``else`` branch is sound.
 
-        Neither branch de-duplicates rows, and neither needs to: a classification
-        reaches an occurrence through a plain foreign key, and it reaches a
-        collection through a membership table that holds one row per
-        (capture, collection) pair, so filtering on a single occurrence or a single
-        collection cannot multiply rows. De-duplicating is also costly here, because
-        the selected columns include the ``logits`` and ``scores`` arrays, which run
-        to roughly half a megabyte per row for a classifier with tens of thousands
-        of categories. Measured on a 55,530-row scope: counting took 208 seconds
-        with ``.distinct()`` and 0.5 seconds without, returning the same number.
-        De-duplication is also a blocking step, so it delayed the first row of the
-        iteration pass as well as the count.
+        Do not add ``.distinct()``: neither scope can duplicate a row, and
+        de-duplicating sorts the ``logits`` and ``scores`` arrays, which measured
+        208s versus 0.5s on a 55,530-row scope. See #1376.
         """
         base = Classification.objects.filter(
             terminal=True,

--- a/ami/ml/post_processing/class_masking.py
+++ b/ami/ml/post_processing/class_masking.py
@@ -50,6 +50,7 @@ def make_classifications_filtered_by_taxa_list(
     batch_size: int = 200,
     reweight: bool = True,
     task_logger: logging.Logger = logger,
+    on_setup: Callable[[int], None] | None = None,
     on_batch: Callable[[dict], None] | None = None,
 ) -> dict[str, int]:
     """Re-score ``classifications`` by masking out classes absent from ``taxa_list``.
@@ -66,6 +67,11 @@ def make_classifications_filtered_by_taxa_list(
     flush with running counters:
     ``{"classifications_checked": i, "classifications_total": total,
        "classifications_masked": masked_count, "occurrences_updated": n_changed}``.
+
+    ``on_setup`` is called once with the number of classifications in scope, after
+    the scope has been sized and the category map expanded but before the first row
+    is processed. It gives an operator the size of the run up front and marks the
+    job as alive before any masking work begins.
 
     ``occurrences_updated`` counts only occurrences whose determination actually
     changed (not just any occurrence touched), matching the size-filter convention.
@@ -112,6 +118,12 @@ def make_classifications_filtered_by_taxa_list(
 
     timestamp = timezone.now()
     masked_count = 0
+
+    # Report the size of the run before touching a row: sizing the scope and
+    # expanding the category map both take time on a large classifier, and until
+    # this fires the job looks untouched.
+    if on_setup is not None:
+        on_setup(total)
 
     for i, classification in enumerate(classifications.iterator(chunk_size=batch_size), start=1):
         logits = classification.logits
@@ -269,6 +281,18 @@ class ClassMaskingTask(BasePostProcessingTask):
 
         ``config_schema`` guarantees exactly one scope id is set, so the single
         ``else`` branch is sound.
+
+        Neither branch de-duplicates rows, and neither needs to: a classification
+        reaches an occurrence through a plain foreign key, and it reaches a
+        collection through a membership table that holds one row per
+        (capture, collection) pair, so filtering on a single occurrence or a single
+        collection cannot multiply rows. De-duplicating is also costly here, because
+        the selected columns include the ``logits`` and ``scores`` arrays, which run
+        to roughly half a megabyte per row for a classifier with tens of thousands
+        of categories. Measured on a 55,530-row scope: counting took 208 seconds
+        with ``.distinct()`` and 0.5 seconds without, returning the same number.
+        De-duplication is also a blocking step, so it delayed the first row of the
+        iteration pass as well as the count.
         """
         base = Classification.objects.filter(
             terminal=True,
@@ -281,7 +305,7 @@ class ClassMaskingTask(BasePostProcessingTask):
             if not Occurrence.objects.filter(pk=config.occurrence_id).exists():
                 raise ValueError(f"Occurrence {config.occurrence_id} not found")
             return (
-                base.filter(detection__occurrence_id=config.occurrence_id).distinct(),
+                base.filter(detection__occurrence_id=config.occurrence_id),
                 f"occurrence {config.occurrence_id}",
             )
 
@@ -290,7 +314,7 @@ class ClassMaskingTask(BasePostProcessingTask):
         except SourceImageCollection.DoesNotExist:
             raise ValueError(f"SourceImageCollection {config.source_image_collection_id} not found")
         return (
-            base.filter(detection__source_image__collections=collection).distinct(),
+            base.filter(detection__source_image__collections=collection),
             f"collection {collection.pk}",
         )
 
@@ -315,6 +339,10 @@ class ClassMaskingTask(BasePostProcessingTask):
         classifications, scope_desc = self._scoped_classifications(config, source_algorithm)
         self.logger.info(f"Applying class masking on {scope_desc} using taxa list {taxa_list.pk}")
 
+        def _on_setup(total: int) -> None:
+            self.update_progress(0.0)
+            self.report_stage_metrics({"classifications_total": total})
+
         def _on_batch(m: dict) -> None:
             total = m["classifications_total"]
             self.update_progress(m["classifications_checked"] / total if total else 1.0)
@@ -333,6 +361,7 @@ class ClassMaskingTask(BasePostProcessingTask):
             new_algorithm=masking_algorithm,
             reweight=config.reweight,
             task_logger=self.logger,
+            on_setup=_on_setup,
             on_batch=_on_batch,
         )
         self.report_stage_metrics(metrics)

--- a/ami/ml/post_processing/class_masking.py
+++ b/ami/ml/post_processing/class_masking.py
@@ -279,9 +279,11 @@ class ClassMaskingTask(BasePostProcessingTask):
         ``config_schema`` guarantees exactly one scope id is set, so the single
         ``else`` branch is sound.
 
-        Do not add ``.distinct()``: neither scope can duplicate a row, and
-        de-duplicating sorts the ``logits`` and ``scores`` arrays, which measured
-        208s versus 0.5s on a 55,530-row scope. See #1376.
+        Do not add ``.distinct()`` while both scopes filter a to-one path: neither
+        can duplicate a row, and de-duplicating sorts the ``logits`` and ``scores``
+        arrays, which measured 208s versus 0.5s on a 55,530-row scope. Broadening
+        either scope to match several collections or a whole project would fan out
+        and need de-duplication again — restrict the columns first. See #1376.
         """
         base = Classification.objects.filter(
             terminal=True,

--- a/ami/ml/post_processing/tests/test_class_masking.py
+++ b/ami/ml/post_processing/tests/test_class_masking.py
@@ -490,14 +490,8 @@ class TestPostProcessingClassMasking(TestCase):
     # ----- scope query shape ----------------------------------------------
 
     def test_collection_scope_returns_each_classification_once(self):
-        """A capture that belongs to several collections still contributes one row per
-        classification when the scope is filtered to one of those collections.
-
-        This is the property that makes de-duplication unnecessary: the collection
-        membership table holds at most one row per (capture, collection) pair, and
-        detection -> capture is a plain foreign key, so filtering on a single
-        collection cannot multiply rows.
-        """
+        """A capture in several collections still contributes one row per
+        classification, which is why the scope needs no de-duplication."""
         capture = self.collection.images.first()
         other_collection = SourceImageCollection.objects.create(
             name="Second collection containing the same capture",
@@ -552,21 +546,11 @@ class TestPostProcessingClassMasking(TestCase):
         self.assertEqual(scoped.count(), 3)
 
     def test_scope_query_does_not_deduplicate_rows(self):
-        """Neither scope may emit ``SELECT DISTINCT``, because the selected columns
-        include the ``logits`` and ``scores`` arrays.
+        """Neither scope de-duplicates rows.
 
-        A production classifier carries 29,176 categories, so those two arrays are
-        roughly half a megabyte per row and de-duplicating whole rows forces the
-        database to sort all of them. Measured against a 55,530-row scope: counting
-        the scope took 208 seconds with de-duplication and 0.5 seconds without,
-        returning the same number. The de-duplication is also blocking, so the first
-        row of the iteration pass cannot arrive until the whole sort completes,
-        which is what pushed masking runs past the stalled-job cutoff before any
-        progress was reported.
-
-        The equivalent-results half of this claim is covered by the two scope tests
-        above; de-duplication cannot be observed in the output, so the query shape
-        is the only thing left to pin.
+        This costs 208s versus 0.5s on a production-sized scope and is invisible in
+        the output, so the query shape is the only thing that can guard it. The two
+        tests above cover the results being equivalent. See #1376.
         """
         taxa_list = TaxaList.objects.create(name="Query shape list")
         taxa_list.taxa.set(self.species_taxa[:2])
@@ -579,17 +563,11 @@ class TestPostProcessingClassMasking(TestCase):
             with self.subTest(**kwargs):
                 task = ClassMaskingTask(taxa_list_id=taxa_list.pk, algorithm_id=self.algorithm.pk, **kwargs)
                 scoped, _ = task._scoped_classifications(task.config, self.algorithm)
-                self.assertNotIn("DISTINCT", str(scoped.query).upper())
+                self.assertFalse(scoped.query.distinct)
 
     def test_scope_size_is_reported_before_the_first_batch(self):
-        """The scope size reaches the job before any row is processed.
-
-        Resolving the scope reads the taxa list and expands the classifier's
-        category map, so an operator watching a large run would otherwise see a
-        stage sitting at zero with no indication of how much work was found. The
-        same callback moves the stage out of its created state, which is what
-        proves to the stalled-job check that the run is alive.
-        """
+        """The scope size reaches the job before any row is processed, so a large
+        run reports what it found rather than sitting at zero while it starts."""
         taxa_list = TaxaList.objects.create(name="Setup callback list")
         taxa_list.taxa.set(self.species_taxa[:2])
 

--- a/ami/ml/post_processing/tests/test_class_masking.py
+++ b/ami/ml/post_processing/tests/test_class_masking.py
@@ -525,32 +525,12 @@ class TestPostProcessingClassMasking(TestCase):
             "A capture in two collections must not yield the classification twice",
         )
 
-    def test_occurrence_scope_returns_each_classification_once(self):
-        """An occurrence with several detections yields one row per classification."""
-        taxa_list = TaxaList.objects.create(name="Occurrence scope shape list")
-        taxa_list.taxa.set(self.species_taxa[:2])
-
-        occurrence = Occurrence.objects.create(project=self.project, event=self.deployment.events.first())
-        logits = [2.0, 1.0, 5.0]
-        for capture in self.collection.images.all()[:3]:
-            detection = Detection.objects.create(source_image=capture, bbox=[0, 0, 200, 200])
-            occurrence.detections.add(detection)
-            self._create_classification_with_logits(detection, self.species_taxa[2], _softmax(logits), logits)
-
-        task = ClassMaskingTask(
-            occurrence_id=occurrence.pk,
-            taxa_list_id=taxa_list.pk,
-            algorithm_id=self.algorithm.pk,
-        )
-        scoped, _ = task._scoped_classifications(task.config, self.algorithm)
-        self.assertEqual(scoped.count(), 3)
-
     def test_scope_query_does_not_deduplicate_rows(self):
         """Neither scope de-duplicates rows.
 
-        This costs 208s versus 0.5s on a production-sized scope and is invisible in
-        the output, so the query shape is the only thing that can guard it. The two
-        tests above cover the results being equivalent. See #1376.
+        De-duplication is invisible in the output but very costly here, so the
+        query shape is the only thing that can guard it; the test above covers the
+        results being equivalent. See #1376.
         """
         taxa_list = TaxaList.objects.create(name="Query shape list")
         taxa_list.taxa.set(self.species_taxa[:2])

--- a/ami/ml/post_processing/tests/test_class_masking.py
+++ b/ami/ml/post_processing/tests/test_class_masking.py
@@ -486,3 +486,133 @@ class TestPostProcessingClassMasking(TestCase):
         # Stored confidence: reweight=False uses the original pre-mask probability.
         self.assertAlmostEqual(new_clf_f.score, scores[0], places=6)
         self.assertNotAlmostEqual(new_clf_t.score, scores[0], places=2)
+
+    # ----- scope query shape ----------------------------------------------
+
+    def test_collection_scope_returns_each_classification_once(self):
+        """A capture that belongs to several collections still contributes one row per
+        classification when the scope is filtered to one of those collections.
+
+        This is the property that makes de-duplication unnecessary: the collection
+        membership table holds at most one row per (capture, collection) pair, and
+        detection -> capture is a plain foreign key, so filtering on a single
+        collection cannot multiply rows.
+        """
+        capture = self.collection.images.first()
+        other_collection = SourceImageCollection.objects.create(
+            name="Second collection containing the same capture",
+            project=self.project,
+            method="manual",
+            kwargs={"image_ids": [capture.pk]},
+        )
+        other_collection.images.add(capture)
+
+        detection = Detection.objects.create(source_image=capture, bbox=[0, 0, 200, 200])
+        occurrence = Occurrence.objects.create(project=self.project, event=self.deployment.events.first())
+        occurrence.detections.add(detection)
+        logits = [2.0, 1.0, 5.0]
+        classification = self._create_classification_with_logits(
+            detection, self.species_taxa[2], _softmax(logits), logits
+        )
+
+        taxa_list = TaxaList.objects.create(name="Scope shape list")
+        taxa_list.taxa.set(self.species_taxa[:2])
+        task = ClassMaskingTask(
+            source_image_collection_id=self.collection.pk,
+            taxa_list_id=taxa_list.pk,
+            algorithm_id=self.algorithm.pk,
+        )
+        scoped, _ = task._scoped_classifications(task.config, self.algorithm)
+
+        self.assertEqual(list(scoped.filter(pk=classification.pk)), [classification])
+        self.assertEqual(
+            scoped.filter(pk=classification.pk).count(),
+            1,
+            "A capture in two collections must not yield the classification twice",
+        )
+
+    def test_occurrence_scope_returns_each_classification_once(self):
+        """An occurrence with several detections yields one row per classification."""
+        taxa_list = TaxaList.objects.create(name="Occurrence scope shape list")
+        taxa_list.taxa.set(self.species_taxa[:2])
+
+        occurrence = Occurrence.objects.create(project=self.project, event=self.deployment.events.first())
+        logits = [2.0, 1.0, 5.0]
+        for capture in self.collection.images.all()[:3]:
+            detection = Detection.objects.create(source_image=capture, bbox=[0, 0, 200, 200])
+            occurrence.detections.add(detection)
+            self._create_classification_with_logits(detection, self.species_taxa[2], _softmax(logits), logits)
+
+        task = ClassMaskingTask(
+            occurrence_id=occurrence.pk,
+            taxa_list_id=taxa_list.pk,
+            algorithm_id=self.algorithm.pk,
+        )
+        scoped, _ = task._scoped_classifications(task.config, self.algorithm)
+        self.assertEqual(scoped.count(), 3)
+
+    def test_scope_query_does_not_deduplicate_rows(self):
+        """Neither scope may emit ``SELECT DISTINCT``, because the selected columns
+        include the ``logits`` and ``scores`` arrays.
+
+        A production classifier carries 29,176 categories, so those two arrays are
+        roughly half a megabyte per row and de-duplicating whole rows forces the
+        database to sort all of them. Measured against a 55,530-row scope: counting
+        the scope took 208 seconds with de-duplication and 0.5 seconds without,
+        returning the same number. The de-duplication is also blocking, so the first
+        row of the iteration pass cannot arrive until the whole sort completes,
+        which is what pushed masking runs past the stalled-job cutoff before any
+        progress was reported.
+
+        The equivalent-results half of this claim is covered by the two scope tests
+        above; de-duplication cannot be observed in the output, so the query shape
+        is the only thing left to pin.
+        """
+        taxa_list = TaxaList.objects.create(name="Query shape list")
+        taxa_list.taxa.set(self.species_taxa[:2])
+        occurrence = Occurrence.objects.create(project=self.project, event=self.deployment.events.first())
+
+        for kwargs in (
+            {"source_image_collection_id": self.collection.pk},
+            {"occurrence_id": occurrence.pk},
+        ):
+            with self.subTest(**kwargs):
+                task = ClassMaskingTask(taxa_list_id=taxa_list.pk, algorithm_id=self.algorithm.pk, **kwargs)
+                scoped, _ = task._scoped_classifications(task.config, self.algorithm)
+                self.assertNotIn("DISTINCT", str(scoped.query).upper())
+
+    def test_scope_size_is_reported_before_the_first_batch(self):
+        """The scope size reaches the job before any row is processed.
+
+        Resolving the scope reads the taxa list and expands the classifier's
+        category map, so an operator watching a large run would otherwise see a
+        stage sitting at zero with no indication of how much work was found. The
+        same callback moves the stage out of its created state, which is what
+        proves to the stalled-job check that the run is alive.
+        """
+        taxa_list = TaxaList.objects.create(name="Setup callback list")
+        taxa_list.taxa.set(self.species_taxa[:2])
+
+        det, _ = self._detection_with_occurrence()
+        logits = [2.0, 1.0, 5.0]
+        self._create_classification_with_logits(det, self.species_taxa[2], _softmax(logits), logits)
+
+        new_algorithm = Algorithm.objects.create(
+            name="masked_setup",
+            key="masked_setup_test",
+            task_type=AlgorithmTaskType.CLASSIFICATION.value,
+            category_map=self.algorithm.category_map,
+        )
+
+        events: list[tuple[str, int]] = []
+        make_classifications_filtered_by_taxa_list(
+            classifications=Classification.objects.filter(detection=det, terminal=True),
+            taxa_list=taxa_list,
+            algorithm=self.algorithm,
+            new_algorithm=new_algorithm,
+            on_setup=lambda total: events.append(("setup", total)),
+            on_batch=lambda m: events.append(("batch", m["classifications_checked"])),
+        )
+
+        self.assertEqual(events[0], ("setup", 1), "Scope size is reported once, before the first batch")
+        self.assertEqual([name for name, _ in events], ["setup", "batch"])

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -1651,62 +1651,38 @@ class TestPostProcessingTasks(TestCase):
         job.refresh_from_db()
         self.assertGreater(job.updated_at, stale, "report_stage_metrics must bump updated_at")
 
-    def _post_processing_job(self, name: str):
-        from ami.jobs.models import Job
+    def test_post_processing_stage_is_started_before_the_task_runs(self):
+        """The stage reads as running from the moment the job starts.
+
+        A task's first progress report can be minutes into a large run, and a stage
+        left at CREATED renders as "Waiting to start" until then. See #1376.
+        """
+        from unittest.mock import patch
+
+        from ami.jobs.models import Job, JobState, PostProcessingJob
 
         job = Job.objects.create(
             project=self.project,
-            name=name,
+            name="stage status test",
             job_type_key="post_processing",
             params={
                 "task": "small_size_filter",
                 "config": {"source_image_collection_id": self.collection.pk, "size_threshold": 0.01},
             },
         )
-        job.progress.add_stage("Post Processing", key="post_processing")
-        job.save()
-        return job
 
-    def test_zero_progress_heartbeat_marks_the_stage_started(self):
-        """A heartbeat at exactly 0% still moves the stage out of CREATED.
+        observed = {}
 
-        ``Job.update_progress`` only promotes a stage once its progress exceeds
-        zero, so the setup heartbeat would otherwise leave a running job labelled
-        "Waiting to start". See #1376.
-        """
-        from ami.jobs.models import JobState
+        def _capture(self_task):
+            stage = self_task.job.progress.get_stage("post_processing")
+            observed["status"] = stage.status
+            observed["label"] = stage.status_label
 
-        job = self._post_processing_job("stage status test")
-        self.assertEqual(job.progress.stages[0].status, JobState.CREATED)
+        with patch.object(SmallSizeFilterTask, "run", _capture):
+            PostProcessingJob.run(job)
 
-        task = SmallSizeFilterTask(job=job, source_image_collection_id=self.collection.pk, size_threshold=0.01)
-        task.update_progress(0.0)
-
-        job.refresh_from_db()
-        stage = job.progress.stages[0]
-        self.assertEqual(stage.status, JobState.STARTED)
-        self.assertEqual(stage.status_label, "0% complete")
-
-    def test_heartbeat_does_not_resurrect_a_finished_stage(self):
-        """Promotion applies only to a stage that has not started.
-
-        A late heartbeat must not pull a stage that already reached a final state
-        back to STARTED, which would hide a failure or a cancellation. See #1376.
-        """
-        from ami.jobs.models import Job, JobState
-
-        for final in (JobState.SUCCESS, JobState.FAILURE, JobState.REVOKED):
-            with self.subTest(final=final):
-                job = self._post_processing_job(f"stage status {final} test")
-                job.progress.update_stage("post_processing", status=final, progress=1.0)
-                job.save()
-
-                task = SmallSizeFilterTask(job=job, source_image_collection_id=self.collection.pk, size_threshold=0.01)
-                task.update_progress(0.5)
-
-                job.refresh_from_db()
-                self.assertEqual(job.progress.stages[0].status, final)
-                Job.objects.filter(pk=job.pk).delete()
+        self.assertEqual(observed["status"], JobState.STARTED)
+        self.assertEqual(observed["label"], "0% complete")
 
     def test_occurrences_updated_counts_only_changed_determinations(self):
         """``occurrences_updated`` counts occurrences whose determination actually

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -1651,6 +1651,37 @@ class TestPostProcessingTasks(TestCase):
         job.refresh_from_db()
         self.assertGreater(job.updated_at, stale, "report_stage_metrics must bump updated_at")
 
+    def test_progress_marks_the_stage_started(self):
+        """A progress heartbeat moves the stage to STARTED.
+
+        The job wrapper creates the stage and later marks it SUCCESS, and nothing
+        in between sets a status. ``get_status_label`` labels CREATED as "Waiting
+        to start" whatever the progress is, so without this a running job reads as
+        not yet begun for its whole duration. See #1376.
+        """
+        from ami.jobs.models import Job, JobState
+
+        job = Job.objects.create(
+            project=self.project,
+            name="stage status test",
+            job_type_key="post_processing",
+            params={
+                "task": "small_size_filter",
+                "config": {"source_image_collection_id": self.collection.pk, "size_threshold": 0.01},
+            },
+        )
+        job.progress.add_stage("Post Processing", key="post_processing")
+        job.save()
+        self.assertEqual(job.progress.stages[0].status, JobState.CREATED)
+
+        task = SmallSizeFilterTask(job=job, source_image_collection_id=self.collection.pk, size_threshold=0.01)
+        task.update_progress(0.5)
+
+        job.refresh_from_db()
+        stage = job.progress.stages[0]
+        self.assertEqual(stage.status, JobState.STARTED)
+        self.assertEqual(stage.status_label, "50% complete")
+
     def test_occurrences_updated_counts_only_changed_determinations(self):
         """``occurrences_updated`` counts occurrences whose determination actually
         changed, not every occurrence the filter re-saved.

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -1651,19 +1651,12 @@ class TestPostProcessingTasks(TestCase):
         job.refresh_from_db()
         self.assertGreater(job.updated_at, stale, "report_stage_metrics must bump updated_at")
 
-    def test_progress_marks_the_stage_started(self):
-        """A progress heartbeat moves the stage to STARTED.
-
-        The job wrapper creates the stage and later marks it SUCCESS, and nothing
-        in between sets a status. ``get_status_label`` labels CREATED as "Waiting
-        to start" whatever the progress is, so without this a running job reads as
-        not yet begun for its whole duration. See #1376.
-        """
-        from ami.jobs.models import Job, JobState
+    def _post_processing_job(self, name: str):
+        from ami.jobs.models import Job
 
         job = Job.objects.create(
             project=self.project,
-            name="stage status test",
+            name=name,
             job_type_key="post_processing",
             params={
                 "task": "small_size_filter",
@@ -1672,15 +1665,48 @@ class TestPostProcessingTasks(TestCase):
         )
         job.progress.add_stage("Post Processing", key="post_processing")
         job.save()
+        return job
+
+    def test_zero_progress_heartbeat_marks_the_stage_started(self):
+        """A heartbeat at exactly 0% still moves the stage out of CREATED.
+
+        ``Job.update_progress`` only promotes a stage once its progress exceeds
+        zero, so the setup heartbeat would otherwise leave a running job labelled
+        "Waiting to start". See #1376.
+        """
+        from ami.jobs.models import JobState
+
+        job = self._post_processing_job("stage status test")
         self.assertEqual(job.progress.stages[0].status, JobState.CREATED)
 
         task = SmallSizeFilterTask(job=job, source_image_collection_id=self.collection.pk, size_threshold=0.01)
-        task.update_progress(0.5)
+        task.update_progress(0.0)
 
         job.refresh_from_db()
         stage = job.progress.stages[0]
         self.assertEqual(stage.status, JobState.STARTED)
-        self.assertEqual(stage.status_label, "50% complete")
+        self.assertEqual(stage.status_label, "0% complete")
+
+    def test_heartbeat_does_not_resurrect_a_finished_stage(self):
+        """Promotion applies only to a stage that has not started.
+
+        A late heartbeat must not pull a stage that already reached a final state
+        back to STARTED, which would hide a failure or a cancellation. See #1376.
+        """
+        from ami.jobs.models import Job, JobState
+
+        for final in (JobState.SUCCESS, JobState.FAILURE, JobState.REVOKED):
+            with self.subTest(final=final):
+                job = self._post_processing_job(f"stage status {final} test")
+                job.progress.update_stage("post_processing", status=final, progress=1.0)
+                job.save()
+
+                task = SmallSizeFilterTask(job=job, source_image_collection_id=self.collection.pk, size_threshold=0.01)
+                task.update_progress(0.5)
+
+                job.refresh_from_db()
+                self.assertEqual(job.progress.stages[0].status, final)
+                Job.objects.filter(pk=job.pk).delete()
 
     def test_occurrences_updated_counts_only_changed_determinations(self):
         """``occurrences_updated`` counts occurrences whose determination actually


### PR DESCRIPTION
## Summary

Large class masking runs were being cancelled roughly eleven minutes in, having reported no progress at all: the job page showed zero classifications checked. The cause was not the masking work itself but the query that decides which classifications are in scope, which asked the database to de-duplicate rows it could not have duplicated. On a scope of 55,530 classifications that took 208 seconds to count and just as long again before the first row could be read, so the run crossed the stalled-job cutoff before it ever committed a batch and reported progress.

Removing the de-duplication brings the same count back in half a second. A masking run now starts working almost immediately and reports the size of the job before it processes the first prediction, so an operator watching a long run can see how much was found rather than a stage sitting at zero.

Checking that claim in review turned up a smaller related gap: post-processing jobs never marked their stage started, so they read as "Waiting to start" until the first progress report. That is fixed here too, and it affects the small size filter as well.

The scope query returns exactly the same classifications, and the masking logic is untouched.

### List of Changes

| # | What changes for the operator | How |
|---|---|---|
| 1 | Large masking runs are no longer cancelled before they begin | `ClassMaskingTask._scoped_classifications` no longer calls `.distinct()` on either scope |
| 2 | The `run_class_masking` command's preflight count returns promptly instead of appearing to hang | Same de-duplication removed from the command's count |
| 3 | A running job shows how many classifications it found before it starts working through them | New `on_setup` callback reports the scope size before the first row |
| 4 | A job that has started but reported no progress yet reads as running, not as "Waiting to start" | `PostProcessingJob.run` marks the stage STARTED before the task runs, matching the other job types |
| 5 | Comment norms written down, so the next PR does not repeat the same review round | `.agents/AGENTS.md` gains a rule on comment length and linking to the PR |

## Detailed Description

### Why de-duplication was both unnecessary and expensive

A classification reaches an occurrence through a plain foreign key, and it reaches a collection through a membership table that holds one row per (capture, collection) pair. Filtering on a single occurrence or a single collection therefore cannot multiply rows, so there was nothing to de-duplicate. The two new scope tests pin exactly that, including the case a reader would worry about: a capture that belongs to several collections still contributes one row per classification.

The cost comes from what `SELECT DISTINCT` has to compare. The selected columns include the `logits` and `scores` arrays, and a production classifier can carry tens of thousands of categories, which puts those two arrays at roughly half a megabyte per row. The database was sorting all of them to prove uniqueness of a column set that already contains the primary key.

De-duplication is also a blocking step, so it delayed the iteration pass as well as the count — no row could be returned until the whole sort finished. Both delays land before the first batch commits, and the first batch commit is where the run reports its first progress.

### Measured, not estimated

Against a live database, on the scope of a run that had been cancelled:

| Query | Time | Result |
|---|---|---|
| Count the scope, with `.distinct()` | 208.0 s | 55,530 |
| Count the scope, without `.distinct()` | 0.5 s | 55,530 |
| Read the first 200 rows, without `.distinct()` | 0.4 s | — |

For context on the remaining setup work, expanding that classifier's category map (29,176 categories) took 10.4 seconds and reading the taxa list took 0.4 seconds. With the de-duplication gone, the work ahead of the first progress report is on the order of ten seconds rather than minutes.

### The stage-status fix, and two corrections it went through

A stage that has started but not yet reported progress reads as "Waiting to start", because `get_status_label` renders a `CREATED` stage that way regardless of progress. Every job type is supposed to move its stage to `STARTED` at the top of `run()`; `PostProcessingJob` was the only one that did not, so its stage sat in `CREATED` until the task's first progress report, which on a large masking run is minutes in.

This took two rounds of review to land correctly, and the audit trail is worth keeping:

- I first cited the cancelled job's stage still being `CREATED` as evidence of the stall. @copilot pointed out a healthy run looked identical, so that was not diagnostic; the evidence that stands is the counter, still at zero eleven minutes in.
- I then fixed it inside `BasePostProcessingTask.update_progress`, guarding the promotion to fire only from `CREATED`. @coderabbitai correctly noted that `Job.update_progress` already promotes on any progress above zero, so my first test at 0.5 was vacuous, and that a per-heartbeat write is the wrong shape for a status transition.
- The takeaway review then placed it correctly: this belongs in `PostProcessingJob.run`, next to `update_status(STARTED)`, exactly as `RegroupEventsJob` and `SourceImageCollectionPopulateJob` already do it. That is one line, it fires before the scope count rather than at the first heartbeat, and it removes the base-class guard entirely. `test_post_processing_stage_is_started_before_the_task_runs` pins it.

### A note on the one `.distinct()` that stays

`ClassMaskingActionForm._algorithms_for_scope` still de-duplicates, and should: it joins from `Algorithm` across a reverse relation to many classifications, so one algorithm genuinely does appear once per classification. It also selects only algorithm columns, so the comparison is cheap.

## Testing

- `ami.ml.post_processing`, `ami.ml.tests` and `ami.jobs` pass, including five new tests.
- `black`, `isort` and `flake8` clean on the touched files.
- The equivalence claim is checked two ways: the new tests assert the scope returns each classification exactly once, and the measurement above confirms both forms of the query return 55,530 on real data.