### PR TITLE
Remove deprecated check-docstring-first precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
       - id: debug-statements
       - id: check-builtin-literals
       - id: check-case-conflict
-      - id: check-docstring-first
       - id: detect-private-key
 
   - repo: https://github.com/adamchainz/django-upgrade


### PR DESCRIPTION
"check-docstring-first: fundamentally flawed, deprecated without replacement."

https://github.com/pre-commit/pre-commit-hooks#deprecated--replaced-hooks

## Summary

Brief description of what this PR does. (tl;dr).

### List of Changes

* Removes pre-commit hook

### How to Test the Changes

Run precommit on an otherwise valid source tree and verify that it succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an automated documentation-style check from the pre-commit validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->