### PR TITLE
Correct the denominator in the model-agreement endpoint's API documentation

### DIFF
--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -1942,14 +1942,14 @@ class ModelAgreementSerializer(serializers.Serializer):
         max_value=1.0,
         allow_null=True,
         required=False,
-        help_text="Wilson 95% CI lower bound for agreed_exact_pct. Null when verified_with_prediction_count is 0.",
+        help_text="Wilson 95% CI lower bound for agreed_exact_pct. Null when comparable_count is 0.",
     )
     agreed_exact_ci_high = serializers.FloatField(
         min_value=0.0,
         max_value=1.0,
         allow_null=True,
         required=False,
-        help_text="Wilson 95% CI upper bound for agreed_exact_pct. Null when verified_with_prediction_count is 0.",
+        help_text="Wilson 95% CI upper bound for agreed_exact_pct. Null when comparable_count is 0.",
     )
     agreed_any_rank_count = serializers.IntegerField(
         help_text="Exact matches plus disagreements whose LCA is at any real rank (UNKNOWN excluded)."
@@ -1957,21 +1957,21 @@ class ModelAgreementSerializer(serializers.Serializer):
     agreed_any_rank_pct = serializers.FloatField(
         min_value=0.0,
         max_value=1.0,
-        help_text="agreed_any_rank_count / verified_with_prediction_count",
+        help_text="agreed_any_rank_count / comparable_count",
     )
     agreed_any_rank_ci_low = serializers.FloatField(
         min_value=0.0,
         max_value=1.0,
         allow_null=True,
         required=False,
-        help_text="Wilson 95% CI lower bound for agreed_any_rank_pct. Null when verified_with_prediction_count is 0.",
+        help_text="Wilson 95% CI lower bound for agreed_any_rank_pct. Null when comparable_count is 0.",
     )
     agreed_any_rank_ci_high = serializers.FloatField(
         min_value=0.0,
         max_value=1.0,
         allow_null=True,
         required=False,
-        help_text="Wilson 95% CI upper bound for agreed_any_rank_pct. Null when verified_with_prediction_count is 0.",
+        help_text="Wilson 95% CI upper bound for agreed_any_rank_pct. Null when comparable_count is 0.",
     )
     cohens_kappa = serializers.FloatField(
         min_value=-1.0,
@@ -2002,5 +2002,5 @@ class ModelAgreementSerializer(serializers.Serializer):
         max_value=1.0,
         allow_null=True,
         required=False,
-        help_text="agreed_coarser_rank_count / verified_with_prediction_count. Null when no threshold supplied.",
+        help_text="agreed_coarser_rank_count / comparable_count. Null when no threshold supplied.",
     )

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -6020,6 +6020,28 @@ class TestModelAgreementForProject(APITestCase):
         # 1 exact agreement out of 1 comparable → 100%, not 50%.
         self.assertEqual(result["agreed_exact_count"], 1)
         self.assertAlmostEqual(result["agreed_exact_pct"], 1.0)
+        self.assertAlmostEqual(result["agreed_any_rank_pct"], 1.0)
+
+    def test_confidence_intervals_null_when_nothing_is_comparable(self):
+        """Wilson bounds are null once nothing is comparable, even though every
+        verified occurrence here carries a machine prediction.
+
+        comparable_count falls below verified_with_prediction_count whenever a
+        verification has no taxon, and the intervals key off the former.
+        """
+        from ami.main.models_future.occurrence import model_agreement_for_project
+
+        occurrences = list(Occurrence.objects.filter(project=self.project).order_by("pk"))
+        for occurrence in occurrences[:2]:
+            Identification.objects.create(user=self.user, occurrence=occurrence, taxon=None)
+
+        result = model_agreement_for_project(Occurrence.objects.filter(project=self.project))
+        self.assertEqual(result["verified_with_prediction_count"], 2)
+        self.assertEqual(result["comparable_count"], 0)
+        self.assertIsNone(result["agreed_exact_ci_low"])
+        self.assertIsNone(result["agreed_exact_ci_high"])
+        self.assertIsNone(result["agreed_any_rank_ci_low"])
+        self.assertIsNone(result["agreed_any_rank_ci_high"])
 
 
 class TestOccurrenceStatsViewSet(APITestCase):


### PR DESCRIPTION
## Summary

The API documentation for the model-agreement endpoint named the wrong denominator. Six of the field descriptions said the agreement percentages and confidence intervals were calculated over `verified_with_prediction_count`, when the endpoint actually divides them by `comparable_count`. Those two numbers are not the same: a verification that carries no taxon — someone leaving a comment rather than naming a species — has a machine prediction but nothing to compare it against, so it counts toward the first and not the second. Anyone reading the schema and recomputing a percentage from the counts we return would get a different answer than the endpoint gives them.

Nothing about the endpoint's behaviour changes here. The numbers it returns were always calculated against `comparable_count`, and the serializer's own class docstring already said so. Only the per-field descriptions had drifted away from it, and those are what a consumer actually sees in the browsable API and the generated OpenAPI schema.

The same confusion had been shipped in the frontend tooltips, and was corrected there in #1308.

### List of Changes

| # | What changes for a consumer | How |
|---|---|---|
| 1 | The description of the any-rank agreement percentage now names the comparable set, so recomputing it from the returned counts matches what the endpoint reports | `agreed_any_rank_pct` help text |
| 2 | The same correction for the coarser-rank percentage | `agreed_coarser_rank_pct` help text |
| 3 | The four confidence bounds now describe the right condition for coming back empty: they are null when nothing is comparable, not when nothing has a prediction | `agreed_exact_ci_low` / `_high` and `agreed_any_rank_ci_low` / `_high` help text |
| 4 | Two claims that nothing was pinning are now covered by tests | `TestModelAgreementForProject` gains an assertion that the any-rank percentage divides by `comparable_count`, plus a case where every verification is comment-only, so `verified_with_prediction_count` is non-zero while `comparable_count` is zero and all four bounds come back null |

## Test plan

- [x] `TestModelAgreementForProject` — 5 tests green (4 existing plus the new confidence-interval case).
- [x] `-k Agreement -k Stats` — 25 tests green.
- [x] Pre-commit hooks pass, `flake8` included.
- [x] Checked against the implementation before editing: `wilson_interval` (`ami/utils/stats.py:33`) returns `None` when its `total` argument is zero, and `model_agreement_for_project` passes `comparable` as that argument. The percentages are built by `_pct(..., comparable)` (`ami/main/models_future/occurrence.py:294-295, 325`).
- [x] The repository has no committed OpenAPI schema file, so nothing needs regenerating alongside this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected model agreement help text to describe agreement percentages and confidence intervals using the comparable occurrence count.
  * Improved agreement reporting when verified occurrences lack a human-assigned taxon, including accurate denominator handling and unavailable confidence intervals when no occurrences are comparable.

* **Tests**
  * Added regression coverage for confidence interval and agreement-rate calculations in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->