### PR TITLE
Return only the requested project's detections

### DIFF
--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1183,10 +1183,17 @@ class DetectionViewSet(DefaultViewSet, ProjectMixin):
         else:
             return DetectionSerializer
 
+    def get_queryset(self) -> QuerySet:
+        qs = super().get_queryset()
+        # Resolving the project here also enforces the list-action project_id
+        # requirement before pagination runs its COUNT over the full table.
+        project = self.get_active_project()
+        if project:
+            qs = qs.filter(source_image__project=project)
+        return qs
+
     @extend_schema(parameters=[project_id_doc_param])
     def list(self, request, *args, **kwargs):
-        # Force project_id validation before pagination triggers a full-table COUNT.
-        self.get_active_project()
         return super().list(request, *args, **kwargs)
 
 

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -2221,12 +2221,37 @@ class TestProjectScopingOnListEndpoints(APITestCase):
                         leaked_ids,
                         f"{path} returned rows from other projects: {sorted(leaked_ids)}",
                     )
-                    self.assertLessEqual(returned_ids, expected_ids, path)
+                    # Exact equality, not a subset: a subset check passes when the
+                    # response silently omits rows that belong to the project. The
+                    # fixtures are far smaller than the requested page size, so every
+                    # expected row must appear.
+                    self.assertSetEqual(returned_ids, expected_ids, path)
                     self.assertEqual(
                         data["count"],
                         len(expected_ids),
                         f"{path} count spans more than the requested project",
                     )
+
+    def test_detail_route_rejects_a_project_it_does_not_belong_to(self):
+        """
+        A detail request naming the wrong project returns 404 rather than the object.
+
+        Scoping happens in ``get_queryset()``, which every action reads, so the
+        project constraint reaches detail routes as well as the list. Naming a
+        project the object does not belong to therefore yields 404, matching the
+        occurrences and classifications detail routes. This is pinned here
+        because the behaviour is a consequence of where the filter lives, and a
+        later refactor that scoped only the list action would silently drop it.
+        """
+        detection = Detection.objects.filter(source_image__project=self.project_a).first()
+        assert detection, "fixture produced no detections in the first project"
+
+        same_project = self.client.get(f"/api/v2/detections/{detection.pk}/?project_id={self.project_a.pk}")
+        self.assertEqual(same_project.status_code, status.HTTP_200_OK)
+        self.assertEqual(same_project.json()["id"], detection.pk)
+
+        other_project = self.client.get(f"/api/v2/detections/{detection.pk}/?project_id={self.project_b.pk}")
+        self.assertEqual(other_project.status_code, status.HTTP_404_NOT_FOUND)
 
 
 class TestCapturesProcessedFilter(APITestCase):

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -2159,22 +2159,11 @@ class TestProjectRequiredOnListEndpoints(APITestCase):
 
 
 class TestProjectScopingOnListEndpoints(APITestCase):
-    """
-    Every list endpoint that requires a project_id must also filter its results
-    by that project.
+    """Every list endpoint that requires a project_id must also filter its results by it.
 
-    Requiring the parameter without filtering by it is a silent failure mode:
-    the request is accepted, but the response mixes in other projects' rows and
-    reports a count over the whole table — so the pagination COUNT the
-    requirement exists to prevent still runs. The status-code tests above
-    cannot catch that, because they never look at the response body. This test
-    pins the other half of the contract: with two projects that both have data
-    in every hot table, a scoped list request returns only the requested
-    project's rows and a count that matches.
-
-    The expected rows are resolved generically through each model's
-    ``get_project_accessor()``, so any future viewset added to the endpoint
-    list below is checked the same way.
+    Requiring the parameter without applying it accepts the request but mixes in other
+    projects' rows and counts the whole table, which the status-code tests above cannot
+    see. Expected rows resolve through each model's ``get_project_accessor()``. See #1390.
     """
 
     def setUp(self) -> None:
@@ -2233,15 +2222,10 @@ class TestProjectScopingOnListEndpoints(APITestCase):
                     )
 
     def test_detail_route_rejects_a_project_it_does_not_belong_to(self):
-        """
-        A detail request naming the wrong project returns 404 rather than the object.
+        """A detail request naming the wrong project returns 404 rather than the object.
 
-        Scoping happens in ``get_queryset()``, which every action reads, so the
-        project constraint reaches detail routes as well as the list. Naming a
-        project the object does not belong to therefore yields 404, matching the
-        occurrences and classifications detail routes. This is pinned here
-        because the behaviour is a consequence of where the filter lives, and a
-        later refactor that scoped only the list action would silently drop it.
+        Scoping lives in ``get_queryset()``, which every action reads, so it reaches detail
+        routes too, matching occurrences and classifications. See #1390.
         """
         detection = Detection.objects.filter(source_image__project=self.project_a).first()
         assert detection, "fixture produced no detections in the first project"

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -2158,6 +2158,77 @@ class TestProjectRequiredOnListEndpoints(APITestCase):
                 self.assertEqual(response.status_code, status.HTTP_200_OK, path)
 
 
