### PR TITLE
Stop API list pages timing out when opened in a browser

### DIFF
--- a/ami/base/filters.py
+++ b/ami/base/filters.py
@@ -1,6 +1,22 @@
 from django.db.models import F, OrderBy
-from django.forms import FloatField
+from django.forms import FloatField, IntegerField
+from django_filters.rest_framework import NumberFilter
 from rest_framework.filters import BaseFilterBackend, OrderingFilter
+
+
+class RelatedIdFilter(NumberFilter):
+    """Filter a foreign key by integer id without enumerating the related table.
+
+    django-filter's auto-generated ``ModelChoiceFilter`` renders the browsable API's
+    filter form as a ``<select>`` with one option per row of the related table, which
+    times out on production-sized tables. A plain number input accepts the same
+    ``?<field>=<id>`` query parameter. The form field is an ``IntegerField`` rather than
+    ``NumberFilter``'s ``DecimalField`` so a fractional value is rejected with 400 instead
+    of being truncated to a different, valid id. See #1391 and
+    https://www.django-rest-framework.org/topics/browsable-api/#handling-choicefield-with-large-numbers-of-items
+    """
+
+    field_class = IntegerField
 
 
 class NullsLastOrderingFilter(OrderingFilter):

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -1661,3 +1661,70 @@ class TestDataStorageSyncJobIncludesRegroupStage(TestCase):
         ):
             with self.assertRaises(RuntimeError):
                 job.run()
