### PR TITLE
Fix CI image builds by moving off end-of-life Debian 11

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -1,7 +1,7 @@
 # define an alias for the specific python version used in this file.
 # 3.11.12 has a bug with an incompatible version of wheel
 # will be fixed in 3.11.13
-FROM python:3.11.11-slim-bullseye as python
+FROM python:3.11.11-slim-bookworm as python
 
 # Python build stage
 FROM python as python-build-stage

--- a/compose/local/docs/Dockerfile
+++ b/compose/local/docs/Dockerfile
@@ -1,5 +1,5 @@
 # define an alias for the specific python version used in this file.
-FROM python:3.11.4-slim-bullseye as python
+FROM python:3.11.11-slim-bookworm as python
 
 
 # Python build stage

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -1,7 +1,7 @@
 # define an alias for the specific python version used in this file.
 # 3.11.12 has a bug with an incompatible version of wheel
 # will be fixed in 3.11.13
-FROM python:3.11.11-slim-bullseye as python
+FROM python:3.11.11-slim-bookworm as python
 
 # Python build stage
 FROM python as python-build-stage


### PR DESCRIPTION
## Summary

Every backend CI run has failed since 2026-09-04, on `main` as well as on open pull requests, because the Django image can no longer be built. The images are based on Debian 11 (bullseye), whose long-term support ended on 2026-08-31, and its security package pool is now being pruned: `apt-get install` fetches a package the index still lists and gets a 404 (`libperl5.32 … deb11u5` on one run, `xz-utils … deb11u2` on the next). Retrying does not help; five reruns across five CDN edges all failed.

This moves the images to Debian 12 (bookworm), which is supported until 2028. The Python version stays at 3.11.11, so nothing about the application's runtime changes apart from the operating-system packages underneath it.

### List of Changes

| # | Change (effect) | How |
|---|---|---|
| 1 | Backend CI builds again, and so do local and production images. | `compose/local/django/Dockerfile` and `compose/production/django/Dockerfile` now start from `python:3.11.11-slim-bookworm` instead of `python:3.11.11-slim-bullseye`. |
| 2 | The docs image no longer depends on an end-of-life Debian either. | `compose/local/docs/Dockerfile` moves from `python:3.11.4-slim-bullseye` to `python:3.11.11-slim-bookworm`. |

## Verification

Both the local and the production Django images were built locally from this branch with `--no-cache`, so the apt step really ran against bookworm rather than a cached layer. In both images `python -c "import django, psycopg, PIL, numpy"` succeeds and `pip check` reports no broken requirements. The CI run on this pull request is the end-to-end check that the build step and the test suite pass on the new base.

Debian 13 (trixie) was considered and left for later: the official Python images do not publish a `3.11.11-slim-trixie` tag, so moving to 13 would also mean changing the pinned Python patch version.
