### PR TITLE
Show recently updated capture sets first in pickers, and stop them waiting on counts they never show

### DIFF
--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -82,6 +82,7 @@ from .serializers import (
     ProjectListSerializer,
     ProjectSerializer,
     SiteSerializer,
+    SourceImageCollectionNestedSerializer,
     SourceImageCollectionSerializer,
     SourceImageListSerializer,
     SourceImageSerializer,
@@ -927,13 +928,7 @@ class SourceImageCollectionViewSet(DefaultViewSet, ProjectMixin):
     Endpoint for viewing capture sets or samples of captures.
     """
 
-    queryset = (
-        SourceImageCollection.objects.all()
-        .with_source_images_count()  # type: ignore
-        .with_source_images_with_detections_count()
-        .with_source_images_processed_count()
-        .prefetch_related("jobs")
-    )
+    queryset = SourceImageCollection.objects.all().prefetch_related("jobs")
     serializer_class = SourceImageCollectionSerializer
     permission_classes = [
         ObjectPermission,
@@ -950,17 +945,32 @@ class SourceImageCollectionViewSet(DefaultViewSet, ProjectMixin):
         "source_images_processed_count",
         "occurrences_count",
     ]
+    # Recently updated first, so a caller reading one page gets the sets a user is most
+    # likely to want. Without a default the row order is whatever Postgres returns, which
+    # also makes pages unstable.
+    ordering = ["-updated_at"]
 
     def get_queryset(self) -> QuerySet:
         query_set: QuerySet = super().get_queryset()
         with_counts_default = False
-        # If with_counts is explicitly requested, require project
-        if "with_counts" in self.request.query_params:
+        # If with_counts is explicitly requested, require project.
+        # Picker choices are always scoped to one project.
+        if "with_counts" in self.request.query_params or self.action == "choices":
             self.require_project = True
         project = self.get_active_project()
 
         if project:
             query_set = query_set.filter(project=project)
+
+        if self.action == "choices":
+            # Choices are names, so skip the counts and the jobs each set has run.
+            return query_set.prefetch_related(None)
+
+        query_set = (
+            query_set.with_source_images_count()  # type: ignore
+            .with_source_images_with_detections_count()
+            .with_source_images_processed_count()
+        )
 
         if self.action == "retrieve":
             # For detail view, include counts by default
@@ -979,6 +989,24 @@ class SourceImageCollectionViewSet(DefaultViewSet, ProjectMixin):
             )
 
         return query_set
+
+    @extend_schema(
+        parameters=[project_id_doc_param],
+        responses=SourceImageCollectionNestedSerializer(many=True),
+    )
+    @action(detail=False, methods=["get"], name="choices")
+    def choices(self, request: Request) -> Response:
+        """Choices for capture set filters and pickers.
+
+        Returns only what those consumers need to name a capture set, most recently
+        updated first.
+        """
+        # Sorting by a count would fail here, since the counts are never annotated.
+        self.ordering_fields = ["id", "created_at", "updated_at", "name", "method"]
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        serializer = SourceImageCollectionNestedSerializer(page, many=True, context=self.get_serializer_context())
+        return self.get_paginated_response(serializer.data)
 
     @action(detail=True, methods=["post"], name="populate")
     def populate(self, request, pk=None):

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -928,6 +928,17 @@ class SourceImageThumbnailViewSet(DefaultReadOnlyViewSet, ProjectMixin):
         return response
 
 
+class CaptureSetChoicesPagination(LimitOffsetPaginationWithPermissions):
+    """Sends a whole project's capture set choices in one response.
+
+    Dropdowns cannot page, so the limit is set here rather than by each caller. It is
+    capped as well as defaulted, so no caller can ask for a larger one.
+    """
+
+    default_limit = 100
+    max_limit = 100
+
+
 class SourceImageCollectionViewSet(DefaultViewSet, ProjectMixin):
     """
     Endpoint for viewing capture sets or samples of captures.
@@ -1004,14 +1015,16 @@ class SourceImageCollectionViewSet(DefaultViewSet, ProjectMixin):
         """Choices for capture set filters and pickers.
 
         Returns only what those consumers need to name a capture set, most recently
-        updated first.
+        updated first, and enough of them that a dropdown never has to page. A project
+        with more capture sets than the cap needs the search field in #1380.
         """
         # Sorting by a count would fail here, since the counts are never annotated.
         self.ordering_fields = ["id", "created_at", "updated_at", "name", "method"]
         queryset = self.filter_queryset(self.get_queryset())
-        page = self.paginate_queryset(queryset)
+        paginator = CaptureSetChoicesPagination()
+        page = paginator.paginate_queryset(queryset, request, view=self)
         serializer = SourceImageCollectionNestedSerializer(page, many=True, context=self.get_serializer_context())
-        return self.get_paginated_response(serializer.data)
+        return paginator.get_paginated_response(serializer.data)
 
     @action(detail=True, methods=["post"], name="populate")
     def populate(self, request, pk=None):

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -6887,3 +6887,80 @@ class ClassificationAdminChangelistTest(TestCase):
         row = next(c for c in self.admin.get_queryset(self._request()) if c.pk == clf.pk)
         self.assertEqual(row.scores_count, 3)
         self.assertEqual(row.logits_count, 0)
+
+
+class TestCaptureSetChoices(APITestCase):
+    """Choices endpoint for capture set filters and pickers.
+
+    Pins the contract those consumers rely on: names without counts, most recently
+    updated first.
+    """
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(email="picker@insectai.org", is_staff=False)
+        self.project = Project.objects.create(name="Picker project", owner=self.user)
+        self.other_project = Project.objects.create(name="Other project", owner=self.user)
+        # A new project starts with a capture set holding all of its captures.
+        self.starting_collection = SourceImageCollection.objects.get(project=self.project)
+        self.oldest, self.middle, self.newest = (
+            SourceImageCollection.objects.create(name=name, project=self.project, method="manual")
+            for name in ("Oldest", "Middle", "Newest")
+        )
+        # updated_at is auto_now, so write the timestamps directly instead of relying on
+        # the order the rows were created in.
+        for days_ago, collection in enumerate([self.newest, self.middle, self.oldest, self.starting_collection]):
+            SourceImageCollection.objects.filter(pk=collection.pk).update(
+                updated_at=timezone.now() - datetime.timedelta(days=days_ago)
+            )
+        self.expected_order = ["Newest", "Middle", "Oldest", self.starting_collection.name]
+        self.other_collection = SourceImageCollection.objects.create(
+            name="Elsewhere", project=self.other_project, method="manual"
+        )
+        self.url = f"/api/v2/captures/collections/choices/?project_id={self.project.pk}"
+
+    def test_most_recently_updated_capture_set_comes_first(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual([row["name"] for row in response.json()["results"]], self.expected_order)
+
+    def test_choices_omit_the_capture_occurrence_and_taxa_counts(self):
+        response = self.client.get(self.url)
+        row = response.json()["results"][0]
+        self.assertEqual(sorted(row.keys()), ["details", "id", "method", "name", "user_permissions"])
+
+    def test_choices_are_limited_to_the_requested_project(self):
+        response = self.client.get(self.url)
+        returned_ids = {row["id"] for row in response.json()["results"]}
+        self.assertEqual(
+            returned_ids,
+            {self.oldest.pk, self.middle.pk, self.newest.pk, self.starting_collection.pk},
+        )
+        self.assertNotIn(self.other_collection.pk, returned_ids)
+
+    def test_a_project_is_required(self):
+        response = self.client.get("/api/v2/captures/collections/choices/")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_capture_sets_in_a_draft_project_are_hidden_from_non_members(self):
+        draft_project = Project.objects.create(name="Draft project", owner=self.user, draft=True)
+        SourceImageCollection.objects.create(name="Secret", project=draft_project, method="manual")
+
+        response = self.client.get(f"/api/v2/captures/collections/choices/?project_id={draft_project.pk}")
+
+        self.assertEqual(response.json()["results"], [])
+
+    def test_the_list_endpoint_still_reports_capture_counts(self):
+        response = self.client.get(f"/api/v2/captures/collections/?project_id={self.project.pk}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        row = response.json()["results"][0]
+        self.assertIn("source_images_count", row)
+
+    def test_the_list_endpoint_also_defaults_to_most_recently_updated_first(self):
+        response = self.client.get(f"/api/v2/captures/collections/?project_id={self.project.pk}")
+        self.assertEqual([row["name"] for row in response.json()["results"]], self.expected_order)
+
+    def test_sorting_by_a_count_still_works_on_the_list_endpoint(self):
+        response = self.client.get(
+            f"/api/v2/captures/collections/?project_id={self.project.pk}&ordering=source_images_count"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -6998,7 +6998,7 @@ class TestCaptureSetChoices(APITestCase):
     """Choices endpoint for capture set filters and pickers.
 
     Pins the contract those consumers rely on: names without counts, most recently
-    updated first.
+    updated first, and a single capped response rather than pages.
     """
 
     def setUp(self) -> None:
@@ -7040,7 +7040,6 @@ class TestCaptureSetChoices(APITestCase):
             returned_ids,
             {self.oldest.pk, self.middle.pk, self.newest.pk, self.starting_collection.pk},
         )
-        self.assertNotIn(self.other_collection.pk, returned_ids)
 
     def test_a_project_is_required(self):
         response = self.client.get("/api/v2/captures/collections/choices/")
@@ -7070,24 +7069,23 @@ class TestCaptureSetChoices(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_a_dropdown_gets_every_capture_set_without_asking_for_a_page(self):
-        SourceImageCollection.objects.bulk_create(
-            SourceImageCollection(name=f"Bulk {index}", project=self.project, method="manual") for index in range(50)
-        )
-        response = self.client.get(self.url)
-        results = response.json()["results"]
-        self.assertEqual(len(results), SourceImageCollection.objects.filter(project=self.project).count())
+    def test_a_dropdown_gets_one_capped_response_instead_of_pages(self):
+        """The response size is the same whether or not a caller asks for a limit.
 
-    def test_a_project_with_too_many_capture_sets_is_capped_rather_than_paged(self):
+        A dropdown cannot page, so the endpoint neither falls back to the small
+        project-wide default nor lets a caller raise the cap. Reaching capture sets
+        past the cap is what the search field in #1380 is for.
+        """
         SourceImageCollection.objects.bulk_create(
             SourceImageCollection(name=f"Bulk {index}", project=self.project, method="manual") for index in range(120)
         )
-        # A caller cannot raise the cap, so the response size stays bounded no matter what
-        # is asked for. Reaching past it is what the search field in #1380 is for.
         for query in ("", "&limit=500"):
             with self.subTest(query=query):
-                response = self.client.get(f"{self.url}{query}")
-                self.assertEqual(len(response.json()["results"]), 100)
+                body = self.client.get(f"{self.url}{query}").json()
+                self.assertEqual(len(body["results"]), 100)
+                # The total still reports every capture set, so a caller can tell that
+                # what it received is a subset.
+                self.assertEqual(body["count"], SourceImageCollection.objects.filter(project=self.project).count())
 
 
 BULK_IDENTIFICATIONS_ENDPOINT = "/api/v2/identifications/bulk/"

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -7070,6 +7070,25 @@ class TestCaptureSetChoices(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_a_dropdown_gets_every_capture_set_without_asking_for_a_page(self):
+        SourceImageCollection.objects.bulk_create(
+            SourceImageCollection(name=f"Bulk {index}", project=self.project, method="manual") for index in range(50)
+        )
+        response = self.client.get(self.url)
+        results = response.json()["results"]
+        self.assertEqual(len(results), SourceImageCollection.objects.filter(project=self.project).count())
+
+    def test_a_project_with_too_many_capture_sets_is_capped_rather_than_paged(self):
+        SourceImageCollection.objects.bulk_create(
+            SourceImageCollection(name=f"Bulk {index}", project=self.project, method="manual") for index in range(120)
+        )
+        # A caller cannot raise the cap, so the response size stays bounded no matter what
+        # is asked for. Reaching past it is what the search field in #1380 is for.
+        for query in ("", "&limit=500"):
+            with self.subTest(query=query):
+                response = self.client.get(f"{self.url}{query}")
+                self.assertEqual(len(response.json()["results"]), 100)
+
 
 BULK_IDENTIFICATIONS_ENDPOINT = "/api/v2/identifications/bulk/"
 

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -43,6 +43,39 @@ in `src/design-system/` — check there before writing a new component.
 - Constants are SCREAMING_SNAKE with word separation: `TAXA_LISTS`, not `TAXALISTS`.
 - Don't shadow global/DOM types (`Response`, `string`) with local interface names.
 
+## Constants
+
+- A magic number used by one module is a `const` at the top of that module:
+  `const MAX_NUM_RESULTS = 5` in `components/taxon-search/useTaxonSearch.ts`.
+- Hoist to `data-services/constants.ts` only once a second module in a different
+  directory needs the same value. That file holds cross-cutting values —
+  `REFETCH_INTERVAL`, `SUCCESS_TIMEOUT` — not per-page settings.
+
+## Comments
+
+The general rule in `.agents/AGENTS.md` is written for the Python side. The frontend
+runs leaner: most components carry no comments at all, so a block of prose stands out
+far more here than the same block would in a Django view.
+
+- One or two lines, and only where the code cannot say it. Anything longer belongs in
+  the PR description with a `See #NNNN` pointer left behind.
+- Match the file you are editing. Before adding a comment, look at its siblings — if
+  they have none, the bar for adding one is high.
+- State each reason once. A rationale repeated in a constant, a prop, and the code that
+  uses them is one comment spread over three files.
+- Comments on an exported prop or constant document the contract for its callers. Say
+  what a caller must decide, not how the internals work.
+
+Before committing, compare your comment density with the neighbours:
+
+```bash
+cd ui && for f in src/path/to/dir/*.tsx; do
+  echo "$(grep -c '^\s*//' "$f")/$(wc -l < "$f")  $(basename "$f")"
+done
+```
+
+Standing out by several times the local ratio means trimming, not justifying.
+
 ## Lint & format — what is actually configured
 
 - ESLint: `ui/.eslintrc.json` — `eslint:recommended` + `@typescript-eslint/recommended`;

--- a/ui/src/components/filtering/filters/capture-set-filter.tsx
+++ b/ui/src/components/filtering/filters/capture-set-filter.tsx
@@ -1,11 +1,10 @@
-import { API_ROUTES, MAX_CAPTURE_SET_CHOICES } from 'data-services/constants'
+import { API_ROUTES } from 'data-services/constants'
 import { EntityPicker } from 'nova-ui-kit'
 import { FilterProps } from './types'
 
 export const CaptureSetFilter = ({ onAdd, onClear, value }: FilterProps) => (
   <EntityPicker
     collection={API_ROUTES.CAPTURE_SET_CHOICES}
-    pageSize={MAX_CAPTURE_SET_CHOICES}
     onValueChange={(value) => {
       if (value) {
         onAdd(value)

--- a/ui/src/components/filtering/filters/capture-set-filter.tsx
+++ b/ui/src/components/filtering/filters/capture-set-filter.tsx
@@ -1,10 +1,11 @@
-import { API_ROUTES } from 'data-services/constants'
+import { API_ROUTES, MAX_CAPTURE_SET_CHOICES } from 'data-services/constants'
 import { EntityPicker } from 'nova-ui-kit'
 import { FilterProps } from './types'
 
 export const CaptureSetFilter = ({ onAdd, onClear, value }: FilterProps) => (
   <EntityPicker
     collection={API_ROUTES.CAPTURE_SET_CHOICES}
+    pageSize={MAX_CAPTURE_SET_CHOICES}
     onValueChange={(value) => {
       if (value) {
         onAdd(value)

--- a/ui/src/components/filtering/filters/capture-set-filter.tsx
+++ b/ui/src/components/filtering/filters/capture-set-filter.tsx
@@ -4,7 +4,7 @@ import { FilterProps } from './types'
 
 export const CaptureSetFilter = ({ onAdd, onClear, value }: FilterProps) => (
   <EntityPicker
-    collection={API_ROUTES.CAPTURE_SETS}
+    collection={API_ROUTES.CAPTURE_SET_CHOICES}
     onValueChange={(value) => {
       if (value) {
         onAdd(value)

--- a/ui/src/data-services/constants.ts
+++ b/ui/src/data-services/constants.ts
@@ -34,10 +34,6 @@ export const API_ROUTES = {
   USERS: 'users',
 }
 
-// How many capture sets a picker or filter loads. Choices arrive most recently updated
-// first, so a project with more than this cannot reach the rest. See #1380.
-export const MAX_CAPTURE_SET_CHOICES = 200
-
 export const STATUS_CODES = {
   FORBIDDEN: 403,
 }

--- a/ui/src/data-services/constants.ts
+++ b/ui/src/data-services/constants.ts
@@ -34,10 +34,8 @@ export const API_ROUTES = {
   USERS: 'users',
 }
 
-// How many capture sets a picker or filter loads at once. Choices arrive most recently
-// updated first, so this covers the sets a user is realistically choosing between. A
-// project with more than this cannot reach the rest from a dropdown, which is what the
-// search field in #1380 is for.
+// How many capture sets a picker or filter loads. Choices arrive most recently updated
+// first, so a project with more than this cannot reach the rest. See #1380.
 export const MAX_CAPTURE_SET_CHOICES = 200
 
 export const STATUS_CODES = {

--- a/ui/src/data-services/constants.ts
+++ b/ui/src/data-services/constants.ts
@@ -34,6 +34,12 @@ export const API_ROUTES = {
   USERS: 'users',
 }
 
+// How many capture sets a picker or filter loads at once. Choices arrive most recently
+// updated first, so this covers the sets a user is realistically choosing between. A
+// project with more than this cannot reach the rest from a dropdown, which is what the
+// search field in #1380 is for.
+export const MAX_CAPTURE_SET_CHOICES = 200
+
 export const STATUS_CODES = {
   FORBIDDEN: 403,
 }

--- a/ui/src/data-services/constants.ts
+++ b/ui/src/data-services/constants.ts
@@ -2,6 +2,7 @@ export const API_URL = '/api/v2'
 
 export const API_ROUTES = {
   ALGORITHM: 'ml/algorithms',
+  CAPTURE_SET_CHOICES: 'captures/collections/choices',
   CAPTURE_SETS: 'captures/collections',
   CAPTURES: 'captures',
   CLASSIFICATIONS: 'classifications',

--- a/ui/src/data-services/hooks/capture-sets/useCaptureSetDetails.ts
+++ b/ui/src/data-services/hooks/capture-sets/useCaptureSetDetails.ts
@@ -1,0 +1,45 @@
+import { API_ROUTES, API_URL } from 'data-services/constants'
+import { CaptureSet, ServerCaptureSet } from 'data-services/models/capture-set'
+import { useMemo } from 'react'
+import { useAuthorizedQuery } from '../auth/useAuthorizedQuery'
+
+const convertServerRecord = (record: ServerCaptureSet) => new CaptureSet(record)
+
+/**
+ * Load a single capture set, including the number of captures it contains.
+ *
+ * Pickers read their options from the choices endpoint, which reports no counts,
+ * so a picker that shows the size of the selected set loads it here. Occurrence
+ * and taxa counts stay off, since nothing displays them.
+ */
+export const useCaptureSetDetails = (
+  captureSetId?: string,
+  projectId?: string
+): {
+  captureSet?: CaptureSet
+  isLoading: boolean
+  isFetching: boolean
+  error?: unknown
+} => {
+  const enabled = !!captureSetId && !!projectId
+  const url = `${API_URL}/${API_ROUTES.CAPTURE_SETS}/${captureSetId}/?project_id=${projectId}&with_counts=false`
+
+  const { data, isLoading, isFetching, error } =
+    useAuthorizedQuery<ServerCaptureSet>({
+      enabled,
+      queryKey: [API_ROUTES.CAPTURE_SETS, captureSetId, projectId],
+      url,
+    })
+
+  const captureSet = useMemo(
+    () => (data ? convertServerRecord(data) : undefined),
+    [data]
+  )
+
+  return {
+    captureSet,
+    isLoading,
+    isFetching,
+    error,
+  }
+}

--- a/ui/src/nova-ui-kit/components/select/capture-set-picker.tsx
+++ b/ui/src/nova-ui-kit/components/select/capture-set-picker.tsx
@@ -1,10 +1,17 @@
 import { FormMessage } from 'components/form/layout/layout'
-import { useCaptureSets } from 'data-services/hooks/capture-sets/useCaptureSets'
+import { API_ROUTES } from 'data-services/constants'
+import { useCaptureSetDetails } from 'data-services/hooks/capture-sets/useCaptureSetDetails'
+import { useEntities } from 'data-services/hooks/entities/useEntities'
 import { ChevronRight, XIcon } from 'lucide-react'
 import { Button, Select } from 'nova-ui-kit'
 import { Link, useParams } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
 import { STRING, translate } from 'utils/language'
+
+// Choices arrive most recently updated first, so this covers the sets a user is
+// realistically picking between. A project with more than this cannot reach the rest of
+// them from here, which is what the search field in #1380 is for.
+const MAX_CHOICES = 200
 
 // TODO: Move to src/components, this is not a design system component
 export const CaptureSetPicker = ({
@@ -17,18 +24,30 @@ export const CaptureSetPicker = ({
   onValueChange: (value?: string) => void
 }) => {
   const { projectId } = useParams()
-  const { captureSets = [], isLoading } = useCaptureSets({
-    projectId: projectId as string,
-  })
-  const captureSet = captureSets.find((c) => c.id === _value)
-  const value = captureSet ? _value : ''
+  const { entities = [], isLoading } = useEntities(
+    API_ROUTES.CAPTURE_SET_CHOICES,
+    {
+      projectId: projectId as string,
+      pagination: { page: 0, perPage: MAX_CHOICES },
+    }
+  )
+  // The choices carry no counts, so the selected set is loaded on its own to report the
+  // number of captures it holds.
+  const { captureSet } = useCaptureSetDetails(_value, projectId)
+
+  // A set that was picked before it dropped off the end of the list is still shown, so an
+  // existing selection never silently disappears from the form.
+  const choices = entities.some((entity) => entity.id === _value)
+    ? entities
+    : [...(captureSet ? [captureSet] : []), ...entities]
+  const value = choices.some((choice) => choice.id === _value) ? _value : ''
 
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between gap-2">
         <Select.Root
           key={value}
-          disabled={isLoading || captureSets.length === 0}
+          disabled={isLoading || choices.length === 0}
           onValueChange={onValueChange}
           value={value}
         >
@@ -36,7 +55,7 @@ export const CaptureSetPicker = ({
             <Select.Value placeholder={translate(STRING.SELECT_PLACEHOLDER)} />
           </Select.Trigger>
           <Select.Content className="max-h-72">
-            {captureSets.map((c) => (
+            {choices.map((c) => (
               <Select.Item key={c.id} value={c.id}>
                 {c.name}
               </Select.Item>

--- a/ui/src/nova-ui-kit/components/select/capture-set-picker.tsx
+++ b/ui/src/nova-ui-kit/components/select/capture-set-picker.tsx
@@ -1,17 +1,13 @@
 import { FormMessage } from 'components/form/layout/layout'
-import { API_ROUTES } from 'data-services/constants'
+import { API_ROUTES, MAX_CAPTURE_SET_CHOICES } from 'data-services/constants'
 import { useCaptureSetDetails } from 'data-services/hooks/capture-sets/useCaptureSetDetails'
 import { useEntities } from 'data-services/hooks/entities/useEntities'
 import { ChevronRight, XIcon } from 'lucide-react'
 import { Button, Select } from 'nova-ui-kit'
+import { useEffect } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
 import { STRING, translate } from 'utils/language'
-
-// Choices arrive most recently updated first, so this covers the sets a user is
-// realistically picking between. A project with more than this cannot reach the rest of
-// them from here, which is what the search field in #1380 is for.
-const MAX_CHOICES = 200
 
 // TODO: Move to src/components, this is not a design system component
 export const CaptureSetPicker = ({
@@ -28,12 +24,15 @@ export const CaptureSetPicker = ({
     API_ROUTES.CAPTURE_SET_CHOICES,
     {
       projectId: projectId as string,
-      pagination: { page: 0, perPage: MAX_CHOICES },
+      pagination: { page: 0, perPage: MAX_CAPTURE_SET_CHOICES },
     }
   )
   // The choices carry no counts, so the selected set is loaded on its own to report the
   // number of captures it holds.
-  const { captureSet } = useCaptureSetDetails(_value, projectId)
+  const { captureSet, isLoading: isLoadingCaptureSet } = useCaptureSetDetails(
+    _value,
+    projectId
+  )
 
   // A set that was picked before it dropped off the end of the list is still shown, so an
   // existing selection never silently disappears from the form.
@@ -41,6 +40,16 @@ export const CaptureSetPicker = ({
     ? entities
     : [...(captureSet ? [captureSet] : []), ...entities]
   const value = choices.some((choice) => choice.id === _value) ? _value : ''
+
+  // Once both fetches have settled, a selection still missing from the choices refers to
+  // a capture set that no longer exists. Report that upwards, so the form cannot be
+  // submitted with an id the picker is not showing.
+  const isMissing = !!_value && !isLoading && !isLoadingCaptureSet && !value
+  useEffect(() => {
+    if (isMissing) {
+      onValueChange(undefined)
+    }
+  }, [isMissing, onValueChange])
 
   return (
     <div className="flex flex-col gap-4">

--- a/ui/src/nova-ui-kit/components/select/capture-set-picker.tsx
+++ b/ui/src/nova-ui-kit/components/select/capture-set-picker.tsx
@@ -34,16 +34,13 @@ export const CaptureSetPicker = ({
     projectId
   )
 
-  // A set that was picked before it dropped off the end of the list is still shown, so an
-  // existing selection never silently disappears from the form.
+  // A set picked before it dropped off the end of the list is added back, so an existing
+  // selection never silently disappears. One still missing once both fetches have settled
+  // no longer exists, and is cleared rather than submitted while the field looks empty.
   const choices = entities.some((entity) => entity.id === _value)
     ? entities
     : [...(captureSet ? [captureSet] : []), ...entities]
   const value = choices.some((choice) => choice.id === _value) ? _value : ''
-
-  // Once both fetches have settled, a selection still missing from the choices refers to
-  // a capture set that no longer exists. Report that upwards, so the form cannot be
-  // submitted with an id the picker is not showing.
   const isMissing = !!_value && !isLoading && !isLoadingCaptureSet && !value
   useEffect(() => {
     if (isMissing) {

--- a/ui/src/nova-ui-kit/components/select/capture-set-picker.tsx
+++ b/ui/src/nova-ui-kit/components/select/capture-set-picker.tsx
@@ -1,5 +1,5 @@
 import { FormMessage } from 'components/form/layout/layout'
-import { API_ROUTES, MAX_CAPTURE_SET_CHOICES } from 'data-services/constants'
+import { API_ROUTES } from 'data-services/constants'
 import { useCaptureSetDetails } from 'data-services/hooks/capture-sets/useCaptureSetDetails'
 import { useEntities } from 'data-services/hooks/entities/useEntities'
 import { ChevronRight, XIcon } from 'lucide-react'
@@ -22,10 +22,7 @@ export const CaptureSetPicker = ({
   const { projectId } = useParams()
   const { entities = [], isLoading } = useEntities(
     API_ROUTES.CAPTURE_SET_CHOICES,
-    {
-      projectId: projectId as string,
-      pagination: { page: 0, perPage: MAX_CAPTURE_SET_CHOICES },
-    }
+    { projectId: projectId as string }
   )
   // The choices carry no counts, so the selected set is loaded on its own to report the
   // number of captures it holds.

--- a/ui/src/nova-ui-kit/components/select/entity-picker.tsx
+++ b/ui/src/nova-ui-kit/components/select/entity-picker.tsx
@@ -6,16 +6,21 @@ import { STRING, translate } from 'utils/language'
 // TODO: Move to src/components, this is not a design system component
 export const EntityPicker = ({
   collection,
+  pageSize,
   value: _value,
   onValueChange,
 }: {
   collection: string
+  // How many options to load. A selection outside the loaded options shows as blank, so
+  // collections with many rows should raise this above the API default.
+  pageSize?: number
   value?: string
   onValueChange: (value?: string) => void
 }) => {
   const { projectId } = useParams()
   const { entities = [], isLoading } = useEntities(collection, {
     projectId: projectId as string,
+    ...(pageSize ? { pagination: { page: 0, perPage: pageSize } } : {}),
   })
   const value = entities.some((e) => e.id === _value) ? _value : ''
 

--- a/ui/src/nova-ui-kit/components/select/entity-picker.tsx
+++ b/ui/src/nova-ui-kit/components/select/entity-picker.tsx
@@ -11,8 +11,7 @@ export const EntityPicker = ({
   onValueChange,
 }: {
   collection: string
-  // How many options to load. A selection outside the loaded options shows as blank, so
-  // collections with many rows should raise this above the API default.
+  // Raise above the API default when a selection could fall outside the first page.
   pageSize?: number
   value?: string
   onValueChange: (value?: string) => void

--- a/ui/src/nova-ui-kit/components/select/entity-picker.tsx
+++ b/ui/src/nova-ui-kit/components/select/entity-picker.tsx
@@ -6,20 +6,16 @@ import { STRING, translate } from 'utils/language'
 // TODO: Move to src/components, this is not a design system component
 export const EntityPicker = ({
   collection,
-  pageSize,
   value: _value,
   onValueChange,
 }: {
   collection: string
-  // Raise above the API default when a selection could fall outside the first page.
-  pageSize?: number
   value?: string
   onValueChange: (value?: string) => void
 }) => {
   const { projectId } = useParams()
   const { entities = [], isLoading } = useEntities(collection, {
     projectId: projectId as string,
-    ...(pageSize ? { pagination: { page: 0, perPage: pageSize } } : {}),
   })
   const value = entities.some((e) => e.id === _value) ? _value : ''
 


### PR DESCRIPTION
## Summary

Picking a capture set when starting a job is meant to be the easy part of the form, and
in a project that has accumulated a lot of capture sets it currently is not. The dropdown
loads one page of results in whatever order the database happens to return them, so a set
a user created minutes ago may not be in the list at all, and there is no way to reach it
from the form. The same dropdown also waits on the number of captures, occurrences and
taxa in every capture set in the project — figures it never displays — which is why it
sits disabled for a long time before it becomes usable.

This changes both. Capture sets now come back most recently updated first, so the sets
someone is actively working with are at the top of every picker and filter. And the
pickers read from a new endpoint that returns just enough to name a capture set, so they
no longer pay for counts they do not show. That endpoint sends a project's capture sets
in a single response rather than in pages, because a dropdown has no way to ask for a
second one. It follows the pattern introduced for the occurrence algorithm filter in
#1368: a small, purpose-built sub-action that serves a filter's choices, separate from
the full list endpoint the table page uses.

Reported against a project whose capture set list had grown past one page.

### List of Changes

| # | Change | How |
| --- | --- | --- |
| 1 | Capture sets are listed most recently updated first, in the job form, the export form, the capture set filter, and the API by default | `ordering = ["-updated_at"]` on `SourceImageCollectionViewSet`. The capture sets table page asks for its own sort order and is unaffected |
| 2 | Capture set dropdowns no longer wait on counts they never display | New `GET /api/v2/captures/collections/choices/` returning id, name and sampling method per set, serialized with the existing `SourceImageCollectionNestedSerializer`. `CaptureSetPicker` and `CaptureSetFilter` read from it |
| 3 | A dropdown receives a project's capture sets in one response and never has to page | `CaptureSetChoicesPagination` sets both the default and the maximum size to 100, so the response size is the same whether or not a caller sends a limit. No pagination arguments are passed from the frontend at all |
| 4 | The job and export form still reports how many captures the selected set holds | `useCaptureSetDetails` fetches the selected set on its own, the same shape the taxon filter uses for its selected taxon |
| 5 | A capture set that is already selected stays visible in the picker, even in a project large enough for it to fall outside the choices | The picker adds the selected set back into its options when the choices do not contain it |
| 6 | A selection pointing at a deleted capture set is cleared instead of being submitted while the field looks empty | Once both the choices request and the single-set request have settled without finding it, the picker reports the value upwards as cleared |
| 7 | Pages of capture sets are stable across requests | The viewset had no default ordering at all, so page boundaries were undefined |
| 8 | Contributor guidance for the frontend records where a shared constant belongs and how long a comment should be | `ui/AGENTS.md`. Docs only, no behaviour change — happy to split it out if you would rather review it separately |

Capture choices load almost instantaneously now:

<img width="1470" height="713" alt="image" src="https://github.com/user-attachments/assets/362fd7d4-f516-47a1-bda8-13d75c0bbf83" />

<img width="1133" height="431" alt="image" src="https://github.com/user-attachments/assets/1c0118ab-3590-44fb-97d6-d408a9b72625" />

## Detailed Description

The capture set list endpoint annotates three counts on every row —
`source_images_count`, `source_images_with_detections_count` and
`source_images_processed_count` — each of which joins through captures to detections and
de-duplicates. Grouping happens before `LIMIT`, so asking for 20 rows still costs the
whole project. Two measurements from a local copy of production data, on a project with
46 capture sets:

| Query | Time |
| --- | --- |
| `list(qs[:20])` with no count annotations | 0.022s |
| `list(qs[:20])` with the three count annotations | 24.8s |

Over HTTP on the same machine and project, the choices endpoint answered in 0.9s against
2.7s for the list endpoint once both were warm, and 6.1s for the list endpoint on the
first request after a restart. Those figures include local development middleware and a
warm query cache, so treat them as indicative of the gap; the ORM timings above are the
direct measurement.

The counts themselves are untouched — the capture sets table still reports all of them,
and `?with_counts=true` still adds occurrence and taxa counts. The annotations simply
moved from the viewset's class-level queryset into `get_queryset()` so the choices action
can opt out of them. Sorting by a count is still available on the list endpoint and is
excluded from the choices action, where the annotations do not exist.

The page size lives on the server rather than with each caller. A dropdown cannot page,
so any size a caller picks is either too small to hold a project's capture sets or an
arbitrary guess, and different callers had been picking differently. `max_limit` is set
alongside `default_limit` so the size is a contract rather than a default: no caller can
raise it, and the response stays bounded for a project of any size. The total count in
the response still reports every capture set, so a caller can tell when it has received
a subset.

## Testing

- `ami.main.tests` and `ami.exports` pass locally, alongside CI.
- `TestCaptureSetChoices` (9 tests) pins the contract the pickers depend on: most
  recently updated first, names without counts, scoped to the requested project, a
  project is required, capture sets in a draft project stay hidden from non-members, one
  capped response whether or not a limit is sent, and the list endpoint keeping both its
  counts and its ability to sort by them.
- Frontend: `tsc --noEmit`, `eslint` and `prettier --check` all clean.
- No model change, so no migration. `makemigrations --check` passes.

## Verified in a browser

Clicked through against a local copy of production data, on a project with 46 capture
sets:

- **Job form** — the picker requests `/captures/collections/choices/?project_id=…` with
  no pagination arguments and lists all 46 sets, most recently updated first. Selecting
  one fetches `/captures/collections/{id}/?project_id=…&with_counts=false` and shows
  "This will select 1,000 captures."
- **Occurrences and jobs filter sidebar** — reads the same endpoint and shows the same
  order.
- **Capture sets table page** — unchanged; it asks for its own sort order and still shows
  every count column.

Not exercised in a browser: the 100 capture set cap, since no project on hand has that
many. It is covered by a test that creates 120 and asserts the response size with and
without a `limit` argument.

## Follow-up

#1380 proposes replacing the dropdown with a searchable field like the taxon filter, which
is the real fix for a project with more capture sets than one response can hold. This
change makes the common case work; it does not make an arbitrarily long list navigable.