+
+
+class TestJobSourceImageSingleFilter(APITestCase):
+    """Pin the ``?source_image_single=<id>`` query-parameter contract.
+
+    ``JobFilterSet`` declares ``source_image_single`` as a ``NumberFilter`` so
+    the browsable API renders a number input instead of a ``<select>``
+    enumerating the source image table (tens of millions of rows in
+    production, which times out the page). The parameter must keep filtering
+    jobs by the exact source image id.
+
+    One deliberate difference from the auto-generated ``ModelChoiceFilter``:
+    an id with no matching row returns an empty page instead of a validation
+    error. Non-numeric values are still rejected.
+    """
+
+    def setUp(self):
+        self.project = Project.objects.create(name="Job Filter Test Project")
+        self.image_a = SourceImage.objects.create(path="a.jpg", project=self.project)
+        self.image_b = SourceImage.objects.create(path="b.jpg", project=self.project)
+        self.job_a = Job.objects.create(project=self.project, name="Job A", source_image_single=self.image_a)
+        self.job_b = Job.objects.create(project=self.project, name="Job B", source_image_single=self.image_b)
+        self.user = User.objects.create_user(  # type: ignore
+            email="jobfilters@insectai.org",
+            is_staff=True,
+            is_superuser=True,
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def test_filters_jobs_by_source_image_id(self):
+        url = reverse_with_params(
+            "api:job-list",
+            params={"project_id": self.project.pk, "source_image_single": self.image_a.pk},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual([row["id"] for row in data["results"]], [self.job_a.pk])
+
+    def test_unknown_id_returns_empty_page(self):
+        url = reverse_with_params(
+            "api:job-list",
+            params={"project_id": self.project.pk, "source_image_single": 99999999},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["results"], [])
+
+    def test_non_numeric_id_is_rejected(self):
+        url = reverse_with_params(
+            "api:job-list",
+            params={"project_id": self.project.pk, "source_image_single": "abc"},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_browsable_page_renders_number_input(self):
+        """The HTML filter form must not enumerate the source image table."""
+        url = reverse_with_params("api:job-list", params={"project_id": self.project.pk})
+        # An unauthenticated read gets the page without create forms, so the
+        # only form fields on the page belong to the filter form.
+        self.client.force_authenticate(user=None)
+        response = self.client.get(url, headers={"accept": "text/html"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        html = response.content.decode()
+        self.assertNotIn('<select name="source_image_single"', html)
+        self.assertIn('<input type="number" name="source_image_single"', html)

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -1722,6 +1722,17 @@ class TestJobSourceImageSingleFilter(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_out_of_range_id_returns_empty_page(self):
+        """An id wider than a bigint is an unknown id, not a server error: Postgres compares
+        it as numeric and matches nothing."""
+        url = reverse_with_params(
+            "api:job-list",
+            params={"project_id": self.project.pk, "source_image_single": "9" * 20},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["results"], [])
+
     def test_browsable_page_renders_number_input(self):
         """The HTML filter form must not enumerate the source image table."""
         url = reverse_with_params("api:job-list", params={"project_id": self.project.pk})

--- a/ami/jobs/tests/test_jobs.py
+++ b/ami/jobs/tests/test_jobs.py
@@ -1666,15 +1666,11 @@ class TestDataStorageSyncJobIncludesRegroupStage(TestCase):
 class TestJobSourceImageSingleFilter(APITestCase):
     """Pin the ``?source_image_single=<id>`` query-parameter contract.
 
-    ``JobFilterSet`` declares ``source_image_single`` as a ``NumberFilter`` so
-    the browsable API renders a number input instead of a ``<select>``
-    enumerating the source image table (tens of millions of rows in
-    production, which times out the page). The parameter must keep filtering
-    jobs by the exact source image id.
-
-    One deliberate difference from the auto-generated ``ModelChoiceFilter``:
-    an id with no matching row returns an empty page instead of a validation
-    error. Non-numeric values are still rejected.
+    ``JobFilterSet`` declares it as a ``RelatedIdFilter`` (see ``ami/base/filters.py``),
+    and it must keep filtering jobs by the exact source image id. One deliberate
+    difference from the auto-generated ``ModelChoiceFilter``: an id with no matching row
+    returns an empty page instead of a validation error. Non-integer values are still
+    rejected.
     """
 
     def setUp(self):
@@ -1713,6 +1709,15 @@ class TestJobSourceImageSingleFilter(APITestCase):
         url = reverse_with_params(
             "api:job-list",
             params={"project_id": self.project.pk, "source_image_single": "abc"},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_fractional_id_is_rejected(self):
+        """``1.5`` must 400 rather than be truncated to id 1 and match the wrong image."""
+        url = reverse_with_params(
+            "api:job-list",
+            params={"project_id": self.project.pk, "source_image_single": "1.5"},
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/ami/jobs/views.py
+++ b/ami/jobs/views.py
@@ -16,6 +16,7 @@ from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.filters import BaseFilterBackend
 from rest_framework.response import Response
 
+from ami.base.filters import RelatedIdFilter
 from ami.base.pagination import LimitOffsetPaginationWithPermissions
 from ami.base.permissions import ObjectPermission
 from ami.base.serializers import SingleParamSerializer
@@ -142,11 +143,8 @@ class JobFilterSet(filters.FilterSet):
 
     pipeline__slug = filters.CharFilter(field_name="pipeline__slug", lookup_expr="exact")
     pipeline__slug__in = filters.BaseInFilter(field_name="pipeline__slug", lookup_expr="in")
-    # A plain number input for the source image id. The auto-generated
-    # ModelChoiceFilter would render the browsable API's filter form as a
-    # <select> enumerating the source image table (tens of millions of rows),
-    # which times out the request.
-    source_image_single = filters.NumberFilter()
+    # Declared so the browsable API form does not enumerate the source image table.
+    source_image_single = RelatedIdFilter()
 
     class Meta:
         model = Job

--- a/ami/jobs/views.py
+++ b/ami/jobs/views.py
@@ -142,6 +142,11 @@ class JobFilterSet(filters.FilterSet):
 
     pipeline__slug = filters.CharFilter(field_name="pipeline__slug", lookup_expr="exact")
     pipeline__slug__in = filters.BaseInFilter(field_name="pipeline__slug", lookup_expr="in")
+    # A plain number input for the source image id. The auto-generated
+    # ModelChoiceFilter would render the browsable API's filter form as a
+    # <select> enumerating the source image table (tens of millions of rows),
+    # which times out the request.
+    source_image_single = filters.NumberFilter()
 
     class Meta:
         model = Job

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -12,7 +12,7 @@ from django.db.models.query import QuerySet
 from django.forms import BooleanField, CharField, IntegerField
 from django.shortcuts import get_object_or_404, redirect
 from django.utils import timezone
-from django_filters.rest_framework import DjangoFilterBackend
+from django_filters.rest_framework import DjangoFilterBackend, FilterSet, NumberFilter
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import exceptions as api_exceptions
@@ -1163,6 +1163,24 @@ class SourceImageUploadViewSet(DefaultViewSet, ProjectMixin):
         obj.save()
 
 
+class DetectionFilterSet(FilterSet):
+    """Declared filterset so the browsable API form stays lightweight.
+
+    ``source_image`` is a ``NumberFilter`` because the auto-generated
+    ``ModelChoiceFilter`` for a foreign key renders the browsable API's filter
+    form as a ``<select>`` enumerating the entire related table. The source
+    image table holds tens of millions of rows, so building that form times
+    out the request. A plain number input accepts the same
+    ``?source_image=<id>`` query parameter without loading the related table.
+    """
+
+    source_image = NumberFilter()
+
+    class Meta:
+        model = Detection
+        fields = ["source_image", "detection_algorithm", "source_image__project"]
+
+
 class DetectionViewSet(DefaultViewSet, ProjectMixin):
     """
     API endpoint that allows detections to be viewed or edited.
@@ -1171,7 +1189,7 @@ class DetectionViewSet(DefaultViewSet, ProjectMixin):
     require_project_for_list = True  # Unfiltered list scans are too expensive on this table
     queryset = Detection.objects.valid().select_related("source_image", "detection_algorithm")
     serializer_class = DetectionSerializer
-    filterset_fields = ["source_image", "detection_algorithm", "source_image__project"]
+    filterset_class = DetectionFilterSet
     ordering_fields = ["created_at", "updated_at", "detection_score", "timestamp"]
 
     def get_serializer_class(self):
@@ -1435,6 +1453,24 @@ OCCURRENCE_FILTERSET_FIELDS = (
 )
 
 
+class OccurrenceFilterSet(FilterSet):
+    """Declared filterset shared by the occurrence list and stats viewsets.
+
+    ``detections__source_image`` is a ``NumberFilter`` because the
+    auto-generated ``ModelChoiceFilter`` renders the browsable API's filter
+    form as a ``<select>`` enumerating the source image table (tens of
+    millions of rows), which times out the request. A plain number input
+    accepts the same ``?detections__source_image=<id>`` query parameter
+    without loading the related table.
+    """
+
+    detections__source_image = NumberFilter()
+
+    class Meta:
+        model = Occurrence
+        fields = list(OCCURRENCE_FILTERSET_FIELDS)
+
+
 class OccurrenceViewSet(DefaultViewSet, ProjectMixin):
     """
     API endpoint that allows occurrences to be viewed or edited.
@@ -1445,7 +1481,7 @@ class OccurrenceViewSet(DefaultViewSet, ProjectMixin):
 
     serializer_class = OccurrenceSerializer
     filter_backends = DefaultViewSetMixin.filter_backends + list(OCCURRENCE_FILTER_BACKENDS)
-    filterset_fields = list(OCCURRENCE_FILTERSET_FIELDS)
+    filterset_class = OccurrenceFilterSet
     ordering_fields = [
         "created_at",
         "updated_at",
@@ -1578,7 +1614,7 @@ class OccurrenceStatsViewSet(viewsets.GenericViewSet, ProjectMixin):
     # `top_identifiers` doesn't call it, so its behavior is unchanged.
     queryset = Occurrence.objects.none()
     filter_backends = [DjangoFilterBackend, *OCCURRENCE_FILTER_BACKENDS]
-    filterset_fields = list(OCCURRENCE_FILTERSET_FIELDS)
+    filterset_class = OccurrenceFilterSet
 
     @extend_schema(
         parameters=[project_id_doc_param, limit_doc_param],
@@ -2154,6 +2190,29 @@ class TagViewSet(DefaultViewSet, ProjectMixin):
         return qs
 
 
+class ClassificationFilterSet(FilterSet):
+    """Declared filterset so the browsable API form stays lightweight.
+
+    ``taxon`` is a ``NumberFilter`` because the auto-generated
+    ``ModelChoiceFilter`` renders the browsable API's filter form as a
+    ``<select>`` enumerating the entire taxon table, which makes the page take
+    many seconds to load. A plain number input accepts the same
+    ``?taxon=<id>`` query parameter without loading the related table. See
+    https://www.django-rest-framework.org/topics/browsable-api/#handling-choicefield-with-large-numbers-of-items
+    """
+
+    taxon = NumberFilter()
+
+    class Meta:
+        model = Classification
+        fields = [
+            "taxon",
+            "algorithm",
+            "detection__source_image__project",
+            "detection__source_image__collections",
+        ]
+
+
 class ClassificationViewSet(DefaultViewSet, ProjectMixin):
     """
     API endpoint for viewing and adding classification results from a model.
@@ -2162,14 +2221,7 @@ class ClassificationViewSet(DefaultViewSet, ProjectMixin):
     require_project_for_list = True  # Unfiltered list scans are too expensive on this table
     queryset = Classification.objects.all().select_related("taxon", "algorithm", "applied_to__algorithm")
     serializer_class = ClassificationSerializer
-    filterset_fields = [
-        # Docs about slow loading API browser because of large choice fields
-        # https://www.django-rest-framework.org/topics/browsable-api/#handling-choicefield-with-large-numbers-of-items
-        "taxon",
-        "algorithm",
-        "detection__source_image__project",
-        "detection__source_image__collections",
-    ]
+    filterset_class = ClassificationFilterSet
     ordering_fields = [
         "created_at",
         "updated_at",

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1779,6 +1779,31 @@ class TagInverseFilter(filters.BaseFilterBackend):
         return queryset.distinct()
 
 
+class TaxonFilterSet(FilterSet):
+    """Declared filterset so the browsable API form stays lightweight.
+
+    ``parent`` is a ``NumberFilter`` because the auto-generated
+    ``ModelChoiceFilter`` renders the browsable API's filter form as a
+    ``<select>`` enumerating the taxon table itself, which makes the page take
+    many seconds to load. A plain number input accepts the same
+    ``?parent=<id>`` query parameter without loading the table.
+    """
+
+    parent = NumberFilter()
+
+    class Meta:
+        model = Taxon
+        fields = [
+            "name",
+            "rank",
+            "parent",
+            "occurrences__event",
+            "occurrences__deployment",
+            "occurrences__project",
+            "projects",
+        ]
+
+
 class TaxonViewSet(DefaultViewSet, ProjectMixin):
     """
     API endpoint that allows taxa to be viewed or edited.
@@ -1798,15 +1823,7 @@ class TaxonViewSet(DefaultViewSet, ProjectMixin):
         TaxonTagFilter,
         TagInverseFilter,
     ]
-    filterset_fields = [
-        "name",
-        "rank",
-        "parent",
-        "occurrences__event",
-        "occurrences__deployment",
-        "occurrences__project",
-        "projects",
-    ]
+    filterset_class = TaxonFilterSet
     ordering_fields = [
         "created_at",
         "updated_at",
@@ -2357,6 +2374,29 @@ class PageViewSet(DefaultViewSet):
             return PageSerializer
 
 
+class IdentificationFilterSet(FilterSet):
+    """Declared filterset so the browsable API form stays lightweight.
+
+    ``occurrence`` and ``taxon`` are ``NumberFilter``s because the
+    auto-generated ``ModelChoiceFilter`` renders the browsable API's filter
+    form as a ``<select>`` enumerating the related table, and both the
+    occurrence and taxon tables are far too large for that. Plain number
+    inputs accept the same ``?occurrence=<id>`` and ``?taxon=<id>`` query
+    parameters without loading the related tables.
+    """
+
+    occurrence = NumberFilter()
+    taxon = NumberFilter()
+
+    class Meta:
+        model = Identification
+        fields = [
+            "occurrence",
+            "user",
+            "taxon",
+        ]
+
+
 class IdentificationViewSet(DefaultViewSet):
     """
     API endpoint that allows identifications to be viewed or edited.
@@ -2364,11 +2404,7 @@ class IdentificationViewSet(DefaultViewSet):
 
     queryset = Identification.objects.all()
     serializer_class = IdentificationSerializer
-    filterset_fields = [
-        "occurrence",
-        "user",
-        "taxon",
-    ]
+    filterset_class = IdentificationFilterSet
     ordering_fields = [
         "created_at",
         "updated_at",

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -12,7 +12,7 @@ from django.db.models.query import QuerySet
 from django.forms import BooleanField, CharField, IntegerField
 from django.shortcuts import get_object_or_404, redirect
 from django.utils import timezone
-from django_filters.rest_framework import DjangoFilterBackend, FilterSet, NumberFilter
+from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import exceptions as api_exceptions
@@ -25,7 +25,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from ami.base.filters import NullsLastOrderingFilter, ThresholdFilter
+from ami.base.filters import NullsLastOrderingFilter, RelatedIdFilter, ThresholdFilter
 from ami.base.metadata import ResponseSchemaMetadata
 from ami.base.models import BaseQuerySet
 from ami.base.pagination import LimitOffsetPaginationWithPermissions
@@ -1164,17 +1164,9 @@ class SourceImageUploadViewSet(DefaultViewSet, ProjectMixin):
 
 
 class DetectionFilterSet(FilterSet):
-    """Declared filterset so the browsable API form stays lightweight.
+    """Declared so the browsable API form does not enumerate the source image table."""
 
-    ``source_image`` is a ``NumberFilter`` because the auto-generated
-    ``ModelChoiceFilter`` for a foreign key renders the browsable API's filter
-    form as a ``<select>`` enumerating the entire related table. The source
-    image table holds tens of millions of rows, so building that form times
-    out the request. A plain number input accepts the same
-    ``?source_image=<id>`` query parameter without loading the related table.
-    """
-
-    source_image = NumberFilter()
+    source_image = RelatedIdFilter()
 
     class Meta:
         model = Detection
@@ -1454,17 +1446,12 @@ OCCURRENCE_FILTERSET_FIELDS = (
 
 
 class OccurrenceFilterSet(FilterSet):
-    """Declared filterset shared by the occurrence list and stats viewsets.
+    """Shared by the occurrence list and stats viewsets.
 
-    ``detections__source_image`` is a ``NumberFilter`` because the
-    auto-generated ``ModelChoiceFilter`` renders the browsable API's filter
-    form as a ``<select>`` enumerating the source image table (tens of
-    millions of rows), which times out the request. A plain number input
-    accepts the same ``?detections__source_image=<id>`` query parameter
-    without loading the related table.
+    Declared so the browsable API form does not enumerate the source image table.
     """
 
-    detections__source_image = NumberFilter()
+    detections__source_image = RelatedIdFilter()
 
     class Meta:
         model = Occurrence
@@ -1780,16 +1767,9 @@ class TagInverseFilter(filters.BaseFilterBackend):
 
 
 class TaxonFilterSet(FilterSet):
-    """Declared filterset so the browsable API form stays lightweight.
+    """Declared so the browsable API form does not enumerate the taxon table."""
 
-    ``parent`` is a ``NumberFilter`` because the auto-generated
-    ``ModelChoiceFilter`` renders the browsable API's filter form as a
-    ``<select>`` enumerating the taxon table itself, which makes the page take
-    many seconds to load. A plain number input accepts the same
-    ``?parent=<id>`` query parameter without loading the table.
-    """
-
-    parent = NumberFilter()
+    parent = RelatedIdFilter()
 
     class Meta:
         model = Taxon
@@ -2208,17 +2188,9 @@ class TagViewSet(DefaultViewSet, ProjectMixin):
 
 
 class ClassificationFilterSet(FilterSet):
-    """Declared filterset so the browsable API form stays lightweight.
+    """Declared so the browsable API form does not enumerate the taxon table."""
 
-    ``taxon`` is a ``NumberFilter`` because the auto-generated
-    ``ModelChoiceFilter`` renders the browsable API's filter form as a
-    ``<select>`` enumerating the entire taxon table, which makes the page take
-    many seconds to load. A plain number input accepts the same
-    ``?taxon=<id>`` query parameter without loading the related table. See
-    https://www.django-rest-framework.org/topics/browsable-api/#handling-choicefield-with-large-numbers-of-items
-    """
-
-    taxon = NumberFilter()
+    taxon = RelatedIdFilter()
 
     class Meta:
         model = Classification
@@ -2375,18 +2347,10 @@ class PageViewSet(DefaultViewSet):
 
 
 class IdentificationFilterSet(FilterSet):
-    """Declared filterset so the browsable API form stays lightweight.
+    """Declared so the browsable API form does not enumerate the occurrence or taxon tables."""
 
-    ``occurrence`` and ``taxon`` are ``NumberFilter``s because the
-    auto-generated ``ModelChoiceFilter`` renders the browsable API's filter
-    form as a ``<select>`` enumerating the related table, and both the
-    occurrence and taxon tables are far too large for that. Plain number
-    inputs accept the same ``?occurrence=<id>`` and ``?taxon=<id>`` query
-    parameters without loading the related tables.
-    """
-
-    occurrence = NumberFilter()
-    taxon = NumberFilter()
+    occurrence = RelatedIdFilter()
+    taxon = RelatedIdFilter()
 
     class Meta:
         model = Identification

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -7655,21 +7655,22 @@ class TestBulkIdentificationQueryCount(BulkIdentificationTestCase):
 
 
 class TestHugeTableFilterParams(APITestCase):
-    """Pin the query-parameter contract for filters on huge related tables.
+    """Pin the query-parameter contract for ``RelatedIdFilter`` params on huge related tables.
 
-    ``source_image`` (detections), ``detections__source_image`` (occurrences)
-    and ``taxon`` (classifications) are declared as ``NumberFilter``s so the
-    browsable API renders a number input instead of a ``<select>`` enumerating
-    the related table (the source image table holds tens of millions of rows
-    in production, so enumerating it times out the page). These tests pin the
-    invariant that the query parameters still filter by id exactly as the
-    auto-generated ``ModelChoiceFilter`` did.
-
-    One deliberate difference from the auto-generated filter: an id with no
-    matching row returns an empty page instead of a validation error, because
-    a plain number filter does not check that the id exists. Non-numeric
-    values are still rejected.
+    Each param in ``ENDPOINT_PARAMS`` must filter by id exactly as the auto-generated
+    ``ModelChoiceFilter`` did. One deliberate difference: an id with no matching row
+    returns an empty page instead of a validation error, because a plain number filter
+    does not check that the id exists. Non-integer values are still rejected.
     """
+
+    ENDPOINT_PARAMS = [
+        ("/api/v2/detections/", "source_image"),
+        ("/api/v2/occurrences/", "detections__source_image"),
+        ("/api/v2/classifications/", "taxon"),
+        ("/api/v2/taxa/", "parent"),
+        ("/api/v2/identifications/", "occurrence"),
+        ("/api/v2/identifications/", "taxon"),
+    ]
 
     def setUp(self):
         self.project, self.deployment = setup_test_project(reuse=False)
@@ -7751,27 +7752,22 @@ class TestHugeTableFilterParams(APITestCase):
 
     def test_unknown_id_returns_empty_page(self):
         """A well-formed id that matches nothing filters everything out rather than erroring."""
-        for path, param in [
-            ("/api/v2/detections/", "source_image"),
-            ("/api/v2/occurrences/", "detections__source_image"),
-            ("/api/v2/classifications/", "taxon"),
-            ("/api/v2/taxa/", "parent"),
-            ("/api/v2/identifications/", "occurrence"),
-        ]:
-            with self.subTest(path=path):
+        for path, param in self.ENDPOINT_PARAMS:
+            with self.subTest(path=path, param=param):
                 ids = self._get_ids(path, {"project_id": self.project.pk, "limit": 200, param: 99999999})
                 self.assertEqual(ids, set())
 
     def test_non_numeric_id_is_rejected(self):
-        for path, param in [
-            ("/api/v2/detections/", "source_image"),
-            ("/api/v2/occurrences/", "detections__source_image"),
-            ("/api/v2/classifications/", "taxon"),
-            ("/api/v2/taxa/", "parent"),
-            ("/api/v2/identifications/", "occurrence"),
-        ]:
-            with self.subTest(path=path):
+        for path, param in self.ENDPOINT_PARAMS:
+            with self.subTest(path=path, param=param):
                 response = self.client.get(f"{path}?project_id={self.project.pk}&{param}=abc")
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_fractional_id_is_rejected(self):
+        """``?taxon=1.5`` must 400 rather than be truncated to id 1 and filter by the wrong row."""
+        for path, param in self.ENDPOINT_PARAMS:
+            with self.subTest(path=path, param=param):
+                response = self.client.get(f"{path}?project_id={self.project.pk}&{param}=1.5")
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -7652,3 +7652,134 @@ class TestBulkIdentificationQueryCount(BulkIdentificationTestCase):
             f"({queries_small} queries for {small} items, {queries_large} for {large}). "
             f"A jump here usually means something started querying per item.",
         )
+
+
+class TestHugeTableFilterParams(APITestCase):
+    """Pin the query-parameter contract for filters on huge related tables.
+
+    ``source_image`` (detections), ``detections__source_image`` (occurrences)
+    and ``taxon`` (classifications) are declared as ``NumberFilter``s so the
+    browsable API renders a number input instead of a ``<select>`` enumerating
+    the related table (the source image table holds tens of millions of rows
+    in production, so enumerating it times out the page). These tests pin the
+    invariant that the query parameters still filter by id exactly as the
+    auto-generated ``ModelChoiceFilter`` did.
+
+    One deliberate difference from the auto-generated filter: an id with no
+    matching row returns an empty page instead of a validation error, because
+    a plain number filter does not check that the id exists. Non-numeric
+    values are still rejected.
+    """
+
+    def setUp(self):
+        self.project, self.deployment = setup_test_project(reuse=False)
+        create_taxa(self.project)
+        create_captures(deployment=self.deployment, num_nights=1, images_per_night=10)
+        taxa = list(Taxon.objects.filter(projects=self.project)[:2])
+        assert len(taxa) == 2
+        self.taxon_a, self.taxon_b = taxa
+        create_occurrences(deployment=self.deployment, num=4, taxon=self.taxon_a)
+        create_occurrences(deployment=self.deployment, num=4, taxon=self.taxon_b)
+
+        # Let every occurrence through the project's default score filters so
+        # the ORM mirrors below match the list endpoints row for row.
+        self.project.default_filters_score_threshold = 0.0
+        self.project.save()
+
+        self.user = User.objects.create_user(  # type: ignore
+            email="hugetablefilters@insectai.org",
+            is_staff=True,
+            is_superuser=True,
+        )
+        self.client.force_authenticate(user=self.user)
+
+        self.capture = SourceImage.objects.filter(deployment=self.deployment, detections__isnull=False).first()
+        assert self.capture is not None
+
+    def _get_ids(self, path: str, params: dict) -> set[int]:
+        query = "&".join(f"{key}={value}" for key, value in params.items())
+        response = self.client.get(f"{path}?{query}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return {row["id"] for row in response.json()["results"]}
+
+    def _assert_filters_by_id(self, path: str, param: str, value: int, expected_pks: set[int]):
+        """The filtered page must equal the unfiltered page restricted to expected_pks."""
+        base_params = {"project_id": self.project.pk, "limit": 200}
+        unfiltered = self._get_ids(path, base_params)
+        filtered = self._get_ids(path, {**base_params, param: value})
+        self.assertEqual(filtered, unfiltered & expected_pks)
+        # Guard against a filter that silently stops restricting anything.
+        self.assertTrue(filtered)
+        self.assertLess(len(filtered), len(unfiltered))
+
+    def test_detections_filter_by_source_image(self):
+        expected = set(Detection.objects.filter(source_image=self.capture).values_list("pk", flat=True))
+        self._assert_filters_by_id("/api/v2/detections/", "source_image", self.capture.pk, expected)
+
+    def test_occurrences_filter_by_source_image(self):
+        expected = set(Occurrence.objects.filter(detections__source_image=self.capture).values_list("pk", flat=True))
+        self._assert_filters_by_id("/api/v2/occurrences/", "detections__source_image", self.capture.pk, expected)
+
+    def test_classifications_filter_by_taxon(self):
+        expected = set(Classification.objects.filter(taxon=self.taxon_a).values_list("pk", flat=True))
+        self._assert_filters_by_id("/api/v2/classifications/", "taxon", self.taxon_a.pk, expected)
+
+    def test_unknown_id_returns_empty_page(self):
+        """A well-formed id that matches nothing filters everything out rather than erroring."""
+        for path, param in [
+            ("/api/v2/detections/", "source_image"),
+            ("/api/v2/occurrences/", "detections__source_image"),
+            ("/api/v2/classifications/", "taxon"),
+        ]:
+            with self.subTest(path=path):
+                ids = self._get_ids(path, {"project_id": self.project.pk, "limit": 200, param: 99999999})
+                self.assertEqual(ids, set())
+
+    def test_non_numeric_id_is_rejected(self):
+        for path, param in [
+            ("/api/v2/detections/", "source_image"),
+            ("/api/v2/occurrences/", "detections__source_image"),
+            ("/api/v2/classifications/", "taxon"),
+        ]:
+            with self.subTest(path=path):
+                response = self.client.get(f"{path}?project_id={self.project.pk}&{param}=abc")
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class TestBrowsableApiFilterFormsStayLightweight(APITestCase):
+    """The browsable API's filter form must not enumerate huge related tables.
+
+    For each list endpoint whose filterset touches the source image or taxon
+    tables, the HTML page must render those filters as number inputs. A
+    ``<select>`` for one of these fields means django-filter regenerated a
+    ``ModelChoiceFilter``, which builds an option per row of the related table
+    and times out against production-sized tables.
+    """
+
+    def setUp(self):
+        self.project, self.deployment = setup_test_project(reuse=False)
+        create_taxa(self.project)
+        create_captures(deployment=self.deployment, num_nights=1, images_per_night=3)
+        create_occurrences(deployment=self.deployment, num=3)
+        # A regular authenticated user sees the page but gets no create forms,
+        # so the only form fields on the page belong to the filter form.
+        self.user = User.objects.create_user(email="browsableforms@insectai.org")  # type: ignore
+        self.client.force_authenticate(user=self.user)
+
+    def _get_html(self, path: str) -> str:
+        response = self.client.get(f"{path}?project_id={self.project.pk}", headers={"accept": "text/html"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.content.decode()
+
+    def _assert_number_input(self, html: str, field_name: str):
+        self.assertNotIn(f'<select name="{field_name}"', html)
+        self.assertIn(f'<input type="number" name="{field_name}"', html)
+
+    def test_detections_browsable_page(self):
+        self._assert_number_input(self._get_html("/api/v2/detections/"), "source_image")
+
+    def test_occurrences_browsable_page(self):
+        self._assert_number_input(self._get_html("/api/v2/occurrences/"), "detections__source_image")
+
+    def test_classifications_browsable_page(self):
+        self._assert_number_input(self._get_html("/api/v2/classifications/"), "taxon")

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -7792,6 +7792,14 @@ class TestHugeTableFilterParams(APITestCase):
                 response = self.client.get(f"{path}?project_id={self.project.pk}&{param}=1.5")
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_out_of_range_id_returns_empty_page(self):
+        """An id wider than a bigint is an unknown id, not a server error: Postgres compares
+        it as numeric and matches nothing."""
+        for path, param in self.ENDPOINT_PARAMS:
+            with self.subTest(path=path, param=param):
+                ids = self._get_ids(path, {"project_id": self.project.pk, "limit": 200, param: "9" * 20})
+                self.assertEqual(ids, set())
+
 
 class TestBrowsableApiFilterFormsStayLightweight(APITestCase):
     """The browsable API's filter form must not enumerate huge related tables.

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -7696,6 +7696,15 @@ class TestHugeTableFilterParams(APITestCase):
         self.capture = SourceImage.objects.filter(deployment=self.deployment, detections__isnull=False).first()
         assert self.capture is not None
 
+        occurrences = list(Occurrence.objects.filter(project=self.project)[:2])
+        assert len(occurrences) == 2
+        self.identification_a = Identification.objects.create(
+            user=self.user, occurrence=occurrences[0], taxon=self.taxon_a
+        )
+        self.identification_b = Identification.objects.create(
+            user=self.user, occurrence=occurrences[1], taxon=self.taxon_b
+        )
+
     def _get_ids(self, path: str, params: dict) -> set[int]:
         query = "&".join(f"{key}={value}" for key, value in params.items())
         response = self.client.get(f"{path}?{query}")
@@ -7724,12 +7733,30 @@ class TestHugeTableFilterParams(APITestCase):
         expected = set(Classification.objects.filter(taxon=self.taxon_a).values_list("pk", flat=True))
         self._assert_filters_by_id("/api/v2/classifications/", "taxon", self.taxon_a.pk, expected)
 
+    def test_taxa_filter_by_parent(self):
+        parent = Taxon.objects.filter(direct_children__isnull=False).first()
+        assert parent is not None
+        expected = set(Taxon.objects.filter(parent=parent).values_list("pk", flat=True))
+        self._assert_filters_by_id("/api/v2/taxa/", "parent", parent.pk, expected)
+
+    def test_identifications_filter_by_occurrence(self):
+        expected = {self.identification_a.pk}
+        self._assert_filters_by_id(
+            "/api/v2/identifications/", "occurrence", self.identification_a.occurrence.pk, expected
+        )
+
+    def test_identifications_filter_by_taxon(self):
+        expected = {self.identification_a.pk}
+        self._assert_filters_by_id("/api/v2/identifications/", "taxon", self.taxon_a.pk, expected)
+
     def test_unknown_id_returns_empty_page(self):
         """A well-formed id that matches nothing filters everything out rather than erroring."""
         for path, param in [
             ("/api/v2/detections/", "source_image"),
             ("/api/v2/occurrences/", "detections__source_image"),
             ("/api/v2/classifications/", "taxon"),
+            ("/api/v2/taxa/", "parent"),
+            ("/api/v2/identifications/", "occurrence"),
         ]:
             with self.subTest(path=path):
                 ids = self._get_ids(path, {"project_id": self.project.pk, "limit": 200, param: 99999999})
@@ -7740,6 +7767,8 @@ class TestHugeTableFilterParams(APITestCase):
             ("/api/v2/detections/", "source_image"),
             ("/api/v2/occurrences/", "detections__source_image"),
             ("/api/v2/classifications/", "taxon"),
+            ("/api/v2/taxa/", "parent"),
+            ("/api/v2/identifications/", "occurrence"),
         ]:
             with self.subTest(path=path):
                 response = self.client.get(f"{path}?project_id={self.project.pk}&{param}=abc")
@@ -7783,3 +7812,14 @@ class TestBrowsableApiFilterFormsStayLightweight(APITestCase):
 
     def test_classifications_browsable_page(self):
         self._assert_number_input(self._get_html("/api/v2/classifications/"), "taxon")
+
+    def test_taxa_browsable_page(self):
+        self._assert_number_input(self._get_html("/api/v2/taxa/"), "parent")
+
+    def test_identifications_browsable_page(self):
+        # Unauthenticated so no create form is rendered; the identification
+        # create form would itself contain selects for these field names.
+        self.client.force_authenticate(user=None)
+        html = self._get_html("/api/v2/identifications/")
+        self._assert_number_input(html, "occurrence")
+        self._assert_number_input(html, "taxon")


### PR DESCRIPTION
## Summary

Opening several API list endpoints in a web browser hangs and eventually fails with a gateway timeout. `curl` and the web app are unaffected, which is why this went unnoticed: the difference is the `Accept` header, not the endpoint or the data.

A browser asks for HTML, so DRF renders the browsable API page. That page includes a filter form, and django-filter renders a foreign-key filter as a `<select>` populated by enumerating the related table. Several filters point at tables with millions of rows — the source image table holds tens of millions — so building the form reads the whole table and the request dies before the page renders.

Measured against a deployment, the same URLs differing only in `Accept`:

| endpoint | `text/html` | `application/json` |
|---|---|---|
| detections | gateway timeout at 60s | 200 in ~0.4s |
| occurrences | gateway timeout at 60s | 200 in ~1s |
| jobs | gateway timeout at 60s | 200, fast |
| classifications | 200 but 15.7s | 200 in ~0.4s |
| captures | 200 in 3.9s | 200, fast |

This replaces the auto-generated foreign-key filters on those large tables with plain integer inputs, via one shared `RelatedIdFilter`. The query parameters are unchanged, so existing API clients are unaffected.

### Why `HTML_SELECT_CUTOFF` did not already cover this

The project already caps how many options a browsable-API form will render, via `"HTML_SELECT_CUTOFF": 100` in the REST framework settings. That setting applies to DRF's own serializer forms — the ones used for POST and PUT on detail pages, which is why those pages are fine. It has no effect on django-filter's filter form, which builds its own fields. The two forms look alike on the page but come from different code, and only one of them was bounded.

### List of Changes

| # | Change (effect) | How |
|---|---|---|
| 1 | The detections list page opens in a browser instead of timing out. | New `DetectionFilterSet` declaring `source_image` as a `RelatedIdFilter`; the viewset switches from `filterset_fields` to `filterset_class`. |
| 2 | The occurrences list page opens in a browser instead of timing out. | New `OccurrenceFilterSet` declaring `detections__source_image` as a `RelatedIdFilter`, used by both the occurrence list and the occurrence stats viewsets, which share the same filter fields. |
| 3 | The jobs list page opens in a browser instead of timing out. | `source_image_single` declared as a `RelatedIdFilter` on the existing `JobFilterSet`. |
| 4 | The classifications and taxa pages load promptly rather than taking many seconds. | `RelatedIdFilter` for the taxon and parent-taxon filters, which enumerate the taxon table. |
| 5 | The identifications page loads promptly as well. | New `IdentificationFilterSet` declaring `occurrence` and `taxon` as `RelatedIdFilter`s. |
| 6 | Filtering by these parameters keeps working exactly as before, and a fractional id such as `?taxon=1.5` is now rejected with 400 instead of silently matching id 1. | Each filter keeps its name and accepts the same `?<param>=<id>`. `RelatedIdFilter` (`ami/base/filters.py`) is a `NumberFilter` whose form field is an `IntegerField`; `NumberFilter`'s default `DecimalField` accepted `1.5`, which Django's FK lookup truncated to `1`. Tests pin the behaviour per endpoint and parameter: unknown id returns an empty page, non-numeric and fractional ids return 400. |
| 7 | The browsable pages are checked so this cannot silently return. | Tests render each page and assert the filter form contains a number input rather than a populated select. |

## Notes

The implicit convention here is that a filter field should terminate on a small table; `ClassificationViewSet` already carries a comment linking DRF's documentation on large choice fields. These entries had drifted from it. Declaring a `FilterSet` follows the pattern `JobFilterSet` already established for cases where the auto-generated filterset is not what you want. All six declarations share the one `RelatedIdFilter` class, so the rationale and the link to DRF's guidance on large choice fields live in a single docstring.

A separate option worth discussing is turning off the browsable API in production, which would sidestep this class of problem entirely and return JSON to anyone opening an API URL in a browser. That is a policy decision about whether the browsable API is a feature the project wants to keep, and the change here is worth making either way.

## What still needs verification

The timings above come from a deployment and are not reproduced by the test suite; the tests assert the form shape rather than a duration. Confirming the fix end to end means opening each list page in a browser after deploying.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added numeric ID filtering for jobs, detections, occurrences, taxa, classifications, and identifications.
  - Browsable API filters now use efficient numeric input fields instead of large dropdown lists.
  - Existing filter query parameters remain supported.

- **Bug Fixes**
  - Prevented filter pages from timing out when related records contain very large datasets.
  - Added validation for invalid numeric filter values and handling for unknown IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
