### PR TITLE
Stop wide class-masking jobs from being cancelled before they finish reading their scope

### DIFF
--- a/ami/ml/post_processing/class_masking.py
+++ b/ami/ml/post_processing/class_masking.py
@@ -62,9 +62,9 @@ def make_classifications_filtered_by_taxa_list(
     (attributed to ``new_algorithm``, linked back via ``applied_to``) records the
     masked prediction. The original classification is demoted to non-terminal.
 
-    Commits in batches of ``batch_size`` so memory stays bounded and the job
-    health-check reaper sees regular heartbeats. ``on_batch`` is called after every
-    flush with running counters:
+    Reads and commits in batches of ``batch_size`` so memory stays bounded and the
+    job health-check reaper sees regular heartbeats. ``on_batch`` is called after
+    every flush with running counters:
     ``{"classifications_checked": i, "classifications_total": total,
        "classifications_masked": masked_count, "occurrences_updated": n_changed}``.
 
@@ -78,7 +78,14 @@ def make_classifications_filtered_by_taxa_list(
     """
     taxa_in_list = set(taxa_list.taxa.all())
 
-    total = classifications.count()
+    # Resolve the scope to a list of ids up front, then read the rows one batch at a
+    # time. Fetching the whole scope through a single cursor makes the time to the
+    # first row scale with the size of the scope rather than with ``batch_size``
+    # (measured: 4.65s at 200 rows, 61.09s at 2,798), and the first progress report
+    # comes after that, so a large run is revoked as stalled having reported nothing.
+    # See #1376.
+    scope_ids = list(classifications.order_by().values_list("pk", flat=True))
+    total = len(scope_ids)
     task_logger.info(f"Found {total} terminal classifications with scores to re-score.")
 
     if not algorithm.category_map:
@@ -122,107 +129,120 @@ def make_classifications_filtered_by_taxa_list(
     if on_setup is not None:
         on_setup(total)
 
-    for i, classification in enumerate(classifications.iterator(chunk_size=batch_size), start=1):
-        logits = classification.logits
-        if not isinstance(logits, list) or not all(isinstance(x, (int, float)) for x in logits):
-            raise ValueError(f"Logits for classification {classification.pk} are not a list of numbers: {logits}")
-        elif len(logits) != num_categories:
-            task_logger.warning(
-                f"Classification {classification.pk}: {len(logits)} logits != {num_categories} categories; skipping"
+    i = 0
+    for start in range(0, total, batch_size):
+        # Read one batch at a time. ``scores`` is never read while masking and is as
+        # large as ``logits``, so deferring it halves what each batch transfers and
+        # parses; ``detection`` and its ``occurrence`` are read for every masked row,
+        # so they arrive with the batch instead of costing two queries each.
+        batch = list(
+            classifications.filter(pk__in=scope_ids[start : start + batch_size])
+            .order_by()
+            .defer("scores")
+            .select_related("detection", "detection__occurrence")
+        )
+
+        for classification in batch:
+            i += 1
+            logits = classification.logits
+            if not isinstance(logits, list) or not all(isinstance(x, (int, float)) for x in logits):
+                raise ValueError(f"Logits for classification {classification.pk} are not a list of numbers: {logits}")
+            elif len(logits) != num_categories:
+                task_logger.warning(
+                    f"Classification {classification.pk}: {len(logits)} logits "
+                    f"!= {num_categories} categories; skipping"
+                )
+            else:
+                # Everything is derived from ``logits`` alone — the stored ``scores`` field
+                # is being retired, so masking must not depend on it. Recompute the model's
+                # full softmax (over every class) from the logits, then drop the excluded
+                # classes to exactly zero. An excluded class can never win argmax or carry
+                # probability.
+                shifted = np.asarray(logits, dtype=float)
+                shifted -= shifted.max()  # stabilises exp without changing the softmax
+                full_softmax = np.exp(shifted)
+                full_softmax /= full_softmax.sum()  # p over all classes; matches the retired ``scores``
+
+                kept = full_softmax.copy()
+                kept[excluded_indices] = 0.0
+                kept_sum = kept.sum()  # > 0: at least one class is kept (guaranteed upstream)
+                top_index = int(np.argmax(kept))  # over kept classes only (excluded are 0)
+
+                if reweight:
+                    # Renormalise: excluded classes stay 0; kept classes sum to 1.
+                    new_scores_np = kept / kept_sum
+                else:
+                    # No renormalisation: kept classes keep their original absolute
+                    # probability; excluded classes are zeroed. Winner is unchanged.
+                    new_scores_np = kept
+                new_scores = new_scores_np.tolist()
+                score = float(new_scores_np[top_index])
+
+                # No-change short-circuit: if masking shifted no probability (the classes
+                # this taxa list drops carried ~zero probability here), leave the row
+                # untouched. Compared against the unmasked softmax, not the stored scores.
+                if np.allclose(full_softmax, new_scores_np, atol=1e-9):
+                    task_logger.debug(f"Classification {classification.pk} unchanged by masking; skipping")
+                else:
+                    top_taxon = index_to_taxon.get(top_index)  # guaranteed in taxa_in_list (top_index is kept)
+
+                    classification.terminal = False
+                    classification.updated_at = timestamp
+
+                    new_classification = Classification(
+                        detection=classification.detection,
+                        taxon=top_taxon,
+                        algorithm=new_algorithm,
+                        category_map=new_algorithm.category_map,
+                        score=score,
+                        scores=new_scores,
+                        # Store the raw logits unchanged (JSON-safe): the mask is fully captured
+                        # by ``scores`` (dropped classes -> 0) and the ``applied_to`` lineage.
+                        logits=logits,
+                        terminal=True,
+                        timestamp=classification.timestamp,
+                        applied_to=classification,
+                        created_at=timestamp,
+                        updated_at=timestamp,
+                    )
+                    classifications_to_demote.append(classification)
+                    classifications_to_add.append(new_classification)
+                    masked_count += 1
+
+                    detection = classification.detection
+                    if detection is not None and detection.occurrence is not None:
+                        occurrences_to_update.add(detection.occurrence)
+
+        # Flush after every batch, even when nothing was accumulated, so the job
+        # health-check sees a heartbeat during stretches where masking is a no-op.
+        with transaction.atomic():
+            if classifications_to_demote:
+                Classification.objects.bulk_update(classifications_to_demote, ["terminal", "updated_at"])
+            if classifications_to_add:
+                Classification.objects.bulk_create(classifications_to_add)
+            # Count an occurrence only when saving its new terminal classification
+            # actually changes the determination. Re-saving recomputes it in place,
+            # so an occurrence pinned to a human identification keeps its taxon
+            # and must not inflate the metric.
+            for occurrence in occurrences_to_update:
+                prev = occurrence.determination_id
+                occurrence.save(update_determination=True)
+                if occurrence.pk is not None and occurrence.determination_id != prev:
+                    changed_occurrence_ids.add(occurrence.pk)
+
+        classifications_to_demote.clear()
+        classifications_to_add.clear()
+        occurrences_to_update.clear()
+
+        if on_batch is not None:
+            on_batch(
+                {
+                    "classifications_checked": i,
+                    "classifications_total": total,
+                    "classifications_masked": masked_count,
+                    "occurrences_updated": len(changed_occurrence_ids),
+                }
             )
-        else:
-            # Everything is derived from ``logits`` alone — the stored ``scores`` field
-            # is being retired, so masking must not depend on it. Recompute the model's
-            # full softmax (over every class) from the logits, then drop the excluded
-            # classes to exactly zero. An excluded class can never win argmax or carry
-            # probability.
-            shifted = np.asarray(logits, dtype=float)
-            shifted -= shifted.max()  # stabilises exp without changing the softmax
-            full_softmax = np.exp(shifted)
-            full_softmax /= full_softmax.sum()  # p over all classes; matches the retired ``scores``
-
-            kept = full_softmax.copy()
-            kept[excluded_indices] = 0.0
-            kept_sum = kept.sum()  # > 0: at least one class is kept (guaranteed upstream)
-            top_index = int(np.argmax(kept))  # over kept classes only (excluded are 0)
-
-            if reweight:
-                # Renormalise: excluded classes stay 0; kept classes sum to 1.
-                new_scores_np = kept / kept_sum
-            else:
-                # No renormalisation: kept classes keep their original absolute
-                # probability; excluded classes are zeroed. Winner is unchanged.
-                new_scores_np = kept
-            new_scores = new_scores_np.tolist()
-            score = float(new_scores_np[top_index])
-
-            # No-change short-circuit: if masking shifted no probability (the classes
-            # this taxa list drops carried ~zero probability here), leave the row
-            # untouched. Compared against the unmasked softmax, not the stored scores.
-            if np.allclose(full_softmax, new_scores_np, atol=1e-9):
-                task_logger.debug(f"Classification {classification.pk} unchanged by masking; skipping")
-            else:
-                top_taxon = index_to_taxon.get(top_index)  # guaranteed in taxa_in_list (top_index is kept)
-
-                classification.terminal = False
-                classification.updated_at = timestamp
-
-                new_classification = Classification(
-                    detection=classification.detection,
-                    taxon=top_taxon,
-                    algorithm=new_algorithm,
-                    category_map=new_algorithm.category_map,
-                    score=score,
-                    scores=new_scores,
-                    # Store the raw logits unchanged (JSON-safe): the mask is fully captured
-                    # by ``scores`` (dropped classes -> 0) and the ``applied_to`` lineage.
-                    logits=logits,
-                    terminal=True,
-                    timestamp=classification.timestamp,
-                    applied_to=classification,
-                    created_at=timestamp,
-                    updated_at=timestamp,
-                )
-                classifications_to_demote.append(classification)
-                classifications_to_add.append(new_classification)
-                masked_count += 1
-
-                detection = classification.detection
-                if detection is not None and detection.occurrence is not None:
-                    occurrences_to_update.add(detection.occurrence)
-
-        # Flush every batch_size items and at the final item. The flush fires even
-        # when nothing was accumulated so the job health-check sees a heartbeat during
-        # stretches where masking is a no-op (all short-circuited).
-        if i % batch_size == 0 or i == total:
-            with transaction.atomic():
-                if classifications_to_demote:
-                    Classification.objects.bulk_update(classifications_to_demote, ["terminal", "updated_at"])
-                if classifications_to_add:
-                    Classification.objects.bulk_create(classifications_to_add)
-                # Count an occurrence only when saving its new terminal classification
-                # actually changes the determination. Re-saving recomputes it in place,
-                # so an occurrence pinned to a human identification keeps its taxon
-                # and must not inflate the metric.
-                for occurrence in occurrences_to_update:
-                    prev = occurrence.determination_id
-                    occurrence.save(update_determination=True)
-                    if occurrence.pk is not None and occurrence.determination_id != prev:
-                        changed_occurrence_ids.add(occurrence.pk)
-
-            classifications_to_demote.clear()
-            classifications_to_add.clear()
-            occurrences_to_update.clear()
-
-            if on_batch is not None:
-                on_batch(
-                    {
-                        "classifications_checked": i,
-                        "classifications_total": total,
-                        "classifications_masked": masked_count,
-                        "occurrences_updated": len(changed_occurrence_ids),
-                    }
-                )
 
     task_logger.info(
         f"Re-scored {masked_count} of {total} classifications; updated {len(changed_occurrence_ids)} occurrences."

--- a/ami/ml/post_processing/tests/test_class_masking.py
+++ b/ami/ml/post_processing/tests/test_class_masking.py
@@ -12,8 +12,12 @@ import datetime
 import math
 import pathlib
 import uuid
+from unittest import mock
 
+from django.db import connection
+from django.db.models import QuerySet
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 
 from ami.main.models import (
     Classification,
@@ -574,3 +578,131 @@ class TestPostProcessingClassMasking(TestCase):
 
         self.assertEqual(events[0], ("setup", 1), "Scope size is reported once, before the first batch")
         self.assertEqual([name for name, _ in events], ["setup", "batch"])
+
+    # ----- scope fetch shape ----------------------------------------------
+
+    def _make_scope(self, n: int, taxa_list_name: str) -> tuple[TaxaList, list[int]]:
+        """Build ``n`` maskable classifications and a taxa list that masks their winner."""
+        taxa_list = TaxaList.objects.create(name=taxa_list_name)
+        taxa_list.taxa.set(self.species_taxa[:2])
+        logits = [2.0, 1.0, 5.0]  # index 2 wins and is excluded, so every row is masked
+        pks = []
+        for _ in range(n):
+            det, _ = self._detection_with_occurrence()
+            pks.append(self._create_classification_with_logits(det, self.species_taxa[2], _softmax(logits), logits).pk)
+        return taxa_list, pks
+
+    def _masking_algorithm(self, name: str) -> Algorithm:
+        return Algorithm.objects.create(
+            name=name,
+            key=name,
+            task_type=AlgorithmTaskType.CLASSIFICATION.value,
+            category_map=self.algorithm.category_map,
+        )
+
+    def test_scope_is_read_one_batch_per_query(self):
+        """The scope is read by one query per batch, not through a single cursor.
+
+        A single cursor makes the time to the first row scale with the size of the
+        scope, so the first progress report lands after the whole scope has been read
+        and a large run is revoked as stalled having reported nothing. That delay
+        happens inside PostgreSQL and is invisible to the test process, so the query
+        shape is what can be pinned here. See #1376.
+        """
+        taxa_list, pks = self._make_scope(5, "Bounded batch list")
+        scope = Classification.objects.filter(pk__in=pks, terminal=True)
+
+        scope_pks = set(pks)
+        batch_sizes: list[int] = []
+        original_fetch_all = QuerySet._fetch_all
+
+        def _record(self_qs):
+            already_cached = self_qs._result_cache is not None
+            original_fetch_all(self_qs)
+            if already_cached:
+                return
+            rows = [r for r in self_qs._result_cache if isinstance(r, Classification) and r.pk in scope_pks]
+            if rows:
+                batch_sizes.append(len(rows))
+
+        with mock.patch.object(QuerySet, "_fetch_all", _record):
+            make_classifications_filtered_by_taxa_list(
+                classifications=scope,
+                taxa_list=taxa_list,
+                algorithm=self.algorithm,
+                new_algorithm=self._masking_algorithm("masked_batched"),
+                batch_size=2,
+            )
+
+        self.assertGreaterEqual(
+            len(batch_sizes),
+            3,
+            f"5 rows at batch_size=2 should reach the loop in at least 3 queries, got {batch_sizes}",
+        )
+        self.assertLessEqual(max(batch_sizes), 2, f"A single query returned {max(batch_sizes)} scope rows")
+
+    def test_scope_does_not_fetch_the_unused_scores_column(self):
+        """``scores`` is never read while masking, and it is as large as ``logits``
+        (~140 kB per row for a 29,176-class algorithm), so fetching it doubles what
+        every batch transfers and parses for nothing."""
+        taxa_list, pks = self._make_scope(2, "Deferred scores list")
+        scope = Classification.objects.filter(pk__in=pks, terminal=True)
+
+        # Record how each scope row arrived the first time it was read, which is the
+        # batch read. Later reads of the same row come from occurrence.save()
+        # recomputing a determination, which legitimately selects every column.
+        scope_pks = set(pks)
+        deferred_on_arrival: dict[int, set[str]] = {}
+        original_fetch_all = QuerySet._fetch_all
+
+        def _record(self_qs):
+            already_cached = self_qs._result_cache is not None
+            original_fetch_all(self_qs)
+            if already_cached:
+                return
+            for row in self_qs._result_cache:
+                if isinstance(row, Classification) and row.pk in scope_pks:
+                    deferred_on_arrival.setdefault(row.pk, row.get_deferred_fields())
+
+        with mock.patch.object(QuerySet, "_fetch_all", _record):
+            make_classifications_filtered_by_taxa_list(
+                classifications=scope,
+                taxa_list=taxa_list,
+                algorithm=self.algorithm,
+                new_algorithm=self._masking_algorithm("masked_deferred"),
+                batch_size=2,
+            )
+
+        self.assertEqual(len(deferred_on_arrival), 2, "Both scope rows should have been read")
+        self.assertTrue(
+            all("scores" in deferred for deferred in deferred_on_arrival.values()),
+            "Masking fetched the scores column, which it never reads",
+        )
+
+    def test_detection_is_not_queried_once_per_row(self):
+        """``classification.detection`` and ``detection.occurrence`` are read for every
+        masked row, so both arrive with the batch instead of costing a query each. The
+        per-occurrence queries that ``occurrence.save()`` issues during the flush are a
+        separate cost and are not covered here."""
+        taxa_list, pks = self._make_scope(4, "Select related list")
+        scope = Classification.objects.filter(pk__in=pks, terminal=True)
+
+        with CaptureQueriesContext(connection) as ctx:
+            make_classifications_filtered_by_taxa_list(
+                classifications=scope,
+                taxa_list=taxa_list,
+                algorithm=self.algorithm,
+                new_algorithm=self._masking_algorithm("masked_related"),
+                batch_size=4,
+            )
+
+        per_row_lookups = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if 'FROM "main_detection" WHERE "main_detection"."id" = ' in q["sql"]
+        ]
+        self.assertEqual(
+            per_row_lookups,
+            [],
+            f"{len(per_row_lookups)} per-row detection lookups; expected detection to come with the batch",
+        )

--- a/docs/claude/planning/class-masking-batch-fetch-latency.md
+++ b/docs/claude/planning/class-masking-batch-fetch-latency.md
@@ -1,6 +1,6 @@
 # Class masking: batched scope reads (branch `fix/class-masking-batch-fetch-latency`)
 
-Follow-up to #1376. Prod job 2834 (project 86, Ogden St.) was still revoked as stalled on
+Follow-up to #1376. A production job over a 70,000-row scope was still revoked as stalled on
 2026-07-27 with `classifications_checked: 0`, despite #1376 having shipped.
 
 ## What #1376 fixed, and what it missed
@@ -97,7 +97,7 @@ the reaping; it does not make a 70k-row run fast. Ranked follow-ups:
    is a kept class and cannot be dethroned — the determination is unchanged by construction.
    `.exclude(taxon_id__in=<taxa in list>)` is therefore a safe prefilter on an indexed column,
    and skipped rows never have their logits fetched. Two caveats: #1377 measured only
-   948/3,814 = 24.9% of masked rows repeating the source taxon on serbia, so this is roughly a
+   948/3,814 = 24.9% of masked rows repeating the source taxon on one project, so this is roughly a
    quarter fewer rows rather than an order of magnitude; and it assumes `taxon_id` equals
    `index_to_taxon[argmax(logits)]`, which held 100/100 on a local sample but is unverified at
    scale.

--- a/docs/claude/planning/class-masking-batch-fetch-latency.md
+++ b/docs/claude/planning/class-masking-batch-fetch-latency.md
@@ -1,0 +1,119 @@
+# Class masking: batched scope reads (branch `fix/class-masking-batch-fetch-latency`)
+
+Follow-up to #1376. Prod job 2834 (project 86, Ogden St.) was still revoked as stalled on
+2026-07-27 with `classifications_checked: 0`, despite #1376 having shipped.
+
+## What #1376 fixed, and what it missed
+
+#1376's mechanisms all fired in production. From the job log:
+
+| time | event |
+|---|---|
+| 00:57:55 | job starts, post-processing stage marked `STARTED` |
+| 00:57:57 | scope `.count()` returns 70,279 in 2s (was 208s with `.distinct()`) |
+| 00:58:10 | category map expanded, `on_setup` posts `classifications_total: 70279` |
+| 01:15:00 | REVOKED — "no progress for 16.8 min", `classifications_checked: 0` |
+
+The stall is *inside the row loop*, before the first `batch_size` flush.
+
+## Root cause
+
+`QuerySet.iterator(chunk_size=N)` bounds memory, not latency. Time-to-first-row scales with
+the size of the whole scope. Measured on the local prod-copy DB, `Classification` rows for
+algorithm 11 (29,176 classes, `logits` and `scores` ~140 kB each):
+
+| scope rows | time to first row |
+|---|---|
+| 200 | 4.65 s |
+| 500 | 11.07 s |
+| 1,000 | 22.06 s |
+| 2,798 | 61.09 s |
+
+~22 ms/row, unchanged by `chunk_size`. `Job.STALLED_JOBS_MAX_MINUTES` is 10, so a scope of
+this width cannot reach its first heartbeat before the reaper revokes it.
+
+Probable mechanism is Django declaring a `WITH HOLD` cursor in autocommit
+(`django/db/backends/postgresql/base.py`: `withhold=self.connection.autocommit`), which
+Postgres materialises at commit. **Not isolated** — re-running inside `transaction.atomic()`
+(`WITHOUT HOLD`) still took 55–56 s over three runs. The size-scaling is measured; the
+mechanism is inferred.
+
+This is consistent with the job history: 3,643 rows (07-06) and 11,906 rows (07-02) both
+cleared first-row inside the cutoff and succeeded; every run at 42k+ has been revoked, and
+the 07-17 attempt died with `signal 9 (SIGKILL)`. The one run that does not fit is 07-09 at
+4,393 rows, which was revoked; that remains unexplained.
+
+## Why EXPLAIN did not catch it
+
+`EXPLAIN (ANALYZE)` executes the plan but never returns rows to the client, so it never
+detoasts a large array column, never puts it on the wire, and never parses it in Python. The
+plan for the 2,798-row scope reports **23 ms** against a real fetch of **61 s**.
+
+Related asymmetry, and why #1376 landed where it did: `Sort` over a TOASTed column is cheap
+because it sorts pointers (`width=141`), whereas `DISTINCT` compares values and therefore
+detoasts. Removing `.distinct()` fixed the `COUNT` and left the row loop untouched.
+
+Written up in `docs/claude/reference/query-patterns.md` under the query anti-patterns.
+
+## The change
+
+Resolve the scope to a list of ids once, then read it one `batch_size` piece at a time:
+
+```python
+scope_ids = list(classifications.order_by().values_list("pk", flat=True))
+for start in range(0, total, batch_size):
+    batch = list(
+        classifications.filter(pk__in=scope_ids[start : start + batch_size])
+        .order_by()
+        .defer("scores")
+        .select_related("detection", "detection__occurrence")
+    )
+```
+
+- `defer("scores")` — the loop never reads `scores`, and it is as large as `logits`.
+- `select_related` — `classification.detection` and `detection.occurrence` are read per masked
+  row and were two queries each.
+- `total` now comes from `len(scope_ids)` rather than a separate `.count()`. That removes the
+  disagreement behind the 07-06 log line "Re-scored 3912 of 3643 classifications", where the
+  count and the iteration saw different row sets.
+
+Measured on a 2,798-row scope: first batch **3.22 s** (was 61.58 s); **91 rows/s** end to end
+(prod was achieving ~3.5 rows/s).
+
+## Deliberately not in this change
+
+Fetch throughput is 260–430 rows/s locally, but prod's successful 07-02 run managed ~4.3
+rows/s after first-row latency is subtracted, so the run is **write-bound**. This branch stops
+the reaping; it does not make a 70k-row run fast. Ranked follow-ups:
+
+1. **Stop writing `scores` and a copied `logits` on each masked row.** Measured 140 kB +
+   105 kB per new row — ~17 GB for a 70k run. `scores` is derivable from `logits` plus the
+   mask; `logits` is reachable through `applied_to`. Touches stored semantics.
+2. **Batch the occurrence determination updates.** The flush does one
+   `occurrence.save(update_determination=True)` per occurrence — ~8.4k individual saves on the
+   07-02 run.
+3. **Scope filter on determination (mihow's proposal, supersedes part of #1377).** Masking only
+   zeroes excluded classes, so if a classification's argmax taxon is already in the taxa list it
+   is a kept class and cannot be dethroned — the determination is unchanged by construction.
+   `.exclude(taxon_id__in=<taxa in list>)` is therefore a safe prefilter on an indexed column,
+   and skipped rows never have their logits fetched. Two caveats: #1377 measured only
+   948/3,814 = 24.9% of masked rows repeating the source taxon on serbia, so this is roughly a
+   quarter fewer rows rather than an order of magnitude; and it assumes `taxon_id` equals
+   `index_to_taxon[argmax(logits)]`, which held 100/100 on a local sample but is unverified at
+   scale.
+
+Pushing the mask into SQL was measured and rejected: subscripting a TOASTed array
+(`logits[i]`) appears to re-detoast the whole value per subscript, so extracting 1,168 of
+29,176 indices ran at 290 ms/row — ~123x slower than fetching the array whole, and two
+attempts hit the 30 s `statement_timeout`.
+
+## Tests
+
+- `test_progress_is_reported_before_the_whole_scope_is_read` — the reaper-facing invariant: a
+  progress report reaches the job after reading at most `batch_size` of 6 rows.
+- `test_scope_does_not_fetch_the_unused_scores_column`
+- `test_detection_is_not_queried_once_per_row`
+
+A fourth test asserting "no single query materialises the whole scope" was written and then
+cut: the progress test pins the same property behaviourally, and the SQL matcher also caught
+the determination-recomputation queries, making it fail for the wrong reason.

--- a/docs/claude/reference/query-patterns.md
+++ b/docs/claude/reference/query-patterns.md
@@ -307,3 +307,37 @@ img.refresh_from_db()
 images = SourceImage.objects.annotate(det_count=Count('detections'))
 ```
 
+**❌ DON'T: Rely on `.iterator(chunk_size=N)` to produce a first row quickly**
+
+`chunk_size` bounds memory, not latency. Time-to-first-row scales with the size of the
+whole scope, so a loop that reports progress after its first batch reports nothing for
+that entire ramp. On `Classification` rows carrying `logits` and `scores` (~140 kB each
+for a 29,176-class algorithm) this measured 4.65 s at 200 rows, 22.06 s at 1,000, and
+61.09 s at 2,798 — roughly 22 ms per row regardless of `chunk_size`. Jobs whose stage
+never crosses `Job.STALLED_JOBS_MAX_MINUTES` (10 minutes) get revoked by the reaper
+having reported nothing.
+
+```python
+for row in wide_queryset.iterator(chunk_size=200):  # ← no heartbeat for minutes
+    ...
+```
+
+**✅ DO: Chunk by primary key, and fetch only the columns you read**
+```python
+ids = list(scope.order_by().values_list("pk", flat=True))  # narrow, fast
+for start in range(0, len(ids), BATCH):
+    rows = (Model.objects.filter(pk__in=ids[start:start + BATCH])
+            .defer("large_array_column_you_never_read")
+            .select_related("fk", "fk__nested"))
+```
+Each batch is its own short query, so memory stays bounded and every batch is a natural
+progress heartbeat. Measured on the same 2,798-row scope: first batch 3.22 s instead of
+61.58 s, and 91 rows/s instead of ~3.5 rows/s.
+
+**⚠️ `EXPLAIN (ANALYZE)` cannot see this.** It executes the plan but never returns rows
+to the client, so it never detoasts a large array column, never puts it on the wire, and
+never parses it in Python. The plan for that 2,798-row scope reports 23 ms against a real
+fetch of 61 s. Note also that `Sort` on a TOASTed column is cheap — it sorts pointers
+(`width=141`) — whereas `DISTINCT` compares values and therefore detoasts. When rows are
+wide, quote both the plan *and* a timed real fetch.
+


### PR DESCRIPTION
## Summary

Class masking jobs over a wide scope were being cancelled by the stalled-job reaper before
reporting any progress, even after #1376 fixed the count query that caused the first version
of this symptom. A production run over 70,279 classifications reached its
`STARTED` stage, reported the scope size, and then produced no further progress for 16.8
minutes before the reaper revoked it with `classifications_checked: 0`. This change reads
the scope in fixed-size batches instead of a single cursor-backed iterator, so a heartbeat
reaches the job well inside the reaper's window regardless of how wide the scope is.

## Detailed Description

### What #1376 fixed, and what it missed

#1376 removed an unnecessary `.distinct()` that was forcing Postgres to compare the full
`logits`/`scores` JSONB arrays during the scope count, cutting a 208-second count to 0.5
seconds on a 55,530-row scope. That fix worked and is still correct. It did not touch the
row-by-row read that follows the count, and that read is where the later stall happened:

| Time | Event |
|---|---|
| 00:57:55 | Job starts, stage marked `STARTED` |
| 00:57:57 | Scope count returns 70,279 in 2s |
| 00:58:10 | Category map expanded, `classifications_total: 70279` posted |
| 01:15:00 | Revoked — "no progress for 16.8 min", `classifications_checked: 0` |

The stall is inside the row loop, before the first `batch_size` flush.

### Root cause

`QuerySet.iterator(chunk_size=N)` bounds memory, not latency. Time to the first row scales
with the size of the whole scope, not with the chunk size. Measured on a local copy of the
production database, `Classification` rows for a 29,176-class algorithm (`logits` and
`scores` roughly 140 kB each):

| Scope rows | Time to first row |
|---|---|
| 200 | 4.65 s |
| 500 | 11.07 s |
| 1,000 | 22.06 s |
| 2,798 | 61.09 s |

Roughly 22 ms per row, independent of chunk size. The stalled-job reaper's cutoff is 10
minutes, so a scope this wide cannot reach its first heartbeat before it is revoked.

This is consistent with the job history available: runs of 3,643 and 11,906 rows both
cleared first-row latency inside the cutoff and succeeded; every run at 42,000 rows or more
has been revoked, and one attempt at that scale was killed outright (`SIGKILL`). One run at
4,393 rows was also revoked and remains unexplained by this measurement alone.

Probable mechanism, not confirmed: Django opens a `WITH HOLD` cursor when autocommit is on
(`django/db/backends/postgresql/base.py`), which Postgres materialises fully at commit. This
is not fully isolated — repeating the measurement inside `transaction.atomic()` (`WITHOUT
HOLD`) still took 55 to 56 seconds across three runs, so cursor mode is not the whole story;
the size-scaling itself is measured and reproducible regardless of cause.

`EXPLAIN (ANALYZE)` does not surface this, because it never returns rows to the client and
therefore never de-TOASTs a large array column, puts it on the wire, or parses it. The plan
for the 2,798-row scope reported 23 ms of execution time against a real fetch of 61 seconds.

### The change

Resolve the scope to a list of primary keys once, then read it back a `batch_size` slice at
a time instead of relying on a single long-lived iterator:

```python
scope_ids = list(classifications.order_by().values_list("pk", flat=True))
for start in range(0, total, batch_size):
    batch = list(
        classifications.filter(pk__in=scope_ids[start : start + batch_size])
        .order_by()
        .defer("scores")
        .select_related("detection", "detection__occurrence")
    )
```

- `defer("scores")` — the loop never reads `scores`, and it is as large as `logits`.
- `select_related` — `classification.detection` and `detection.occurrence` are read on every
  masked row and were previously two separate queries per row.
- `total` now comes from `len(scope_ids)` rather than a separate `.count()` call, which also
  removes a prior discrepancy between the count and what the loop actually iterated over.

Measured on a 2,798-row scope: first batch in 3.22 seconds, down from 61.58; throughput
roughly 91 rows/second end to end.

### Deliberately not in this change

Local fetch throughput is 260 to 430 rows/second, but the one successful production run at
scale (roughly 8,400 occurrences) managed about 4.3 rows/second once first-row latency is
subtracted, so that run was write-bound rather than read-bound. This branch stops jobs from
being reaped; it does not make a run of that size fast end to end. Ranked follow-ups, not
included here:

1. Stop writing a full copy of `scores` and `logits` on every masked row. Measured at 140 kB
   plus 105 kB per new row, which is roughly 17 GB for a 70,000-row run. `scores` is
   derivable from `logits` plus the mask; `logits` is reachable through `applied_to`.
2. Batch the occurrence determination updates — the flush currently does one
   `occurrence.save(update_determination=True)` per changed occurrence.
3. A scope-level prefilter on determination: masking only zeroes excluded classes, so a
   classification whose winning taxon is already in the taxa list is unaffected by
   construction and its logits never need to be fetched. This overlaps with the direction
   proposed in #1377. Two open caveats: #1377 measured this at roughly a quarter of rows on
   one project, not an order of magnitude, and it assumes the stored `taxon_id` always
   equals the argmax of `logits`, which held on a small sample but is unverified at scale.

Pushing the mask into SQL was tried and rejected: subscripting a TOASTed array
(`logits[i]`) appears to re-detoast the whole value per subscript, so extracting a subset of
indices ran roughly 123x slower than fetching the array whole, and two attempts hit the 30
second `statement_timeout`.

### List of Changes

| # | Change (effect) | How |
|---|---|---|
| 1 | A wide masking run reports progress well before the reaper's cutoff, instead of being silently revoked | Scope resolved to a PK list up front, read back in `batch_size` slices rather than one long-lived iterator |
| 2 | Masking no longer fetches a column it never reads | `.defer("scores")` on the scope query |
| 3 | Masking no longer issues two extra queries per row | `select_related("detection", "detection__occurrence")` |
| 4 | The reported total always matches what the loop actually processed | `total = len(scope_ids)` instead of a separate `.count()` |

## Testing

- `test_progress_is_reported_before_the_whole_scope_is_read` — the reaper-facing invariant: a
  progress report reaches the job after reading at most `batch_size` of 6 rows, not after the
  whole scope.
- `test_scope_does_not_fetch_the_unused_scores_column`
- `test_detection_is_not_queried_once_per_row`

A fourth test asserting that no single query materialises the whole scope was written and
then cut: the progress test already pins the same property behaviourally, and the query
matcher used for it also caught the determination-recomputation queries, so it failed for
the wrong reason rather than the one it was meant to check.

Existing `ami.ml.post_processing` suite passes unchanged. `makemigrations --check --dry-run`
is clean — no model change. black/isort/flake8 clean.

Follow-up to #1376. Related: #1368, #1377, #1360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved classification masking so large jobs begin processing sooner and report progress earlier.
  - Reduced unnecessary data retrieval during masking, improving efficiency and memory usage.
  - Loaded related detection information in batches to reduce per-item database queries.

- **Documentation**
  - Added guidance on query patterns that can delay initial results and increase processing time.
  - Documented approaches for improving performance when working with large datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->