### PR TITLE
Explain two undocumented traps in the bucket file listing and the form section hook

### DIFF
--- a/ami/utils/s3.py
+++ b/ami/utils/s3.py
@@ -271,7 +271,10 @@ def list_files(
     """
     "Recursively" list files in a bucket, with optional limit and regex filter.
 
-    Returns an ObjectSummary object.
+    Yields one ``(ObjectSummary, num_files_checked)`` pair per key that passes the
+    filter, then a final ``(None, num_files_checked)`` with the total number of keys
+    scanned. Callers must skip that last pair; its count is the only way to tell an
+    empty prefix from one where the filter rejected every key.
 
     @TODO Consider returning just the key instead of the full object so we
     can make list_files_paginated more consistent with list_files.
@@ -307,7 +310,9 @@ def list_files_paginated(
     """
     List files in a bucket, with pagination to increase performance.
 
-    Returns an ObjectTypeDef dict instead of an ObjectSummary object.
+    Yields ObjectTypeDef dicts instead of the ObjectSummary objects list_files yields;
+    the generator contract is otherwise the same, including the trailing
+    ``(None, num_files_checked)`` pair. See test_connection() for why that pair matters.
 
     @TODO Consider returning just the key instead of the full object so we
     can make list_files_paginated more consistent with list_files.

--- a/ami/utils/s3.py
+++ b/ami/utils/s3.py
@@ -310,9 +310,10 @@ def list_files_paginated(
     """
     List files in a bucket, with pagination to increase performance.
 
-    Yields ObjectTypeDef dicts instead of the ObjectSummary objects list_files yields;
-    the generator contract is otherwise the same, including the trailing
-    ``(None, num_files_checked)`` pair. See test_connection() for why that pair matters.
+    Yields ``(ObjectTypeDef, num_files_checked)`` pairs rather than the
+    ``(ObjectSummary, num_files_checked)`` pairs list_files yields. The contract is
+    otherwise the same, including the trailing ``(None, num_files_checked)`` pair.
+    See test_connection() for why that pair matters.
 
     @TODO Consider returning just the key instead of the full object so we
     can make list_files_paginated more consistent with list_files.

--- a/ui/src/utils/useSyncSectionStatus.ts
+++ b/ui/src/utils/useSyncSectionStatus.ts
@@ -9,6 +9,8 @@ export const useSyncSectionStatus = (
   const { isDirty, isValid } = useFormState({ control })
   const { setFormSectionStatus } = useContext(FormContext)
 
+  // Do not add setFormSectionStatus to the deps. It is memoised on the form state
+  // that it replaces, so depending on its identity makes this effect loop forever.
   useEffect(() => {
     setFormSectionStatus(section, { isDirty, isValid })
   }, [isDirty, isValid])


### PR DESCRIPTION
## Summary

Two places in the codebase quietly expect the next developer to already know something, and this pull request writes that knowledge down. Neither change affects behaviour — the only edits are a docstring and a two-line comment.

The first is in the storage layer that scans a bucket for new capture images. Its docstring describes a return value that does not match what the function actually produces, and it says nothing about a final marker item that the function always emits at the end. Every existing caller quietly works around that marker, so the code runs correctly today, but anyone writing a new caller from the docstring would get a crash on the last item. The second is a form hook used by the multi-section project settings forms, where a line that looks like an oversight is in fact deliberate: correcting it in the obvious way sends the form into an endless re-render loop, and there is no linter configured that would warn about either the omission or the "fix".

Both are the kind of thing that costs someone an afternoon exactly once, then gets forgotten again.

### List of Changes

| # | Change (reader-facing effect) | How |
|---|---|---|
| 1 | Anyone writing new code that lists files in a bucket can now see, from the docstring alone, that the listing ends with a marker item they need to skip — and what the number attached to it is for. | Replaced the incorrect `Returns an ObjectSummary object.` line on `list_files()` in `ami/utils/s3.py` with an accurate description of the `(object, count)` pairs it yields and the trailing `(None, count)` pair. |
| 2 | The paginated variant of the same listing no longer looks like it has a different contract from its sibling; it points at the one place that depends on the trailing pair, so nobody removes it as dead code. | Rewrote the `list_files_paginated()` docstring to state that it shares the generator contract and to reference `test_connection()`, which uses the trailing pair's count to distinguish an empty location from one where the file filter matched nothing. |
| 3 | A developer tidying up the project settings forms will no longer "fix" a dependency list into an infinite render loop. | Added a two-line comment above the `useEffect` in `ui/src/utils/useSyncSectionStatus.ts` recording that `setFormSectionStatus` is deliberately excluded, because it is memoised on the form state that it itself replaces. |

### Notes for reviewers

- Comments, docstrings and prose only; no executable code changed.
- The frontend comment follows the two-line limit in `ui/AGENTS.md`. The file and its siblings carry no comments, so the bar for adding one is high — the justification here is that the trap is invisible: `ui/.eslintrc.json` configures no `react-hooks` plugin, so neither the omission nor a well-meant correction produces a warning.
- Verified locally before pushing: `pre-commit run` on the changed Python file (black, isort, flake8, pyupgrade, django-upgrade) and, in `ui/`, `yarn format --check`, `yarn lint` and `yarn type-check` — all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how file-listing operations report filtered results and completion details.
  - Documented the paginated listing result format.
  - Added guidance around form section status synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->