+class TestProjectScopingOnListEndpoints(APITestCase):
+    """
+    Every list endpoint that requires a project_id must also filter its results
+    by that project.
+
+    Requiring the parameter without filtering by it is a silent failure mode:
+    the request is accepted, but the response mixes in other projects' rows and
+    reports a count over the whole table — so the pagination COUNT the
+    requirement exists to prevent still runs. The status-code tests above
+    cannot catch that, because they never look at the response body. This test
+    pins the other half of the contract: with two projects that both have data
+    in every hot table, a scoped list request returns only the requested
+    project's rows and a count that matches.
+
+    The expected rows are resolved generically through each model's
+    ``get_project_accessor()``, so any future viewset added to the endpoint
+    list below is checked the same way.
+    """
+
+    def setUp(self) -> None:
+        self.project_a, deployment_a = setup_test_project(reuse=False)
+        self.project_b, deployment_b = setup_test_project(reuse=False)
+        for project, deployment in [
+            (self.project_a, deployment_a),
+            (self.project_b, deployment_b),
+        ]:
+            create_captures(deployment=deployment)
+            create_taxa(project=project)
+            create_occurrences(deployment=deployment, num=5)
+        self.user = User.objects.create_user(email="scopingtestuser@insectai.org", is_staff=True)  # type: ignore
+        self.client.force_authenticate(user=self.user)
+        return super().setUp()
+
+    def test_list_results_are_scoped_to_requested_project(self):
+        endpoints: list[tuple[str, type[models.Model]]] = [
+            ("/api/v2/captures/", SourceImage),
+            ("/api/v2/detections/", Detection),
+            ("/api/v2/occurrences/", Occurrence),
+            ("/api/v2/classifications/", Classification),
+        ]
+
+        for path, model in endpoints:
+            accessor = model.get_project_accessor()
+            assert accessor, f"{model.__name__} has no project accessor"
+            for project in [self.project_a, self.project_b]:
+                with self.subTest(path=path, project=project.pk):
+                    expected_ids = set(model.objects.filter(**{accessor: project}).values_list("id", flat=True))
+                    other_ids = set(model.objects.exclude(**{accessor: project}).values_list("id", flat=True))
+                    # Both projects must have rows, otherwise the scoping
+                    # assertions below would pass vacuously.
+                    self.assertTrue(expected_ids, f"No {model.__name__} rows in the requested project")
+                    self.assertTrue(other_ids, f"No {model.__name__} rows outside the requested project")
+
+                    response = self.client.get(f"{path}?project_id={project.pk}&limit=200")
+                    self.assertEqual(response.status_code, status.HTTP_200_OK, path)
+                    data = response.json()
+
+                    returned_ids = {result["id"] for result in data["results"]}
+                    leaked_ids = returned_ids & other_ids
+                    self.assertFalse(
+                        leaked_ids,
+                        f"{path} returned rows from other projects: {sorted(leaked_ids)}",
+                    )
+                    self.assertLessEqual(returned_ids, expected_ids, path)
+                    self.assertEqual(
+                        data["count"],
+                        len(expected_ids),
+                        f"{path} count spans more than the requested project",
+                    )
+
+
 class TestCapturesProcessedFilter(APITestCase):
     """
     The captures list distinguishes two related filters:


### PR DESCRIPTION
## Summary

The detections list endpoint requires a `project_id` and then ignores it. A request for one project's detections comes back with rows belonging to other projects and a `count` covering the whole table, so callers see data that isn't theirs and a total that means nothing to them. It is also slow, because the pagination COUNT and the visibility join run across every row rather than the requested project's.

This is a correctness bug rather than an access-control one: the visibility filter still hides draft projects, so nothing private is exposed. What leaks across is data from other non-draft projects.

The fix scopes the queryset to the requested project, which is what the three sibling endpoints already do. It also adds a test that pins the invariant for all four project-required list endpoints, so the next one added is checked automatically.

### Why the existing requirement did not prevent this

"Require project_id on list endpoints for the four hot tables" (#1250) added the parameter requirement to four viewsets, with the stated aim of stopping a full-table COUNT during pagination. Three of those viewsets resolve the project inside `get_queryset()` and filter by it. The detections viewset called the same resolver from `list()` and discarded the result, so the parameter was validated but never applied.

The effect is that the requirement only deterred callers who omitted the parameter. A caller who supplied it still triggered the full-table COUNT the requirement exists to prevent. The behaviour looked symmetric across the four viewsets in the diff; the asymmetry was in what each one did with the resolved project.

### List of Changes

| # | Change (effect) | How |
|---|---|---|
| 1 | A detections list request now returns only the requested project's detections, with a matching count. | `DetectionViewSet.get_queryset()` filters on `source_image__project`, mirroring `ClassificationViewSet` and `OccurrenceViewSet`. |
| 2 | The pagination COUNT is 10 to 40 times faster on a local copy of the production database (measured; see Verification). | Scoping happens in `get_queryset()`, which runs before pagination issues its COUNT, so the visibility join and `DISTINCT` run over one project's rows instead of the whole table. The planner still scans the detection table to find that project's rows, so the COUNT stays bounded by total table size; see Notes. |
| 3 | A detections list request without `project_id` still returns 400. | `get_queryset()` calls the same resolver `list()` used to; the redundant call in `list()` is removed, and the `@extend_schema` parameter documentation is unchanged. |
| 4 | Every project-required list endpoint is now checked for this class of bug, including ones added later. | New `TestProjectScopingOnListEndpoints` asserts returned ids and `count` stay within the requested project, resolving each model's path to `Project` through `get_project_accessor()`. |

## Notes

Detail routes now return 404 when `project_id` names a different project than the object belongs to. That matches how the occurrences and classifications detail routes already behave, so it is a consistency change rather than a regression.

**The COUNT is faster, not index-served.** `Detection` has no `project` column, so the filter goes through `source_image__project`. On every project size surveyed the planner chose a `Parallel Seq Scan on main_detection` followed by index probes into `main_sourceimage`, rather than starting from the project's source images. The cost therefore does not fall with project size and will grow with the platform. Putting the COUNT on an index needs either a denormalised `project` on `Detection` or the estimated-count paginator discussed in #1328; both are out of scope here.

The new test guards against passing vacuously: it asserts that the requested project has rows *and* that rows exist outside it before checking that the response contains only the former. Without both guards a scoping test can pass on an empty fixture.

## Verification

The test was run against this branch with the fix reverted, to confirm it fails in the direction that matters. Without the scoping change:

```
FAIL: test_list_results_are_scoped_to_requested_project (path='/api/v2/detections/', project=4)
  AssertionError: /api/v2/detections/ returned rows from other projects: [1..39, 55..59]
FAIL: test_detail_route_rejects_a_project_it_does_not_belong_to
  AssertionError: 200 != 404
FAILED (failures=3)
```

The captures, occurrences and classifications cases pass in that same run, so the test isolates detections as the only endpoint missing the filter rather than failing indiscriminately. With the fix restored, both tests pass.

**Measured COUNT cost**, `EXPLAIN (ANALYZE)` of the pagination COUNT (the viewset queryset with `visible_for_user` for a non-superuser member, then `.count()`) on a local copy of the production database, query cache disabled:

| project | source images | detections in project | COUNT before (unscoped) | COUNT after (scoped) |
|---|---|---|---|---|
| largest | 1.96M | 179k | 22.1 s | 1.8 s |
| second | 1.30M | 23k | 22 s (same whole-table query) | 0.6 s |
| third | 455k | 2.1k | 22 s (same whole-table query) | 0.5 s |

The unscoped query is the same for every project, so it was measured once. The `count` returned by the API equals a plain `Detection.objects.filter(source_image__project=...)` count on each project, so the visibility join is de-duplicated correctly.
